### PR TITLE
test: add comprehensive unit tests for services and lib modules

### DIFF
--- a/backend/src/lib/retry.test.ts
+++ b/backend/src/lib/retry.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect, mock } from 'bun:test';
+import { isK8sRetryableError, withRetry, createRetryWrapper } from './retry';
+
+describe('isK8sRetryableError', () => {
+  test('returns false for null/undefined', () => {
+    expect(isK8sRetryableError(null)).toBe(false);
+    expect(isK8sRetryableError(undefined)).toBe(false);
+  });
+
+  test('returns false for non-object', () => {
+    expect(isK8sRetryableError('error')).toBe(false);
+    expect(isK8sRetryableError(42)).toBe(false);
+  });
+
+  test('returns true for 5xx status codes', () => {
+    expect(isK8sRetryableError({ statusCode: 500 })).toBe(true);
+    expect(isK8sRetryableError({ statusCode: 502 })).toBe(true);
+    expect(isK8sRetryableError({ statusCode: 503 })).toBe(true);
+    expect(isK8sRetryableError({ statusCode: 504 })).toBe(true);
+  });
+
+  test('returns true for 429 rate limiting', () => {
+    expect(isK8sRetryableError({ statusCode: 429 })).toBe(true);
+    expect(isK8sRetryableError({ response: { statusCode: 429 } })).toBe(true);
+  });
+
+  test('returns false for 4xx client errors', () => {
+    expect(isK8sRetryableError({ statusCode: 400 })).toBe(false);
+    expect(isK8sRetryableError({ statusCode: 404 })).toBe(false);
+    expect(isK8sRetryableError({ statusCode: 403 })).toBe(false);
+  });
+
+  test('returns true for network error codes', () => {
+    expect(isK8sRetryableError({ code: 'ECONNRESET' })).toBe(true);
+    expect(isK8sRetryableError({ code: 'ETIMEDOUT' })).toBe(true);
+    expect(isK8sRetryableError({ code: 'ECONNREFUSED' })).toBe(true);
+    expect(isK8sRetryableError({ code: 'ENOTFOUND' })).toBe(true);
+    expect(isK8sRetryableError({ code: 'EAI_AGAIN' })).toBe(true);
+  });
+
+  test('returns true for network error messages', () => {
+    expect(isK8sRetryableError({ message: 'socket hang up' })).toBe(true);
+    expect(isK8sRetryableError({ message: 'network error occurred' })).toBe(true);
+    expect(isK8sRetryableError({ message: 'connection ECONNRESET' })).toBe(true);
+    expect(isK8sRetryableError({ message: 'request ETIMEDOUT' })).toBe(true);
+  });
+
+  test('returns false for regular errors', () => {
+    expect(isK8sRetryableError({ message: 'invalid resource' })).toBe(false);
+    expect(isK8sRetryableError(new Error('some error'))).toBe(false);
+  });
+
+  test('handles nested response statusCode', () => {
+    expect(isK8sRetryableError({ response: { statusCode: 500 } })).toBe(true);
+    expect(isK8sRetryableError({ response: { statusCode: 404 } })).toBe(false);
+  });
+});
+
+describe('withRetry', () => {
+  test('returns result on success', async () => {
+    const fn = mock(() => Promise.resolve('success'));
+    const result = await withRetry(fn, { maxRetries: 3 });
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries on retryable error', async () => {
+    let attempts = 0;
+    const fn = mock(async () => {
+      attempts++;
+      if (attempts < 3) {
+        throw { statusCode: 503 };
+      }
+      return 'success';
+    });
+
+    const result = await withRetry(fn, {
+      maxRetries: 3,
+      initialDelayMs: 1,
+      maxDelayMs: 10,
+    });
+
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test('throws immediately on non-retryable error', async () => {
+    const fn = mock(async () => {
+      throw { statusCode: 404, message: 'Not found' };
+    });
+
+    await expect(
+      withRetry(fn, { maxRetries: 3, initialDelayMs: 1 })
+    ).rejects.toEqual({ statusCode: 404, message: 'Not found' });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws after max retries exceeded', async () => {
+    const fn = mock(async () => {
+      throw { statusCode: 503 };
+    });
+
+    await expect(
+      withRetry(fn, { maxRetries: 2, initialDelayMs: 1, maxDelayMs: 5 })
+    ).rejects.toEqual({ statusCode: 503 });
+
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  test('uses custom isRetryable function', async () => {
+    let attempts = 0;
+    const fn = mock(async () => {
+      attempts++;
+      if (attempts < 2) {
+        throw new Error('custom error');
+      }
+      return 'success';
+    });
+
+    const result = await withRetry(fn, {
+      maxRetries: 3,
+      initialDelayMs: 1,
+      isRetryable: (err) => err instanceof Error && err.message === 'custom error',
+    });
+
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('uses default options', async () => {
+    const fn = mock(() => Promise.resolve('success'));
+    const result = await withRetry(fn);
+    expect(result).toBe('success');
+  });
+});
+
+describe('createRetryWrapper', () => {
+  test('creates wrapper with preset options', async () => {
+    const wrapper = createRetryWrapper({
+      maxRetries: 2,
+      initialDelayMs: 1,
+      isRetryable: () => true,
+    });
+
+    let attempts = 0;
+    const fn = async () => {
+      attempts++;
+      if (attempts < 2) {
+        throw new Error('retry me');
+      }
+      return 'wrapped success';
+    };
+
+    const result = await wrapper(fn);
+    expect(result).toBe('wrapped success');
+    expect(attempts).toBe(2);
+  });
+
+  test('allows overriding preset options', async () => {
+    const wrapper = createRetryWrapper({ maxRetries: 5 });
+
+    const fn = mock(async () => {
+      throw { statusCode: 503 };
+    });
+
+    await expect(
+      wrapper(fn, { maxRetries: 1, initialDelayMs: 1 })
+    ).rejects.toBeDefined();
+
+    expect(fn).toHaveBeenCalledTimes(2); // override to 1 retry = 2 attempts
+  });
+});

--- a/backend/src/lib/validation.test.ts
+++ b/backend/src/lib/validation.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect } from 'bun:test';
+import { namespaceSchema, resourceNameSchema } from './validation';
+
+describe('namespaceSchema', () => {
+  test('accepts valid namespaces', () => {
+    expect(namespaceSchema.safeParse('default').success).toBe(true);
+    expect(namespaceSchema.safeParse('my-namespace').success).toBe(true);
+    expect(namespaceSchema.safeParse('kube-system').success).toBe(true);
+    expect(namespaceSchema.safeParse('test123').success).toBe(true);
+    expect(namespaceSchema.safeParse('a').success).toBe(true);
+    expect(namespaceSchema.safeParse('a1').success).toBe(true);
+  });
+
+  test('rejects empty namespace', () => {
+    const result = namespaceSchema.safeParse('');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('empty');
+    }
+  });
+
+  test('rejects namespace over 63 characters', () => {
+    const longName = 'a'.repeat(64);
+    const result = namespaceSchema.safeParse(longName);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('63');
+    }
+  });
+
+  test('accepts 63 character namespace', () => {
+    const validName = 'a'.repeat(63);
+    expect(namespaceSchema.safeParse(validName).success).toBe(true);
+  });
+
+  test('rejects uppercase characters', () => {
+    expect(namespaceSchema.safeParse('MyNamespace').success).toBe(false);
+    expect(namespaceSchema.safeParse('TEST').success).toBe(false);
+  });
+
+  test('rejects namespace starting with hyphen', () => {
+    expect(namespaceSchema.safeParse('-namespace').success).toBe(false);
+  });
+
+  test('rejects namespace ending with hyphen', () => {
+    expect(namespaceSchema.safeParse('namespace-').success).toBe(false);
+  });
+
+  test('rejects namespace with underscore', () => {
+    expect(namespaceSchema.safeParse('my_namespace').success).toBe(false);
+  });
+
+  test('rejects namespace with dots', () => {
+    expect(namespaceSchema.safeParse('my.namespace').success).toBe(false);
+  });
+
+  test('rejects namespace with special characters', () => {
+    expect(namespaceSchema.safeParse('my@namespace').success).toBe(false);
+    expect(namespaceSchema.safeParse('my namespace').success).toBe(false);
+    expect(namespaceSchema.safeParse('my/namespace').success).toBe(false);
+  });
+
+  test('rejects namespace starting with number but allows alphanumeric', () => {
+    // Numbers are alphanumeric, so starting with number should be valid
+    expect(namespaceSchema.safeParse('123-test').success).toBe(true);
+    expect(namespaceSchema.safeParse('0namespace').success).toBe(true);
+  });
+});
+
+describe('resourceNameSchema', () => {
+  test('accepts valid resource names', () => {
+    expect(resourceNameSchema.safeParse('my-resource').success).toBe(true);
+    expect(resourceNameSchema.safeParse('my.resource.name').success).toBe(true);
+    expect(resourceNameSchema.safeParse('resource-with-dots.and-hyphens').success).toBe(true);
+    expect(resourceNameSchema.safeParse('test123').success).toBe(true);
+    expect(resourceNameSchema.safeParse('a').success).toBe(true);
+  });
+
+  test('rejects empty name', () => {
+    const result = resourceNameSchema.safeParse('');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('empty');
+    }
+  });
+
+  test('rejects name over 253 characters', () => {
+    const longName = 'a'.repeat(254);
+    const result = resourceNameSchema.safeParse(longName);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain('253');
+    }
+  });
+
+  test('accepts 253 character name', () => {
+    const validName = 'a'.repeat(253);
+    expect(resourceNameSchema.safeParse(validName).success).toBe(true);
+  });
+
+  test('rejects uppercase characters', () => {
+    expect(resourceNameSchema.safeParse('MyResource').success).toBe(false);
+    expect(resourceNameSchema.safeParse('TEST').success).toBe(false);
+  });
+
+  test('rejects name starting with hyphen', () => {
+    expect(resourceNameSchema.safeParse('-resource').success).toBe(false);
+  });
+
+  test('rejects name ending with hyphen', () => {
+    expect(resourceNameSchema.safeParse('resource-').success).toBe(false);
+  });
+
+  test('rejects name starting with dot', () => {
+    expect(resourceNameSchema.safeParse('.resource').success).toBe(false);
+  });
+
+  test('rejects name ending with dot', () => {
+    expect(resourceNameSchema.safeParse('resource.').success).toBe(false);
+  });
+
+  test('accepts dots in middle of name', () => {
+    expect(resourceNameSchema.safeParse('my.resource.name').success).toBe(true);
+  });
+
+  test('rejects name with underscore', () => {
+    expect(resourceNameSchema.safeParse('my_resource').success).toBe(false);
+  });
+
+  test('rejects name with special characters', () => {
+    expect(resourceNameSchema.safeParse('my@resource').success).toBe(false);
+    expect(resourceNameSchema.safeParse('my resource').success).toBe(false);
+    expect(resourceNameSchema.safeParse('my/resource').success).toBe(false);
+  });
+});

--- a/backend/src/services/config.test.ts
+++ b/backend/src/services/config.test.ts
@@ -1,0 +1,289 @@
+import { describe, test, expect } from 'bun:test';
+import type { AppConfig } from './config';
+
+describe('ConfigService - AppConfig Structure', () => {
+  test('creates valid config with all fields', () => {
+    const config: AppConfig = {
+      activeProviderId: 'dynamo',
+      defaultNamespace: 'kubefoundry-system',
+    };
+
+    expect(config.activeProviderId).toBe('dynamo');
+    expect(config.defaultNamespace).toBe('kubefoundry-system');
+  });
+
+  test('all fields are optional', () => {
+    const config: AppConfig = {};
+    expect(config.activeProviderId).toBeUndefined();
+    expect(config.defaultNamespace).toBeUndefined();
+  });
+
+  test('allows partial config', () => {
+    const config: AppConfig = {
+      defaultNamespace: 'ml-workloads',
+    };
+
+    expect(config.defaultNamespace).toBe('ml-workloads');
+    expect(config.activeProviderId).toBeUndefined();
+  });
+});
+
+describe('ConfigService - Default Config Logic', () => {
+  function getDefaultConfig(): AppConfig {
+    return {
+      defaultNamespace: process.env.DEFAULT_NAMESPACE,
+    };
+  }
+
+  test('uses DEFAULT_NAMESPACE env var when set', () => {
+    const originalEnv = process.env.DEFAULT_NAMESPACE;
+    process.env.DEFAULT_NAMESPACE = 'test-namespace';
+
+    const config = getDefaultConfig();
+    expect(config.defaultNamespace).toBe('test-namespace');
+
+    // Restore
+    if (originalEnv === undefined) {
+      delete process.env.DEFAULT_NAMESPACE;
+    } else {
+      process.env.DEFAULT_NAMESPACE = originalEnv;
+    }
+  });
+
+  test('defaultNamespace is undefined when env var not set', () => {
+    const originalEnv = process.env.DEFAULT_NAMESPACE;
+    delete process.env.DEFAULT_NAMESPACE;
+
+    const config = getDefaultConfig();
+    expect(config.defaultNamespace).toBeUndefined();
+
+    // Restore
+    if (originalEnv !== undefined) {
+      process.env.DEFAULT_NAMESPACE = originalEnv;
+    }
+  });
+});
+
+describe('ConfigService - Config Merging', () => {
+  function mergeConfig(current: AppConfig, updates: Partial<AppConfig>): AppConfig {
+    return {
+      ...current,
+      ...updates,
+    };
+  }
+
+  test('merges partial updates', () => {
+    const current: AppConfig = {
+      activeProviderId: 'dynamo',
+      defaultNamespace: 'default',
+    };
+
+    const merged = mergeConfig(current, { defaultNamespace: 'new-namespace' });
+
+    expect(merged.activeProviderId).toBe('dynamo');
+    expect(merged.defaultNamespace).toBe('new-namespace');
+  });
+
+  test('overwrites existing values', () => {
+    const current: AppConfig = {
+      activeProviderId: 'dynamo',
+    };
+
+    const merged = mergeConfig(current, { activeProviderId: 'kaito' });
+    expect(merged.activeProviderId).toBe('kaito');
+  });
+
+  test('adds new values', () => {
+    const current: AppConfig = {};
+    const merged = mergeConfig(current, {
+      activeProviderId: 'dynamo',
+      defaultNamespace: 'ml-ns',
+    });
+
+    expect(merged.activeProviderId).toBe('dynamo');
+    expect(merged.defaultNamespace).toBe('ml-ns');
+  });
+
+  test('preserves unmodified values', () => {
+    const current: AppConfig = {
+      activeProviderId: 'kaito',
+      defaultNamespace: 'original',
+    };
+
+    const merged = mergeConfig(current, {});
+
+    expect(merged.activeProviderId).toBe('kaito');
+    expect(merged.defaultNamespace).toBe('original');
+  });
+});
+
+describe('ConfigService - ConfigMap Naming', () => {
+  const CONFIG_NAMESPACE = 'kubefoundry-system';
+  const CONFIG_NAME = 'kubefoundry-config';
+  const CONFIG_KEY = 'config.json';
+
+  test('uses correct ConfigMap namespace', () => {
+    expect(CONFIG_NAMESPACE).toBe('kubefoundry-system');
+  });
+
+  test('uses correct ConfigMap name', () => {
+    expect(CONFIG_NAME).toBe('kubefoundry-config');
+  });
+
+  test('uses correct data key', () => {
+    expect(CONFIG_KEY).toBe('config.json');
+  });
+});
+
+describe('ConfigService - Config Serialization', () => {
+  test('serializes config to JSON', () => {
+    const config: AppConfig = {
+      activeProviderId: 'dynamo',
+      defaultNamespace: 'ml-workloads',
+    };
+
+    const json = JSON.stringify(config, null, 2);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.activeProviderId).toBe('dynamo');
+    expect(parsed.defaultNamespace).toBe('ml-workloads');
+  });
+
+  test('handles empty config serialization', () => {
+    const config: AppConfig = {};
+    const json = JSON.stringify(config, null, 2);
+    const parsed = JSON.parse(json);
+
+    expect(parsed).toEqual({});
+  });
+
+  test('deserializes config from JSON', () => {
+    const json = '{"activeProviderId":"kaito","defaultNamespace":"kaito-workspace"}';
+    const config = JSON.parse(json) as AppConfig;
+
+    expect(config.activeProviderId).toBe('kaito');
+    expect(config.defaultNamespace).toBe('kaito-workspace');
+  });
+});
+
+describe('ConfigService - Cache Behavior', () => {
+  // Simulate cache behavior
+  class MockConfigCache {
+    private cachedConfig: AppConfig | null = null;
+    private initialized = false;
+
+    getFromCache(): AppConfig | null {
+      if (this.cachedConfig && this.initialized) {
+        return this.cachedConfig;
+      }
+      return null;
+    }
+
+    setCache(config: AppConfig): void {
+      this.cachedConfig = config;
+      this.initialized = true;
+    }
+
+    clearCache(): void {
+      this.cachedConfig = null;
+      this.initialized = false;
+    }
+
+    isInitialized(): boolean {
+      return this.initialized;
+    }
+  }
+
+  test('returns null when not initialized', () => {
+    const cache = new MockConfigCache();
+    expect(cache.getFromCache()).toBeNull();
+    expect(cache.isInitialized()).toBe(false);
+  });
+
+  test('returns cached config after initialization', () => {
+    const cache = new MockConfigCache();
+    const config: AppConfig = { defaultNamespace: 'cached-ns' };
+
+    cache.setCache(config);
+
+    expect(cache.getFromCache()).toEqual(config);
+    expect(cache.isInitialized()).toBe(true);
+  });
+
+  test('clears cache correctly', () => {
+    const cache = new MockConfigCache();
+    cache.setCache({ defaultNamespace: 'test' });
+
+    cache.clearCache();
+
+    expect(cache.getFromCache()).toBeNull();
+    expect(cache.isInitialized()).toBe(false);
+  });
+
+  test('updates cache on subsequent sets', () => {
+    const cache = new MockConfigCache();
+
+    cache.setCache({ defaultNamespace: 'first' });
+    expect(cache.getFromCache()?.defaultNamespace).toBe('first');
+
+    cache.setCache({ defaultNamespace: 'second' });
+    expect(cache.getFromCache()?.defaultNamespace).toBe('second');
+  });
+});
+
+describe('ConfigService - Provider Fallback Logic', () => {
+  // Simulate the fallback logic for getting default namespace
+  function getDefaultNamespace(
+    config: AppConfig,
+    providerNamespaces: Record<string, string>
+  ): string {
+    // First: use configured default namespace
+    if (config.defaultNamespace) {
+      return config.defaultNamespace;
+    }
+
+    // Second: use active provider's namespace (backward compat)
+    if (config.activeProviderId && providerNamespaces[config.activeProviderId]) {
+      return providerNamespaces[config.activeProviderId];
+    }
+
+    // Third: fall back to dynamo's namespace
+    return providerNamespaces['dynamo'] || 'kubefoundry-system';
+  }
+
+  const providerNamespaces: Record<string, string> = {
+    dynamo: 'dynamo',
+    kaito: 'kaito-workspace',
+    kuberay: 'kuberay',
+  };
+
+  test('prefers explicit defaultNamespace', () => {
+    const config: AppConfig = {
+      defaultNamespace: 'custom-ns',
+      activeProviderId: 'dynamo',
+    };
+
+    expect(getDefaultNamespace(config, providerNamespaces)).toBe('custom-ns');
+  });
+
+  test('falls back to activeProvider namespace', () => {
+    const config: AppConfig = {
+      activeProviderId: 'kaito',
+    };
+
+    expect(getDefaultNamespace(config, providerNamespaces)).toBe('kaito-workspace');
+  });
+
+  test('falls back to dynamo namespace', () => {
+    const config: AppConfig = {};
+
+    expect(getDefaultNamespace(config, providerNamespaces)).toBe('dynamo');
+  });
+
+  test('falls back to kubefoundry-system if no dynamo', () => {
+    const config: AppConfig = {};
+    const emptyProviders: Record<string, string> = {};
+
+    expect(getDefaultNamespace(config, emptyProviders)).toBe('kubefoundry-system');
+  });
+});

--- a/backend/src/services/helm.test.ts
+++ b/backend/src/services/helm.test.ts
@@ -1,0 +1,314 @@
+import { describe, test, expect } from 'bun:test';
+import type { HelmResult, HelmRelease, HelmRepo, HelmChart } from '../providers/types';
+import { GPU_OPERATOR_REPO, GPU_OPERATOR_CHART } from './helm';
+
+describe('HelmService - GPU Operator Constants', () => {
+  test('GPU_OPERATOR_REPO has correct configuration', () => {
+    expect(GPU_OPERATOR_REPO.name).toBe('nvidia');
+    expect(GPU_OPERATOR_REPO.url).toBe('https://helm.ngc.nvidia.com/nvidia');
+  });
+
+  test('GPU_OPERATOR_CHART has correct configuration', () => {
+    expect(GPU_OPERATOR_CHART.name).toBe('gpu-operator');
+    expect(GPU_OPERATOR_CHART.chart).toBe('nvidia/gpu-operator');
+    expect(GPU_OPERATOR_CHART.namespace).toBe('gpu-operator');
+    expect(GPU_OPERATOR_CHART.createNamespace).toBe(true);
+  });
+});
+
+describe('HelmService - HelmResult Structure', () => {
+  test('creates successful result', () => {
+    const result: HelmResult = {
+      success: true,
+      stdout: 'Release "my-app" has been installed.',
+      stderr: '',
+      exitCode: 0,
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+
+  test('creates failed result', () => {
+    const result: HelmResult = {
+      success: false,
+      stdout: '',
+      stderr: 'Error: release "my-app" already exists',
+      exitCode: 1,
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('already exists');
+  });
+
+  test('creates timeout result', () => {
+    const result: HelmResult = {
+      success: false,
+      stdout: 'Partial output...',
+      stderr: 'Command timed out',
+      exitCode: null,
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBeNull();
+    expect(result.stderr).toContain('timed out');
+  });
+
+  test('creates execution error result', () => {
+    const result: HelmResult = {
+      success: false,
+      stdout: '',
+      stderr: 'Failed to execute helm: ENOENT',
+      exitCode: null,
+    };
+
+    expect(result.success).toBe(false);
+    expect(result.stderr).toContain('Failed to execute');
+  });
+});
+
+describe('HelmService - HelmRelease Structure', () => {
+  test('creates valid release info', () => {
+    const release: HelmRelease = {
+      name: 'dynamo',
+      namespace: 'dynamo',
+      revision: '1',
+      updated: '2024-01-15 10:30:00.123456789 +0000 UTC',
+      status: 'deployed',
+      chart: 'dynamo-0.1.0',
+      appVersion: '0.1.0',
+    };
+
+    expect(release.name).toBe('dynamo');
+    expect(release.status).toBe('deployed');
+    expect(release.revision).toBe('1');
+  });
+
+  test('handles pending-install status', () => {
+    const release: HelmRelease = {
+      name: 'gpu-operator',
+      namespace: 'gpu-operator',
+      revision: '1',
+      updated: '2024-01-15 10:30:00.123456789 +0000 UTC',
+      status: 'pending-install',
+      chart: 'gpu-operator-23.9.0',
+      appVersion: '23.9.0',
+    };
+
+    expect(release.status).toBe('pending-install');
+  });
+
+  test('handles failed status', () => {
+    const release: HelmRelease = {
+      name: 'broken-app',
+      namespace: 'default',
+      revision: '3',
+      updated: '2024-01-15 10:30:00.123456789 +0000 UTC',
+      status: 'failed',
+      chart: 'my-chart-1.0.0',
+      appVersion: '1.0.0',
+    };
+
+    expect(release.status).toBe('failed');
+  });
+});
+
+describe('HelmService - Command Building Logic', () => {
+  // Test the logic for building helm commands
+  function buildInstallCommand(chart: HelmChart): string[] {
+    const args = ['upgrade', chart.name, chart.chart, '--install'];
+    args.push('--namespace', chart.namespace);
+
+    if (chart.createNamespace) {
+      args.push('--create-namespace');
+    }
+
+    if (chart.version) {
+      args.push('--version', chart.version);
+    }
+
+    return args;
+  }
+
+  test('builds basic install command', () => {
+    const chart: HelmChart = {
+      name: 'my-app',
+      chart: 'repo/my-chart',
+      namespace: 'my-namespace',
+    };
+
+    const args = buildInstallCommand(chart);
+    expect(args).toContain('upgrade');
+    expect(args).toContain('my-app');
+    expect(args).toContain('repo/my-chart');
+    expect(args).toContain('--install');
+    expect(args).toContain('--namespace');
+    expect(args).toContain('my-namespace');
+  });
+
+  test('adds --create-namespace when specified', () => {
+    const chart: HelmChart = {
+      name: 'my-app',
+      chart: 'repo/my-chart',
+      namespace: 'new-namespace',
+      createNamespace: true,
+    };
+
+    const args = buildInstallCommand(chart);
+    expect(args).toContain('--create-namespace');
+  });
+
+  test('does not add --create-namespace when false', () => {
+    const chart: HelmChart = {
+      name: 'my-app',
+      chart: 'repo/my-chart',
+      namespace: 'existing-namespace',
+      createNamespace: false,
+    };
+
+    const args = buildInstallCommand(chart);
+    expect(args).not.toContain('--create-namespace');
+  });
+
+  test('adds version when specified', () => {
+    const chart: HelmChart = {
+      name: 'my-app',
+      chart: 'repo/my-chart',
+      namespace: 'default',
+      version: '1.2.3',
+    };
+
+    const args = buildInstallCommand(chart);
+    expect(args).toContain('--version');
+    expect(args).toContain('1.2.3');
+  });
+});
+
+describe('HelmService - getInstallCommands Logic', () => {
+  function getInstallCommands(repos: HelmRepo[], charts: HelmChart[]): string[] {
+    const commands: string[] = [];
+
+    for (const repo of repos) {
+      commands.push(`helm repo add ${repo.name} ${repo.url}`);
+    }
+
+    if (repos.length > 0) {
+      commands.push('helm repo update');
+    }
+
+    for (const chart of charts) {
+      if (chart.fetchUrl) {
+        let cmd = `helm fetch ${chart.fetchUrl} && helm install ${chart.name} ${chart.chart}`;
+        cmd += ` --namespace ${chart.namespace}`;
+        if (chart.createNamespace) {
+          cmd += ' --create-namespace';
+        }
+        commands.push(cmd);
+      } else {
+        let cmd = `helm install ${chart.name} ${chart.chart}`;
+        cmd += ` --namespace ${chart.namespace}`;
+        if (chart.createNamespace) {
+          cmd += ' --create-namespace';
+        }
+        if (chart.version) {
+          cmd += ` --version ${chart.version}`;
+        }
+        commands.push(cmd);
+      }
+    }
+
+    return commands;
+  }
+
+  test('generates repo add commands', () => {
+    const repos: HelmRepo[] = [
+      { name: 'nvidia', url: 'https://helm.ngc.nvidia.com/nvidia' },
+    ];
+    const charts: HelmChart[] = [];
+
+    const commands = getInstallCommands(repos, charts);
+    expect(commands).toContain('helm repo add nvidia https://helm.ngc.nvidia.com/nvidia');
+    expect(commands).toContain('helm repo update');
+  });
+
+  test('generates install commands', () => {
+    const repos: HelmRepo[] = [];
+    const charts: HelmChart[] = [
+      { name: 'my-app', chart: 'repo/chart', namespace: 'default' },
+    ];
+
+    const commands = getInstallCommands(repos, charts);
+    expect(commands[0]).toContain('helm install my-app repo/chart');
+    expect(commands[0]).toContain('--namespace default');
+  });
+
+  test('generates commands for GPU Operator', () => {
+    const commands = getInstallCommands([GPU_OPERATOR_REPO], [GPU_OPERATOR_CHART]);
+
+    expect(commands[0]).toBe('helm repo add nvidia https://helm.ngc.nvidia.com/nvidia');
+    expect(commands[1]).toBe('helm repo update');
+    expect(commands[2]).toContain('helm install gpu-operator nvidia/gpu-operator');
+    expect(commands[2]).toContain('--namespace gpu-operator');
+    expect(commands[2]).toContain('--create-namespace');
+  });
+
+  test('handles charts with fetchUrl', () => {
+    const charts: HelmChart[] = [
+      {
+        name: 'custom-chart',
+        chart: '/tmp/chart.tgz',
+        namespace: 'custom-ns',
+        fetchUrl: 'https://example.com/chart.tgz',
+        createNamespace: true,
+      },
+    ];
+
+    const commands = getInstallCommands([], charts);
+    expect(commands[0]).toContain('helm fetch https://example.com/chart.tgz');
+    expect(commands[0]).toContain('--create-namespace');
+  });
+});
+
+describe('HelmService - Release Status Detection', () => {
+  function isProblematicStatus(status: string): boolean {
+    const s = status.toLowerCase();
+    // Only 'failed' is truly problematic
+    // pending-install/upgrade are normal during installation
+    return s === 'failed';
+  }
+
+  function isPendingStatus(status: string): boolean {
+    const s = status.toLowerCase();
+    return s === 'pending-install' || s === 'pending-upgrade' || s === 'pending-rollback';
+  }
+
+  test('identifies failed status as problematic', () => {
+    expect(isProblematicStatus('failed')).toBe(true);
+    expect(isProblematicStatus('Failed')).toBe(true);
+    expect(isProblematicStatus('FAILED')).toBe(true);
+  });
+
+  test('does not treat pending statuses as problematic', () => {
+    expect(isProblematicStatus('pending-install')).toBe(false);
+    expect(isProblematicStatus('pending-upgrade')).toBe(false);
+    expect(isProblematicStatus('pending-rollback')).toBe(false);
+  });
+
+  test('does not treat deployed as problematic', () => {
+    expect(isProblematicStatus('deployed')).toBe(false);
+  });
+
+  test('identifies pending statuses', () => {
+    expect(isPendingStatus('pending-install')).toBe(true);
+    expect(isPendingStatus('pending-upgrade')).toBe(true);
+    expect(isPendingStatus('pending-rollback')).toBe(true);
+    expect(isPendingStatus('Pending-Install')).toBe(true);
+  });
+
+  test('does not treat deployed as pending', () => {
+    expect(isPendingStatus('deployed')).toBe(false);
+    expect(isPendingStatus('failed')).toBe(false);
+  });
+});

--- a/backend/src/services/kubernetes.test.ts
+++ b/backend/src/services/kubernetes.test.ts
@@ -1,0 +1,422 @@
+import { describe, test, expect } from 'bun:test';
+import type { ClusterGpuCapacity, NodeGpuInfo, GPUAvailability, GPUOperatorStatus } from './kubernetes';
+import type { ClusterStatus, PodStatus, DeploymentStatus, PodPhase } from '@kubefoundry/shared';
+
+describe('KubernetesService - Type Definitions', () => {
+  describe('ClusterGpuCapacity', () => {
+    test('creates valid capacity with GPU nodes', () => {
+      const nodes: NodeGpuInfo[] = [
+        { nodeName: 'node-1', totalGpus: 8, allocatedGpus: 4, availableGpus: 4 },
+        { nodeName: 'node-2', totalGpus: 8, allocatedGpus: 2, availableGpus: 6 },
+      ];
+
+      const capacity: ClusterGpuCapacity = {
+        totalGpus: 16,
+        allocatedGpus: 6,
+        availableGpus: 10,
+        maxContiguousAvailable: 6,
+        maxNodeGpuCapacity: 8,
+        gpuNodeCount: 2,
+        totalMemoryGb: 80,
+        nodes,
+      };
+
+      expect(capacity.totalGpus).toBe(16);
+      expect(capacity.availableGpus).toBe(10);
+      expect(capacity.maxContiguousAvailable).toBe(6);
+      expect(capacity.nodes).toHaveLength(2);
+    });
+
+    test('handles cluster with no GPUs', () => {
+      const capacity: ClusterGpuCapacity = {
+        totalGpus: 0,
+        allocatedGpus: 0,
+        availableGpus: 0,
+        maxContiguousAvailable: 0,
+        maxNodeGpuCapacity: 0,
+        gpuNodeCount: 0,
+        nodes: [],
+      };
+
+      expect(capacity.totalGpus).toBe(0);
+      expect(capacity.gpuNodeCount).toBe(0);
+      expect(capacity.nodes).toHaveLength(0);
+    });
+
+    test('totalMemoryGb is optional', () => {
+      const capacity: ClusterGpuCapacity = {
+        totalGpus: 4,
+        allocatedGpus: 0,
+        availableGpus: 4,
+        maxContiguousAvailable: 4,
+        maxNodeGpuCapacity: 4,
+        gpuNodeCount: 1,
+        nodes: [{ nodeName: 'node-1', totalGpus: 4, allocatedGpus: 0, availableGpus: 4 }],
+      };
+
+      expect(capacity.totalMemoryGb).toBeUndefined();
+    });
+  });
+
+  describe('GPUAvailability', () => {
+    test('creates available GPU status', () => {
+      const availability: GPUAvailability = {
+        available: true,
+        totalGPUs: 8,
+        gpuNodes: ['node-1', 'node-2'],
+      };
+
+      expect(availability.available).toBe(true);
+      expect(availability.totalGPUs).toBe(8);
+      expect(availability.gpuNodes).toHaveLength(2);
+    });
+
+    test('creates unavailable GPU status', () => {
+      const availability: GPUAvailability = {
+        available: false,
+        totalGPUs: 0,
+        gpuNodes: [],
+      };
+
+      expect(availability.available).toBe(false);
+      expect(availability.totalGPUs).toBe(0);
+    });
+  });
+
+  describe('GPUOperatorStatus', () => {
+    test('creates fully installed status', () => {
+      const status: GPUOperatorStatus = {
+        installed: true,
+        crdFound: true,
+        operatorRunning: true,
+        gpusAvailable: true,
+        totalGPUs: 4,
+        gpuNodes: ['gpu-node-1'],
+        message: 'GPUs enabled: 4 GPU(s) on 1 node(s)',
+      };
+
+      expect(status.installed).toBe(true);
+      expect(status.operatorRunning).toBe(true);
+      expect(status.gpusAvailable).toBe(true);
+    });
+
+    test('creates not installed status', () => {
+      const status: GPUOperatorStatus = {
+        installed: false,
+        crdFound: false,
+        operatorRunning: false,
+        gpusAvailable: false,
+        totalGPUs: 0,
+        gpuNodes: [],
+        message: 'GPU Operator not installed',
+      };
+
+      expect(status.installed).toBe(false);
+      expect(status.message).toContain('not installed');
+    });
+
+    test('creates partial status (CRD found but not running)', () => {
+      const status: GPUOperatorStatus = {
+        installed: false,
+        crdFound: true,
+        operatorRunning: false,
+        gpusAvailable: false,
+        totalGPUs: 0,
+        gpuNodes: [],
+        message: 'GPU Operator CRD found but operator is not running',
+      };
+
+      expect(status.installed).toBe(false);
+      expect(status.crdFound).toBe(true);
+      expect(status.operatorRunning).toBe(false);
+    });
+  });
+
+  describe('ClusterStatus', () => {
+    test('creates connected status', () => {
+      const status: ClusterStatus = {
+        connected: true,
+        namespace: 'default',
+        clusterName: 'my-cluster',
+      };
+
+      expect(status.connected).toBe(true);
+      expect(status.error).toBeUndefined();
+    });
+
+    test('creates disconnected status with error', () => {
+      const status: ClusterStatus = {
+        connected: false,
+        namespace: 'default',
+        error: 'Unable to connect to cluster',
+      };
+
+      expect(status.connected).toBe(false);
+      expect(status.error).toBeDefined();
+    });
+  });
+
+  describe('PodStatus', () => {
+    test('creates running pod status', () => {
+      const pod: PodStatus = {
+        name: 'my-pod-abc123',
+        phase: 'Running',
+        ready: true,
+        restarts: 0,
+        node: 'worker-node-1',
+      };
+
+      expect(pod.phase).toBe('Running');
+      expect(pod.ready).toBe(true);
+    });
+
+    test('creates pending pod status', () => {
+      const pod: PodStatus = {
+        name: 'my-pod-pending',
+        phase: 'Pending',
+        ready: false,
+        restarts: 0,
+      };
+
+      expect(pod.phase).toBe('Pending');
+      expect(pod.ready).toBe(false);
+      expect(pod.node).toBeUndefined();
+    });
+
+    test('creates failed pod with restarts', () => {
+      const pod: PodStatus = {
+        name: 'crashloop-pod',
+        phase: 'Running',
+        ready: false,
+        restarts: 5,
+        node: 'worker-node-2',
+      };
+
+      expect(pod.restarts).toBe(5);
+      expect(pod.ready).toBe(false);
+    });
+  });
+});
+
+describe('KubernetesService - GPU Memory Detection Logic', () => {
+  // Test the GPU memory detection from product names
+  function detectGpuMemoryFromProduct(gpuProduct: string): number | undefined {
+    const product = gpuProduct.toLowerCase();
+
+    // NVIDIA Data Center GPUs
+    if (product.includes('a100') && product.includes('80')) return 80;
+    if (product.includes('a100') && product.includes('40')) return 40;
+    if (product.includes('a100')) return 40;
+    if (product.includes('h100') && product.includes('80')) return 80;
+    if (product.includes('h100')) return 80;
+    if (product.includes('h200')) return 141;
+    if (product.includes('a10g')) return 24;
+    if (product.includes('a10')) return 24;
+    if (product.includes('l40s')) return 48;
+    if (product.includes('l40')) return 48;
+    if (product.includes('l4')) return 24;
+    if (product.includes('t4')) return 16;
+    if (product.includes('v100') && product.includes('32')) return 32;
+    if (product.includes('v100')) return 16;
+
+    // NVIDIA Consumer GPUs
+    if (product.includes('4090')) return 24;
+    if (product.includes('4080')) return 16;
+    if (product.includes('3090')) return 24;
+    if (product.includes('3080') && product.includes('12')) return 12;
+    if (product.includes('3080')) return 10;
+
+    return undefined;
+  }
+
+  test('detects A100 80GB', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-A100-SXM4-80GB')).toBe(80);
+    expect(detectGpuMemoryFromProduct('Tesla-A100-80GB-PCIe')).toBe(80);
+  });
+
+  test('detects A100 40GB', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-A100-40GB')).toBe(40);
+    expect(detectGpuMemoryFromProduct('Tesla-A100-PCIE-40GB')).toBe(40);
+  });
+
+  test('detects A100 default as 40GB', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-A100-SXM')).toBe(40);
+    expect(detectGpuMemoryFromProduct('a100')).toBe(40);
+  });
+
+  test('detects H100', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-H100-80GB')).toBe(80);
+    expect(detectGpuMemoryFromProduct('H100-SXM')).toBe(80);
+  });
+
+  test('detects H200', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-H200')).toBe(141);
+  });
+
+  test('detects A10G', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-A10G')).toBe(24);
+  });
+
+  test('detects L40S', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-L40S')).toBe(48);
+  });
+
+  test('detects L4', () => {
+    expect(detectGpuMemoryFromProduct('NVIDIA-L4')).toBe(24);
+  });
+
+  test('detects T4', () => {
+    expect(detectGpuMemoryFromProduct('Tesla-T4')).toBe(16);
+    expect(detectGpuMemoryFromProduct('NVIDIA-T4')).toBe(16);
+  });
+
+  test('detects V100 32GB', () => {
+    expect(detectGpuMemoryFromProduct('Tesla-V100-32GB')).toBe(32);
+  });
+
+  test('detects V100 default as 16GB', () => {
+    expect(detectGpuMemoryFromProduct('Tesla-V100-SXM2')).toBe(16);
+    expect(detectGpuMemoryFromProduct('V100')).toBe(16);
+  });
+
+  test('detects consumer GPUs', () => {
+    expect(detectGpuMemoryFromProduct('GeForce-RTX-4090')).toBe(24);
+    expect(detectGpuMemoryFromProduct('RTX-4080')).toBe(16);
+    expect(detectGpuMemoryFromProduct('GeForce-RTX-3090')).toBe(24);
+    expect(detectGpuMemoryFromProduct('RTX-3080-12GB')).toBe(12);
+    expect(detectGpuMemoryFromProduct('RTX-3080')).toBe(10);
+  });
+
+  test('returns undefined for unknown GPU', () => {
+    expect(detectGpuMemoryFromProduct('Unknown-GPU')).toBeUndefined();
+    expect(detectGpuMemoryFromProduct('AMD-MI250X')).toBeUndefined();
+    expect(detectGpuMemoryFromProduct('')).toBeUndefined();
+  });
+});
+
+describe('KubernetesService - Label Selector Logic', () => {
+  // Test the label selector patterns used for finding pods
+  const labelSelectors = [
+    'app.kubernetes.io/instance={name}',
+    'kaito.sh/workspace={name}',
+    'app={name}',
+  ];
+
+  test('generates correct standard K8s label selector', () => {
+    const deploymentName = 'my-llm';
+    const selector = labelSelectors[0].replace('{name}', deploymentName);
+    expect(selector).toBe('app.kubernetes.io/instance=my-llm');
+  });
+
+  test('generates correct KAITO label selector', () => {
+    const deploymentName = 'kaito-model';
+    const selector = labelSelectors[1].replace('{name}', deploymentName);
+    expect(selector).toBe('kaito.sh/workspace=kaito-model');
+  });
+
+  test('generates correct fallback label selector', () => {
+    const deploymentName = 'legacy-app';
+    const selector = labelSelectors[2].replace('{name}', deploymentName);
+    expect(selector).toBe('app=legacy-app');
+  });
+});
+
+describe('KubernetesService - Protected Namespaces', () => {
+  const protectedNamespaces = ['default', 'kube-system', 'kube-public', 'kube-node-lease'];
+
+  test('identifies protected namespaces', () => {
+    expect(protectedNamespaces.includes('default')).toBe(true);
+    expect(protectedNamespaces.includes('kube-system')).toBe(true);
+    expect(protectedNamespaces.includes('kube-public')).toBe(true);
+    expect(protectedNamespaces.includes('kube-node-lease')).toBe(true);
+  });
+
+  test('allows deletion of non-protected namespaces', () => {
+    expect(protectedNamespaces.includes('my-namespace')).toBe(false);
+    expect(protectedNamespaces.includes('kubefoundry-system')).toBe(false);
+    expect(protectedNamespaces.includes('dynamo')).toBe(false);
+  });
+});
+
+describe('KubernetesService - ANSI Color Code Stripping', () => {
+  // Test the ANSI color code regex used in getPodLogs
+  const ansiRegex = /\x1b\[[0-9;]*m/g;
+
+  function stripAnsiCodes(text: string): string {
+    return text.replace(ansiRegex, '');
+  }
+
+  test('strips ANSI color codes from logs', () => {
+    const coloredLog = '\x1b[32mINFO\x1b[0m: Application started';
+    expect(stripAnsiCodes(coloredLog)).toBe('INFO: Application started');
+  });
+
+  test('strips multiple ANSI codes', () => {
+    const coloredLog = '\x1b[31mERROR\x1b[0m: \x1b[33mWarning\x1b[0m detected';
+    expect(stripAnsiCodes(coloredLog)).toBe('ERROR: Warning detected');
+  });
+
+  test('handles text without ANSI codes', () => {
+    const plainLog = 'Normal log message';
+    expect(stripAnsiCodes(plainLog)).toBe('Normal log message');
+  });
+
+  test('handles empty string', () => {
+    expect(stripAnsiCodes('')).toBe('');
+  });
+
+  test('strips bold and other formatting codes', () => {
+    const formattedLog = '\x1b[1mBold\x1b[0m and \x1b[4munderline\x1b[0m';
+    expect(stripAnsiCodes(formattedLog)).toBe('Bold and underline');
+  });
+});
+
+describe('KubernetesService - Node Pool Label Detection', () => {
+  // Test the logic for detecting node pool names from labels
+  function getNodePoolName(labels: Record<string, string>): string {
+    return (
+      labels['agentpool'] ||
+      labels['kubernetes.azure.com/agentpool'] ||
+      labels['cloud.google.com/gke-nodepool'] ||
+      labels['eks.amazonaws.com/nodegroup'] ||
+      'default'
+    );
+  }
+
+  test('detects AKS agentpool label', () => {
+    const labels = { agentpool: 'gpupool' };
+    expect(getNodePoolName(labels)).toBe('gpupool');
+  });
+
+  test('detects AKS kubernetes.azure.com/agentpool label', () => {
+    const labels = { 'kubernetes.azure.com/agentpool': 'gpu-nodepool' };
+    expect(getNodePoolName(labels)).toBe('gpu-nodepool');
+  });
+
+  test('detects GKE nodepool label', () => {
+    const labels = { 'cloud.google.com/gke-nodepool': 'gpu-pool' };
+    expect(getNodePoolName(labels)).toBe('gpu-pool');
+  });
+
+  test('detects EKS nodegroup label', () => {
+    const labels = { 'eks.amazonaws.com/nodegroup': 'gpu-nodes' };
+    expect(getNodePoolName(labels)).toBe('gpu-nodes');
+  });
+
+  test('prefers agentpool over other labels', () => {
+    const labels = {
+      agentpool: 'aks-pool',
+      'cloud.google.com/gke-nodepool': 'gke-pool',
+    };
+    expect(getNodePoolName(labels)).toBe('aks-pool');
+  });
+
+  test('returns default for empty labels', () => {
+    expect(getNodePoolName({})).toBe('default');
+  });
+
+  test('returns default for unrecognized labels', () => {
+    const labels = { 'custom-label': 'value' };
+    expect(getNodePoolName(labels)).toBe('default');
+  });
+});

--- a/backend/src/services/metrics.test.ts
+++ b/backend/src/services/metrics.test.ts
@@ -1,0 +1,230 @@
+import { describe, test, expect } from 'bun:test';
+import type { RawMetricValue, MetricsResponse } from '@kubefoundry/shared';
+
+describe('MetricsService - buildMetricsUrl', () => {
+  // Test the URL building logic (unit test the pattern)
+  function buildMetricsUrl(
+    deploymentName: string,
+    namespace: string,
+    servicePattern: string,
+    port: number,
+    endpointPath: string
+  ): string {
+    const serviceName = servicePattern.replace('{name}', deploymentName);
+    return `http://${serviceName}.${namespace}.svc.cluster.local:${port}${endpointPath}`;
+  }
+
+  test('builds correct URL with service pattern', () => {
+    const url = buildMetricsUrl(
+      'my-model',
+      'default',
+      '{name}-router',
+      8000,
+      '/metrics'
+    );
+    expect(url).toBe('http://my-model-router.default.svc.cluster.local:8000/metrics');
+  });
+
+  test('handles namespace with hyphens', () => {
+    const url = buildMetricsUrl(
+      'llama-model',
+      'ml-workloads',
+      '{name}-svc',
+      9090,
+      '/v1/metrics'
+    );
+    expect(url).toBe('http://llama-model-svc.ml-workloads.svc.cluster.local:9090/v1/metrics');
+  });
+
+  test('handles pattern without placeholder', () => {
+    const url = buildMetricsUrl(
+      'ignored',
+      'monitoring',
+      'prometheus',
+      9090,
+      '/metrics'
+    );
+    expect(url).toBe('http://prometheus.monitoring.svc.cluster.local:9090/metrics');
+  });
+});
+
+describe('MetricsService - Error Message Handling', () => {
+  // Test error message mapping logic
+  function mapErrorMessage(errorMessage: string): string {
+    if (errorMessage.includes('ENOTFOUND') || errorMessage.includes('getaddrinfo')) {
+      return 'Cannot resolve service DNS. KubeFoundry must be running in-cluster to fetch metrics.';
+    } else if (errorMessage.includes('ECONNREFUSED')) {
+      return 'Connection refused. The deployment may not be ready yet.';
+    } else if (errorMessage.includes('abort')) {
+      return 'Request timed out. The deployment may be under heavy load or not responding.';
+    } else if (errorMessage.includes('HTTP 404')) {
+      return 'Metrics endpoint not found. The deployment may not expose metrics.';
+    } else if (errorMessage.includes('HTTP 503')) {
+      return 'Service unavailable. The deployment is starting up.';
+    } else if (errorMessage.includes('fetch failed') || errorMessage.includes('TypeError')) {
+      return 'Cannot connect to metrics endpoint. KubeFoundry must be running in-cluster.';
+    }
+    return errorMessage;
+  }
+
+  test('maps DNS resolution errors', () => {
+    expect(mapErrorMessage('getaddrinfo ENOTFOUND service.namespace.svc')).toContain('Cannot resolve service DNS');
+    expect(mapErrorMessage('Error: ENOTFOUND')).toContain('in-cluster');
+  });
+
+  test('maps connection refused errors', () => {
+    expect(mapErrorMessage('connect ECONNREFUSED 10.0.0.1:8000')).toContain('Connection refused');
+    expect(mapErrorMessage('ECONNREFUSED')).toContain('not be ready');
+  });
+
+  test('maps timeout errors', () => {
+    expect(mapErrorMessage('The operation was aborted')).toContain('timed out');
+    expect(mapErrorMessage('signal was aborted')).toContain('heavy load');
+  });
+
+  test('maps HTTP 404 errors', () => {
+    expect(mapErrorMessage('HTTP 404: Not Found')).toContain('endpoint not found');
+    expect(mapErrorMessage('HTTP 404')).toContain('not expose metrics');
+  });
+
+  test('maps HTTP 503 errors', () => {
+    expect(mapErrorMessage('HTTP 503: Service Unavailable')).toContain('Service unavailable');
+    expect(mapErrorMessage('HTTP 503')).toContain('starting up');
+  });
+
+  test('maps fetch errors', () => {
+    expect(mapErrorMessage('fetch failed')).toContain('in-cluster');
+    expect(mapErrorMessage('TypeError: Failed to fetch')).toContain('in-cluster');
+  });
+
+  test('returns original message for unknown errors', () => {
+    expect(mapErrorMessage('Some unknown error')).toBe('Some unknown error');
+    expect(mapErrorMessage('Unexpected condition')).toBe('Unexpected condition');
+  });
+});
+
+describe('MetricsService - MetricsResponse structure', () => {
+  test('creates unavailable response for off-cluster', () => {
+    const response: MetricsResponse = {
+      available: false,
+      error: 'Metrics are only available when KubeFoundry is deployed inside the Kubernetes cluster.',
+      timestamp: new Date().toISOString(),
+      metrics: [],
+      runningOffCluster: true,
+    };
+
+    expect(response.available).toBe(false);
+    expect(response.runningOffCluster).toBe(true);
+    expect(response.metrics).toHaveLength(0);
+    expect(response.error).toContain('inside the Kubernetes cluster');
+  });
+
+  test('creates available response with metrics', () => {
+    const metrics: RawMetricValue[] = [
+      { name: 'vllm:num_requests_running', value: 5, labels: {} },
+      { name: 'vllm:gpu_cache_usage_perc', value: 0.73, labels: { model: 'llama' } },
+    ];
+
+    const response: MetricsResponse = {
+      available: true,
+      timestamp: new Date().toISOString(),
+      metrics,
+    };
+
+    expect(response.available).toBe(true);
+    expect(response.error).toBeUndefined();
+    expect(response.metrics).toHaveLength(2);
+    expect(response.metrics[0].name).toBe('vllm:num_requests_running');
+  });
+
+  test('creates error response', () => {
+    const response: MetricsResponse = {
+      available: false,
+      error: 'Connection refused. The deployment may not be ready yet.',
+      timestamp: new Date().toISOString(),
+      metrics: [],
+    };
+
+    expect(response.available).toBe(false);
+    expect(response.error).toContain('Connection refused');
+    expect(response.runningOffCluster).toBeUndefined();
+  });
+});
+
+describe('MetricsService - Key Metrics Filtering', () => {
+  // Test the logic for filtering key metrics from raw metrics
+  function extractKeyMetrics(
+    rawMetrics: RawMetricValue[],
+    keyMetricNames: Set<string>
+  ): RawMetricValue[] {
+    // Expand key metric names to include histogram variants
+    const expandedNames = new Set(keyMetricNames);
+    for (const name of keyMetricNames) {
+      expandedNames.add(`${name}_sum`);
+      expandedNames.add(`${name}_count`);
+      expandedNames.add(`${name}_bucket`);
+      expandedNames.add(`${name}_total`);
+    }
+
+    return rawMetrics.filter(m => expandedNames.has(m.name));
+  }
+
+  test('filters to only key metrics', () => {
+    const rawMetrics: RawMetricValue[] = [
+      { name: 'vllm:num_requests_running', value: 5, labels: {} },
+      { name: 'vllm:gpu_cache_usage_perc', value: 0.73, labels: {} },
+      { name: 'unrelated_metric', value: 100, labels: {} },
+      { name: 'another_random_metric', value: 42, labels: {} },
+    ];
+
+    const keyNames = new Set(['vllm:num_requests_running', 'vllm:gpu_cache_usage_perc']);
+    const filtered = extractKeyMetrics(rawMetrics, keyNames);
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map(m => m.name)).toContain('vllm:num_requests_running');
+    expect(filtered.map(m => m.name)).toContain('vllm:gpu_cache_usage_perc');
+  });
+
+  test('includes histogram variants (_sum, _count, _bucket)', () => {
+    const rawMetrics: RawMetricValue[] = [
+      { name: 'latency_seconds', value: 5, labels: {} },
+      { name: 'latency_seconds_sum', value: 500, labels: {} },
+      { name: 'latency_seconds_count', value: 100, labels: {} },
+      { name: 'latency_seconds_bucket', value: 50, labels: { le: '0.5' } },
+      { name: 'other_metric', value: 42, labels: {} },
+    ];
+
+    const keyNames = new Set(['latency_seconds']);
+    const filtered = extractKeyMetrics(rawMetrics, keyNames);
+
+    expect(filtered).toHaveLength(4);
+    expect(filtered.map(m => m.name)).not.toContain('other_metric');
+  });
+
+  test('includes counter variants (_total)', () => {
+    const rawMetrics: RawMetricValue[] = [
+      { name: 'requests', value: 100, labels: {} },
+      { name: 'requests_total', value: 100, labels: {} },
+      { name: 'other_total', value: 50, labels: {} },
+    ];
+
+    const keyNames = new Set(['requests']);
+    const filtered = extractKeyMetrics(rawMetrics, keyNames);
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map(m => m.name)).toContain('requests');
+    expect(filtered.map(m => m.name)).toContain('requests_total');
+  });
+
+  test('returns empty array when no matches', () => {
+    const rawMetrics: RawMetricValue[] = [
+      { name: 'metric_a', value: 1, labels: {} },
+      { name: 'metric_b', value: 2, labels: {} },
+    ];
+
+    const keyNames = new Set(['metric_c', 'metric_d']);
+    const filtered = extractKeyMetrics(rawMetrics, keyNames);
+
+    expect(filtered).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
- Add tests for retry utilities (18 tests)
- Add tests for validation schemas (22 tests)
- Add tests for metrics service (17 tests)
- Add tests for kubernetes service logic (41 tests)
- Add tests for helm service (24 tests)
- Add tests for config service (23 tests)

Total: 145 new tests, bringing backend total to 630 tests