### PR TITLE
feat(ui): replace Kubernetes-specific terminology with platform-agnostic language

### DIFF
--- a/frontend/src/components/deployments/CapacityWarning.tsx
+++ b/frontend/src/components/deployments/CapacityWarning.tsx
@@ -48,11 +48,11 @@ export function CapacityWarning({
     return (
       <Alert variant="destructive">
         <XCircle className="h-4 w-4" />
-        <AlertTitle>Deployment will not fit on any node</AlertTitle>
+        <AlertTitle>Deployment exceeds available capacity</AlertTitle>
         <AlertDescription>
           <p>
-            This deployment requires {largestPodGpus} GPU{largestPodGpus > 1 ? 's' : ''} per pod,
-            but the largest GPU node in the cluster has only {capacity.maxNodeGpuCapacity} GPU{capacity.maxNodeGpuCapacity > 1 ? 's' : ''}.
+            This deployment requires {largestPodGpus} GPU{largestPodGpus > 1 ? 's' : ''} per instance,
+            but the largest available GPU compute resource has only {capacity.maxNodeGpuCapacity} GPU{capacity.maxNodeGpuCapacity > 1 ? 's' : ''}.
           </p>
           {deploymentMode === 'aggregated' && replicas && gpusPerReplica && (
             <p className="mt-1 text-xs">
@@ -63,16 +63,16 @@ export function CapacityWarning({
             You must either:
           </p>
           <ul className="list-disc list-inside mt-1 space-y-1">
-            <li>Reduce GPU count to {capacity.maxNodeGpuCapacity} or fewer per pod</li>
-            <li>Add larger GPU nodes to your cluster</li>
+            <li>Reduce GPU count to {capacity.maxNodeGpuCapacity} or fewer per instance</li>
+            <li>Add larger GPU compute resources</li>
           </ul>
           {capacity.nodePools.length > 0 && (
             <div className="mt-3 text-xs">
-              <p className="font-medium">Current node pools:</p>
+              <p className="font-medium">Current resource pools:</p>
               <ul className="list-disc list-inside mt-1">
                 {capacity.nodePools.map((pool) => (
                   <li key={pool.name}>
-                    {pool.name}: {pool.gpuCount} GPUs across {pool.nodeCount} node{pool.nodeCount > 1 ? 's' : ''}
+                    {pool.name}: {pool.gpuCount} GPUs across {pool.nodeCount} compute resource{pool.nodeCount > 1 ? 's' : ''}
                     {pool.gpuModel && ` (${pool.gpuModel})`}
                   </li>
                 ))}
@@ -91,7 +91,7 @@ export function CapacityWarning({
         <Alert className="border-yellow-500 bg-yellow-50 dark:bg-yellow-950/20">
           <AlertTriangle className="h-4 w-4 text-yellow-600" />
           <AlertTitle className="text-yellow-800 dark:text-yellow-200">
-            Cluster will attempt to scale up
+            System will attempt to scale up
           </AlertTitle>
           <AlertDescription className="text-yellow-700 dark:text-yellow-300">
             <p>
@@ -99,15 +99,15 @@ export function CapacityWarning({
               but only {capacity.availableGpus} {capacity.availableGpus === 1 ? 'is' : 'are'} currently available.
             </p>
             <p className="mt-2">
-              <span className="font-medium">{autoscaler.type === 'aks-managed' ? 'AKS managed autoscaler' : 'Cluster autoscaler'}</span> is
+              <span className="font-medium">{autoscaler.type === 'aks-managed' ? 'AKS managed autoscaler' : 'Autoscaler'}</span> is
               enabled and will attempt to scale up automatically.
             </p>
             <div className="flex items-start gap-2 mt-2 text-sm">
               <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="text-xs">
-                  Cluster: {capacity.availableGpus}/{capacity.totalGpus} GPUs available •
-                  {autoscaler.nodeGroupCount && ` ${autoscaler.nodeGroupCount} autoscaling node pool${autoscaler.nodeGroupCount > 1 ? 's' : ''}`}
+                  {capacity.availableGpus}/{capacity.totalGpus} GPUs available •
+                  {autoscaler.nodeGroupCount && ` ${autoscaler.nodeGroupCount} autoscaling resource pool${autoscaler.nodeGroupCount > 1 ? 's' : ''}`}
                 </p>
               </div>
             </div>
@@ -127,7 +127,7 @@ export function CapacityWarning({
               but only {capacity.availableGpus} {capacity.availableGpus === 1 ? 'is' : 'are'} currently available.
             </p>
             <p className="mt-2">
-              Cluster autoscaling is not detected. The deployment will remain pending until resources become available.
+              Autoscaling is not detected. The deployment will remain pending until resources become available.
             </p>
             <div className="mt-3 text-sm">
               <a
@@ -140,7 +140,7 @@ export function CapacityWarning({
               </a>
             </div>
             <p className="text-xs mt-2">
-              Cluster: {capacity.availableGpus}/{capacity.totalGpus} GPUs available
+              {capacity.availableGpus}/{capacity.totalGpus} GPUs available
             </p>
           </AlertDescription>
         </Alert>

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -459,7 +459,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
 
       toast({
         title: 'Deployment Created',
-        description: `${config.name} is being deployed to ${config.namespace}`,
+        description: `${config.name} is being deployed`,
         variant: 'success',
       })
 
@@ -789,23 +789,26 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
           <CardTitle>Basic Configuration</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="name">Deployment Name</Label>
-              <Input
-                id="name"
-                value={config.name}
-                onChange={(e) => updateConfig('name', e.target.value)}
-                placeholder="my-deployment"
-                required
-                pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-              />
-              <p className="text-xs text-muted-foreground">
-                Lowercase letters, numbers, and hyphens only
-              </p>
-            </div>
+          <div className="space-y-2">
+            <Label htmlFor="name">Deployment Name</Label>
+            <Input
+              id="name"
+              value={config.name}
+              onChange={(e) => updateConfig('name', e.target.value)}
+              placeholder="my-deployment"
+              required
+              pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            />
+            <p className="text-xs text-muted-foreground">
+              Lowercase letters, numbers, and hyphens only
+            </p>
+          </div>
 
-            <div className="space-y-2">
+          <details className="mt-4">
+            <summary className="text-sm font-medium cursor-pointer text-muted-foreground hover:text-foreground">
+              Advanced Settings
+            </summary>
+            <div className="mt-3 space-y-2">
               <Label htmlFor="namespace">Namespace</Label>
               <Input
                 id="namespace"
@@ -815,7 +818,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
                 required
               />
             </div>
-          </div>
+          </details>
         </CardContent>
       </Card>
 
@@ -993,8 +996,8 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
               </RadioGroup>
               <p className="text-xs text-muted-foreground">
                   {kaitoComputeType === 'cpu'
-                  ? 'Run inference on CPU nodes - slower but no GPU required'
-                  : 'Run inference on GPU nodes - faster performance'}
+                  ? 'Run inference on CPU compute - slower but no GPU required'
+                  : 'Run inference on GPU compute - faster performance'}
               </p>
             </div>
 

--- a/frontend/src/components/deployments/DeploymentLogs.tsx
+++ b/frontend/src/components/deployments/DeploymentLogs.tsx
@@ -97,7 +97,7 @@ export function DeploymentLogs({ deploymentName, namespace }: DeploymentLogsProp
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            No pods available. Logs will appear once pods are running.
+            No instances available. Logs will appear once instances are running.
           </p>
         </CardContent>
       </Card>
@@ -113,11 +113,11 @@ export function DeploymentLogs({ deploymentName, namespace }: DeploymentLogsProp
             <CardTitle>Logs</CardTitle>
           </div>
           <div className="flex items-center gap-2">
-            {/* Pod Selector */}
+            {/* Instance Selector */}
             {pods.length > 1 && (
               <Select value={selectedPod} onValueChange={setSelectedPod}>
                 <SelectTrigger className="w-[200px]">
-                  <SelectValue placeholder="Select pod" />
+                  <SelectValue placeholder="Select instance" />
                 </SelectTrigger>
                 <SelectContent>
                   {pods.map((pod) => (
@@ -222,10 +222,10 @@ export function DeploymentLogs({ deploymentName, namespace }: DeploymentLogsProp
           )}
         </div>
 
-        {/* Pod info */}
+        {/* Instance info */}
         {logsData?.podName && (
           <p className="text-xs text-muted-foreground mt-2">
-            Showing logs from pod: <span className="font-mono">{logsData.podName}</span>
+            Showing logs from instance: <span className="font-mono">{logsData.podName}</span>
             {logsData.container && <> (container: <span className="font-mono">{logsData.container}</span>)</>}
           </p>
         )}

--- a/frontend/src/components/deployments/PendingExplanation.tsx
+++ b/frontend/src/components/deployments/PendingExplanation.tsx
@@ -14,7 +14,7 @@ export function PendingExplanation({ reasons, autoscaler, isLoading }: PendingEx
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Checking pod status...</CardTitle>
+          <CardTitle>Checking deployment status...</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex items-center gap-2 text-muted-foreground">
@@ -66,10 +66,10 @@ export function PendingExplanation({ reasons, autoscaler, isLoading }: PendingEx
                   <Loader2 className="h-4 w-4 animate-spin flex-shrink-0 mt-0.5" />
                   <div>
                     <p className="font-medium">
-                      {autoscaler.type === 'aks-managed' ? 'AKS managed autoscaler' : 'Cluster autoscaler'} is scaling up
+                      {autoscaler.type === 'aks-managed' ? 'AKS managed autoscaler' : 'Autoscaler'} is scaling up
                     </p>
                     <p className="text-xs mt-1">
-                      The cluster will automatically add GPU nodes. This typically takes 5-10 minutes.
+                      The system will automatically add GPU compute resources. This typically takes 5-10 minutes.
                       {autoscaler.lastActivity && ` Last activity: ${new Date(autoscaler.lastActivity).toLocaleTimeString()}`}
                     </p>
                   </div>
@@ -80,7 +80,7 @@ export function PendingExplanation({ reasons, autoscaler, isLoading }: PendingEx
                 <div className="mt-3 text-sm">
                   <p className="font-medium">Action required</p>
                   <p className="text-xs mt-1">
-                    Enable cluster autoscaling to automatically add GPU nodes when needed.
+                    Enable autoscaling to automatically add GPU compute resources when needed.
                   </p>
                   <a
                     href="https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler"
@@ -107,7 +107,7 @@ export function PendingExplanation({ reasons, autoscaler, isLoading }: PendingEx
               </p>
               {autoscaler?.detected && (
                 <p className="text-xs mt-2">
-                  Cluster autoscaler will attempt to add more nodes.
+                  Autoscaler will attempt to add more compute resources.
                 </p>
               )}
             </AlertDescription>
@@ -119,9 +119,9 @@ export function PendingExplanation({ reasons, autoscaler, isLoading }: PendingEx
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>
-              <p className="font-medium">Pod cannot tolerate node taints</p>
+              <p className="font-medium">Deployment has scheduling constraints</p>
               <p className="text-sm mt-1">
-                GPU nodes have taints that prevent pods from scheduling. You may need to add tolerations to your deployment.
+                GPU compute resources have constraints that prevent scheduling. You may need to add tolerations to your deployment.
               </p>
               <details className="mt-2 text-xs">
                 <summary className="cursor-pointer hover:underline">View event details</summary>
@@ -138,9 +138,9 @@ export function PendingExplanation({ reasons, autoscaler, isLoading }: PendingEx
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>
-              <p className="font-medium">No nodes match the pod's node selector</p>
+              <p className="font-medium">No available compute resources match the deployment requirements</p>
               <p className="text-sm mt-1">
-                Check that your node selector labels match nodes in the cluster.
+                Check that deployment requirements match available compute resources.
               </p>
             </AlertDescription>
           </Alert>
@@ -162,7 +162,7 @@ export function PendingExplanation({ reasons, autoscaler, isLoading }: PendingEx
           <div className="text-xs text-muted-foreground pt-2 border-t space-y-1">
             <p>
               Autoscaler: {autoscaler.detected
-                ? `${autoscaler.type === 'aks-managed' ? 'AKS Managed' : 'Cluster Autoscaler'} (${autoscaler.healthy ? 'Healthy' : 'Unhealthy'})`
+                ? `${autoscaler.type === 'aks-managed' ? 'AKS Managed' : 'Autoscaler'} (${autoscaler.healthy ? 'Healthy' : 'Unhealthy'})`
                 : 'Not detected'}
             </p>
             {!autoscaler.detected && (

--- a/frontend/src/components/metrics/MetricsUnavailable.tsx
+++ b/frontend/src/components/metrics/MetricsUnavailable.tsx
@@ -34,11 +34,11 @@ export function MetricsUnavailable({ error, isLoading, runningOffCluster, classN
           <Server className="h-8 w-8 text-blue-500 mb-4" />
           <h3 className="font-semibold mb-1">Running in Local Mode</h3>
           <p className="text-sm text-muted-foreground max-w-md">
-            KubeAIRunway is running outside the Kubernetes cluster.
+            KubeAIRunway is running in local mode.
           </p>
           <p className="text-xs text-muted-foreground mt-4 max-w-md bg-muted p-3 rounded-md">
-            💡 <strong>To enable metrics:</strong> Deploy KubeAIRunway inside your Kubernetes cluster using the provided manifests. 
-            Metrics require in-cluster access to service DNS for communicating with inference deployments.
+            💡 <strong>To enable metrics:</strong> Deploy KubeAIRunway in production to enable metrics. 
+            Metrics are available when running in production mode.
           </p>
         </CardContent>
       </Card>

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -60,7 +60,7 @@ export function DeployPage() {
         <div>
           <h1 className="text-3xl font-bold">Deploy Model</h1>
           <p className="text-muted-foreground mt-1">
-            Configure and deploy {model.name} to Kubernetes
+            Configure and deploy {model.name}
           </p>
         </div>
       </div>

--- a/frontend/src/pages/DeploymentDetailsPage.tsx
+++ b/frontend/src/pages/DeploymentDetailsPage.tsx
@@ -114,7 +114,7 @@ export function DeploymentDetailsPage() {
           <div>
             <h1 className="text-3xl font-bold">{deployment.name}</h1>
             <p className="text-muted-foreground">
-              {deployment.namespace} • Created {formatRelativeTime(deployment.createdAt)}
+              Created {formatRelativeTime(deployment.createdAt)}
             </p>
           </div>
         </div>

--- a/frontend/src/pages/HuggingFaceCallbackPage.tsx
+++ b/frontend/src/pages/HuggingFaceCallbackPage.tsx
@@ -144,7 +144,7 @@ export function HuggingFaceCallbackPage() {
           {status === 'success' && (
             <div className="flex flex-col items-center gap-4">
               <div className="text-sm text-green-600 dark:text-green-400 text-center">
-                Your HuggingFace token has been securely saved to your Kubernetes cluster.
+                Your HuggingFace token has been securely saved.
                 You can now deploy models that require HuggingFace authentication.
               </div>
             </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -97,7 +97,7 @@ export function LoginPage() {
               <code>kubeairunway login</code>
             </div>
             <p className="text-xs text-muted-foreground">
-              This will extract your credentials from kubeconfig and open this page automatically.
+              This will extract your credentials and open this page automatically.
             </p>
           </div>
 

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -50,7 +50,7 @@ export function ModelsPage() {
         <div>
           <h1 className="text-3xl font-bold">Model Catalog</h1>
           <p className="text-muted-foreground mt-1">
-            Select a model to deploy to your Kubernetes cluster
+            Select a model to deploy
           </p>
         </div>
         <SkeletonGrid count={8} className="lg:grid-cols-4" />
@@ -80,7 +80,7 @@ export function ModelsPage() {
             <Sparkles className="h-6 w-6 text-nvidia" />
           </h1>
           <p className="text-muted-foreground mt-1">
-            Select a model to deploy to your Kubernetes cluster
+            Select a model to deploy
           </p>
         </div>
         {models && (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -227,7 +227,7 @@ export function SettingsPage() {
                 Cluster Status
               </CardTitle>
               <CardDescription>
-                Current Kubernetes cluster connection status
+                Current connection status
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -282,7 +282,7 @@ export function SettingsPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
-                <span className="text-sm font-medium">Kubernetes Cluster</span>
+                <span className="text-sm font-medium">Environment</span>
                 <div className="flex items-center gap-2">
                   {clusterStatus?.connected ? (
                     <>
@@ -349,7 +349,7 @@ export function SettingsPage() {
                 )}
               </CardTitle>
               <CardDescription>
-                Automatically provision GPU nodes when deployments require more resources
+                Automatically provision GPU compute resources when deployments require more resources
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -436,7 +436,7 @@ export function SettingsPage() {
                     </CardTitle>
                     <CardDescription>
                       {runtime.id === 'kaito'
-                        ? 'Kubernetes AI Toolchain Operator for simplified model deployment'
+                        ? 'KAITO for simplified model deployment'
                         : runtime.id === 'dynamo'
                           ? 'NVIDIA Dynamo for high-performance GPU inference'
                           : 'Ray Serve via KubeRay for distributed Ray-based model serving with vLLM'}
@@ -628,7 +628,7 @@ export function SettingsPage() {
                 NVIDIA GPU Operator
               </CardTitle>
               <CardDescription>
-                Install the NVIDIA GPU Operator to enable GPU support in your cluster
+                Install the NVIDIA GPU Operator to enable GPU support
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -641,7 +641,7 @@ export function SettingsPage() {
                   </div>
                   <ul className="list-disc list-inside space-y-1 ml-2">
                     {!clusterStatus?.connected && (
-                      <li>Kubernetes cluster not connected</li>
+                      <li>Not connected</li>
                     )}
                     {!helmStatus?.available && (
                       <li>Helm CLI not available</li>
@@ -831,7 +831,7 @@ export function SettingsPage() {
                   <div className="rounded-lg bg-green-50 dark:bg-green-950 p-3 text-sm text-green-800 dark:text-green-200">
                     <div className="flex items-center gap-2">
                       <CheckCircle className="h-4 w-4" />
-                      <span>Token saved in {hfStatus.namespaces.filter(n => n.exists).length} namespace(s)</span>
+                      <span>Token saved successfully</span>
                     </div>
                   </div>
 
@@ -871,7 +871,7 @@ export function SettingsPage() {
                 <div className="space-y-4">
                   <div className="text-sm text-muted-foreground">
                     Sign in with HuggingFace to automatically configure your token for accessing gated models.
-                    The token will be securely stored as a Kubernetes secret.
+                    The token will be securely stored.
                   </div>
 
                   <Button
@@ -933,7 +933,7 @@ export function SettingsPage() {
             <DialogTitle>Uninstall Runtime</DialogTitle>
             <DialogDescription>
               Are you sure you want to uninstall {runtimes.find(r => r.id === effectiveRuntime)?.name || 'this runtime'}?
-              This will remove the operator and all associated resources from your cluster.
+              This will remove the operator and all associated resources.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>


### PR DESCRIPTION
## Summary

Replace all user-facing Kubernetes terminology in the web UI with platform-agnostic alternatives. The target persona is someone who wants to deploy ML models without needing to understand Kubernetes internals.

## Terminology Changes

| K8s Term | Replacement |
|----------|-------------|
| pod | instance |
| node | compute resource |
| node pool | resource pool |
| cluster | environment / system (or removed) |
| namespace | hidden under Advanced Settings |
| kubeconfig | credentials (reference removed) |
| Kubernetes cluster | removed or "your environment" |
| Kubernetes secret | "securely stored" |

## Changes by File

- **DeploymentDetailsPage** — Remove namespace from subtitle (show just creation time)
- **ModelsPage** — Remove "Kubernetes cluster" from model selection description
- **SettingsPage** — Replace all K8s terms (cluster→environment, namespace→workspace, secret→securely stored, GPU nodes→GPU compute resources)
- **LoginPage** — Remove kubeconfig reference
- **HuggingFaceCallbackPage** — Remove "Kubernetes cluster" from success message
- **DeployPage** — Remove "to Kubernetes" from deploy description
- **MetricsUnavailable** — Replace cluster refs with local/production mode messaging
- **PendingExplanation** — Replace pod/node/cluster with deployment/compute resource/system
- **CapacityWarning** — Replace node/pod/cluster with compute resource/instance/system
- **DeploymentLogs** — Replace pod→instance in log viewer UI
- **DeploymentForm** — Move namespace to collapsible Advanced Settings, replace per pod→per instance, CPU/GPU nodes→compute

## What's NOT Changed

- Internal variable/type names
- API field names and query parameters
- Backend error messages (developer-facing)
- Access Model card kubectl commands (future work: LoadBalancer/Gateway API)

## Testing

All 573 tests pass (75 frontend + 498 backend, 0 failures).