### PR TITLE
fix: remove hardcoded provider count assertion in runtimes status test

### DIFF
--- a/backend/src/hono-app.test.ts
+++ b/backend/src/hono-app.test.ts
@@ -113,8 +113,7 @@ describe('Hono Routes', () => {
           const data = await res.json();
           expect(data.runtimes).toBeDefined();
           expect(Array.isArray(data.runtimes)).toBe(true);
-          // Should have both dynamo and kuberay runtimes
-          expect(data.runtimes.length).toBeGreaterThanOrEqual(2);
+          // Validate shape of each runtime if any are returned
           for (const runtime of data.runtimes) {
             expect(runtime.id).toBeDefined();
             expect(runtime.name).toBeDefined();


### PR DESCRIPTION
## Summary

Remove the hardcoded `expect(data.runtimes.length).toBeGreaterThanOrEqual(2)` assertion in the runtimes status test. The number of `InferenceProviderConfig` CRDs is environment-dependent, so assuming ≥2 providers causes failures when fewer are registered.

The test still validates that `data.runtimes` is a defined array and checks the shape of each runtime object.

Fixes #105