### PR TITLE
feat: add e2e backend integration test workflow

### DIFF
--- a/.github/workflows/e2e-backend.yml
+++ b/.github/workflows/e2e-backend.yml
@@ -1,0 +1,85 @@
+name: E2E Backend Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  e2e-backend:
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: controller/go.sum
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        with:
+          bun-version: latest
+
+      - name: Setup Kind
+        run: |
+          go install sigs.k8s.io/kind@latest
+          kind create cluster --name kubeairunway-backend-e2e --wait 120s
+
+      - name: Install KAITO operator
+        run: |
+          helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
+          helm install kaito-workspace kaito/workspace \
+            --namespace kaito-workspace \
+            --create-namespace \
+            --set featureGates.disableNodeAutoProvisioning=true
+          kubectl wait --for=condition=Available deployment -n kaito-workspace -l app.kubernetes.io/name=workspace --timeout=120s
+
+      - name: Build and deploy controller
+        run: |
+          make controller-docker-build CONTROLLER_IMG=kubeairunway-controller:e2e
+          kind load docker-image kubeairunway-controller:e2e --name kubeairunway-backend-e2e
+          make controller-deploy CONTROLLER_IMG=kubeairunway-controller:e2e
+          kubectl wait --for=condition=Available deployment -n kubeairunway-system -l control-plane=controller-manager --timeout=120s
+
+      - name: Build and deploy KAITO provider
+        run: |
+          make kaito-provider-docker-build KAITO_PROVIDER_IMG=kaito-provider:e2e
+          kind load docker-image kaito-provider:e2e --name kubeairunway-backend-e2e
+          make kaito-provider-deploy KAITO_PROVIDER_IMG=kaito-provider:e2e
+          kubectl wait --for=condition=Available deployment -n kubeairunway-system -l control-plane=kaito-provider --timeout=120s
+
+      - name: Wait for provider registration
+        run: |
+          kubectl wait --for=jsonpath='{.status.ready}'=true inferenceproviderconfig/kaito --timeout=120s
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Run backend integration tests
+        run: |
+          cd backend
+          bun test
+
+      - name: Collect debug info
+        if: failure()
+        run: |
+          echo "=== InferenceProviderConfigs ==="
+          kubectl get inferenceproviderconfigs -o yaml
+          echo "=== Controller Logs ==="
+          kubectl logs -n kubeairunway-system -l control-plane=controller-manager --tail=100
+          echo "=== KAITO Provider Logs ==="
+          kubectl logs -n kubeairunway-system -l control-plane=kaito-provider --tail=100
+          echo "=== Pods ==="
+          kubectl get pods -A
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kind delete cluster --name kubeairunway-backend-e2e


### PR DESCRIPTION
## Summary

Add a separate GitHub Actions workflow (`e2e-backend.yml`) that runs backend tests against a live KinD cluster with the controller and KAITO provider deployed.

### Why

The backend tests in `hono-app.test.ts` have K8s-dependent tests that gracefully skip via `withTimeout` when no cluster is available. In the unit test CI (`test.yml`), these tests always skip because there's no cluster. This workflow ensures they actually exercise real K8s API paths.

### What it does

1. Creates a KinD cluster
2. Deploys controller (installs CRDs)
3. Deploys KAITO provider (registers an `InferenceProviderConfig`)
4. Runs `bun test` — K8s-dependent tests now hit a real API server

Runs in parallel with the existing `e2e-controller` and `e2e-gateway` workflows.

### Relation to #81

This addresses the **CI pipeline infrastructure** item from #81 ("Add to CI pipeline"). The remaining items from that issue — additional route coverage, multi-step flow tests, test harness with fixtures, and local run documentation — are not in scope for this PR.