### PR TITLE
fix: add headlamp workspace to Dockerfile for bun install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY package.json bun.lock* ./
 COPY backend/package.json backend/
 COPY frontend/package.json frontend/
 COPY shared/package.json shared/
+COPY plugins/headlamp/package.json plugins/headlamp/
 
 # Install dependencies
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
Fixes release CI failure: https://github.com/kaito-project/kubeairunway/actions/runs/22637649619

The plugins/headlamp workspace was added to package.json but the Dockerfile was not updated to copy its package.json, causing bun install to fail with Workspace not found error.