### PR TITLE
docs: clarify provider shim installation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ KubeAIRunway gives you a web UI and a unified Kubernetes CRD (`ModelDeployment`)
 
 ## Supported Providers
 
-| Provider | Description |
-| --- | --- |
-| [**NVIDIA Dynamo**](https://github.com/ai-dynamo/dynamo) | GPU-accelerated inference with aggregated or disaggregated serving |
-| [**KubeRay**](https://github.com/ray-project/kuberay) | Ray-based distributed inference |
-| [**KAITO**](https://github.com/kaito-project/kaito) | vLLM (GPU) and llama.cpp (CPU/GPU) support |
-| [**LLM-D**](https://github.com/llm-d/llm-d) | vLLM (GPU) with aggregated or disaggregated serving |
+| Provider                                                 | Description                                                        | Provider Shim                                         |
+| -------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| [**NVIDIA Dynamo**](https://github.com/ai-dynamo/dynamo) | GPU-accelerated inference with aggregated or disaggregated serving | [dynamo.yaml](providers/dynamo/deploy/dynamo.yaml)    |
+| [**KubeRay**](https://github.com/ray-project/kuberay)    | Ray-based distributed inference                                    | [kuberay.yaml](providers/kuberay/deploy/kuberay.yaml) |
+| [**KAITO**](https://github.com/kaito-project/kaito)      | vLLM (GPU) and llama.cpp (CPU/GPU) support                         | [kaito.yaml](providers/kaito/deploy/kaito.yaml)       |
+| [**LLM-D**](https://github.com/llm-d/llm-d)              | vLLM (GPU) with aggregated or disaggregated serving                | [llmd.yaml](providers/llmd/deploy/llmd.yaml)          |
 
 ## Quick Start
 
@@ -63,10 +63,11 @@ Open **http://localhost:3001** — see [deployment docs](deploy/README.md) for m
 
 ### Getting Started
 
-1. **Install a provider** — Go to the Installation page and install your preferred provider via Helm
-2. **Connect HuggingFace** — Sign in via Settings → HuggingFace (required for gated models)
-3. **Deploy a model** — Browse the catalog, pick a model, configure, and deploy
-4. **Monitor** — Track status, stream logs, and view metrics on the Deployments page
+1. **Install a provider shim** — Apply one or more provider shims to register providers with KubeAIRunway. See [Supported Providers](#supported-providers) for available options.
+2. **Install the provider** — Go to the Installation page and install the upstream provider via Helm
+3. **Connect HuggingFace** — Sign in via Settings → HuggingFace (optional for non-gated models)
+4. **Deploy a model** — Browse the catalog, pick a model, configure, and deploy
+5. **Monitor** — Track status, stream logs, and view metrics on the Deployments page
 
 ### Access Your Model
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,11 +11,21 @@ This directory contains Kubernetes manifests for deploying KubeAIRunway to a clu
 # 1. Install CRDs and controller (required)
 kubectl apply -f controller.yaml
 
-# 2. Install dashboard UI (optional)
+# 2. Install one or more provider shims (required — registers providers with KubeAIRunway)
+# See "Available provider shims" below for the full list
+kubectl apply -f https://raw.githubusercontent.com/kaito-project/kubeairunway/main/providers/<provider>/deploy/<provider>.yaml
+
+# 3. Install dashboard UI (optional)
 kubectl apply -f dashboard.yaml
 ```
 
-> **Note:** `controller.yaml` must be applied first — it creates the CRDs and namespace that the dashboard depends on. Webhooks become fully functional after the controller starts and completes certificate rotation (~10-30s).
+> **Note:** `controller.yaml` must be applied first — it creates the CRDs and namespace that the dashboard depends on. Provider shims must be installed before providers appear in the UI. Webhooks become fully functional after the controller starts and completes certificate rotation (~10-30s).
+
+Available provider shims:
+- [kaito.yaml](../providers/kaito/deploy/kaito.yaml)
+- [dynamo.yaml](../providers/dynamo/deploy/dynamo.yaml)
+- [kuberay.yaml](../providers/kuberay/deploy/kuberay.yaml)
+- [llmd.yaml](../providers/llmd/deploy/llmd.yaml)
 
 ## Access KubeAIRunway
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -69,16 +69,16 @@ Users create `ModelDeployment` CRs, and the controller + provider controllers ha
 - Provider-agnostic lifecycle management
 
 ### Web UI Deployment
-The Web UI backend reads provider information (capabilities, installation steps, Helm charts) from `InferenceProviderConfig` CRDs in the cluster. It can trigger Helm-based provider installation and creates `ModelDeployment` CRs for model deployment, which are then handled by the controller and provider controllers.
+The Web UI backend reads provider information (capabilities, installation steps, Helm charts) from `InferenceProviderConfig` CRDs in the cluster. These CRDs are created by **provider shims** — each provider shim must be installed (e.g., `kubectl apply -f providers/kaito/deploy/kaito.yaml`) before its provider appears in the UI. Once visible, the UI can trigger Helm-based upstream provider installation and creates `ModelDeployment` CRs for model deployment, which are then handled by the controller and provider controllers.
 
 ### Supported Providers
 
-| Provider      | Upstream CRD          | Status      | Description                                                                    |
-| ------------- | --------------------- | ----------- | ------------------------------------------------------------------------------ |
-| NVIDIA Dynamo | DynamoGraphDeployment | ✅ Available | High-performance GPU inference with KV-cache routing and disaggregated serving |
-| KubeRay       | RayService            | ✅ Available | Ray-based distributed inference with autoscaling                               |
-| KAITO         | Workspace             | ✅ Available | Flexible inference with vLLM (GPU) or llama.cpp (CPU/GPU)                      |
-| llm-d         | none                  | ✅ Available | Flexible inference with vLLM (GPU) with KV-cache routing and disaggregated serving |
+| Provider      | Upstream CRD          | Status      | Shim YAML | Description                                                                    |
+| ------------- | --------------------- | ----------- | --------- | ------------------------------------------------------------------------------ |
+| NVIDIA Dynamo | DynamoGraphDeployment | ✅ Available | [dynamo.yaml](../providers/dynamo/deploy/dynamo.yaml) | High-performance GPU inference with KV-cache routing and disaggregated serving |
+| KubeRay       | RayService            | ✅ Available | [kuberay.yaml](../providers/kuberay/deploy/kuberay.yaml) | Ray-based distributed inference with autoscaling                               |
+| KAITO         | Workspace             | ✅ Available | [kaito.yaml](../providers/kaito/deploy/kaito.yaml) | Flexible inference with vLLM (GPU) or llama.cpp (CPU/GPU)                      |
+| llm-d         | none                  | ✅ Available | [llmd.yaml](../providers/llmd/deploy/llmd.yaml) | Flexible inference with vLLM (GPU) with KV-cache routing and disaggregated serving |
 
 ### KAITO Provider
 


### PR DESCRIPTION
## Summary

The Getting Started and deployment docs implied users could see providers immediately after installing the controller. In reality, provider shims must be installed first to register `InferenceProviderConfig` CRDs, which make providers visible in the UI.

## Changes

- **README.md**: Added provider shim installation as step 1 in Getting Started; added "Shim YAML" column to Supported Providers table
- **deploy/README.md**: Added shim installation as step 2 in Quick Start with generic placeholder URL and list of all available shims
- **docs/providers.md**: Clarified Web UI Deployment section to explain shim requirement; added "Shim YAML" column to Supported Providers table