### PR TITLE
ci(model-downloader): add Docker image build and release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,3 +197,47 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  model-downloader-docker:
+    name: Build and Push Model Downloader Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/kaito-project/kubeairunway/model-downloader
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ !contains(github.ref, '-rc') && !contains(github.ref, '-beta') && !contains(github.ref, '-alpha') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: images/model-downloader
+          file: images/model-downloader/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 .PHONY: install dev dev-frontend dev-backend build compile lint test clean help
 .PHONY: controller-build controller-docker-build controller-install controller-deploy controller-generate generate-deploy-manifests
+.PHONY: model-downloader-docker-build
 
 # Controller image
 CONTROLLER_IMG ?= ghcr.io/kaito-project/kubeairunway/controller:latest
 
 # Dashboard image
 DASHBOARD_IMG ?= ghcr.io/kaito-project/kubeairunway/dashboard:latest
+
+# Model downloader image
+MODEL_DOWNLOADER_IMG ?= ghcr.io/kaito-project/kubeairunway/model-downloader:latest
 
 # Gateway API Inference Extension version
 GAIE_VERSION ?= v1.3.1
@@ -34,6 +38,7 @@ help:
 	@echo "Controller Targets:"
 	@echo "  controller-build       Build the Go controller binary"
 	@echo "  controller-docker-build Build controller Docker image"
+	@echo "  model-downloader-docker-build Build model downloader Docker image"
 	@echo "  controller-install     Install CRDs into cluster"
 	@echo "  controller-deploy      Deploy controller to cluster"
 	@echo "  controller-generate    Generate CRD manifests and code"
@@ -160,3 +165,10 @@ generate-deploy-manifests:
 	controller/bin/kustomize build backend/config/default > deploy/dashboard.yaml
 	@git checkout backend/config/manager/kustomization.yaml 2>/dev/null || true
 	@echo "✅ Generated deploy/dashboard.yaml"
+
+# ==================== Model Downloader Targets ====================
+
+# Build model downloader Docker image
+model-downloader-docker-build:
+	docker build -f images/model-downloader/Dockerfile -t $(MODEL_DOWNLOADER_IMG) images/model-downloader
+	@echo "✅ Model downloader image built: $(MODEL_DOWNLOADER_IMG)"

--- a/images/model-downloader/Dockerfile
+++ b/images/model-downloader/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.14-slim
+
+RUN pip install --no-cache-dir huggingface_hub==1.6.0 && \
+    hf version
+
+ENTRYPOINT ["hf"]


### PR DESCRIPTION
## Description

Add a new job to the release workflow to build and push the model-downloader Docker image to GHCR. Also add a local Makefile target for building the image and introduce the Dockerfile based on `python:3.14-slim` with `huggingface_hub`.

This is a pre-requisite for adding PVC support to ModelDeployment.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Changes Made

- `images/model-downloader/Dockerfile`: New Dockerfile based on `python:3.10-slim` that installs `huggingface_hub` and `hf_transfer` packages
- `Makefile`: Added `model-downloader-docker-build` target for local image builds and `MODEL_DOWNLOADER_IMG` variable
- `.github/workflows/release.yml`: Added `model-downloader-docker` job for multi-arch (linux/amd64, linux/arm64) release builds, pushing to
`ghcr.io/kaito-project/kubeairunway/model-downloader`

## Testing

- Manual testing performed
  - Built image locally with `make model-downloader-docker-build`

```bash
TAG=$(git describe --tags --always)-$(date +%Y-%m-%d-%H-%M-%S)
export MODEL_DOWNLOADER_IMG="quay.io/surajd/kubeairunway-model-downloader:${TAG}"
make model-downloader-docker-build
docker run -it $MODEL_DOWNLOADER_IMG download Qwen/Qwen3-0.6B
```