### PR TITLE
fix(controller): increase model download job resources

### DIFF
--- a/controller/pkg/storage/download.go
+++ b/controller/pkg/storage/download.go
@@ -40,14 +40,15 @@ const (
 	downloadJobSuffix = "-model-download"
 
 	// defaultBackoffLimit is the number of retries for the download Job
-	defaultBackoffLimit int32 = 3
+	defaultBackoffLimit int32 = 6
 
 	// Resource defaults for the download Job container.
-	// The download job uses hf_xet (chunk-based Xet storage) for fast downloads,
-	// so its resource needs are predictable and I/O-bound rather than CPU/memory-bound.
-	defaultDownloadJobCPURequest    = "100m"
-	defaultDownloadJobMemoryRequest = "512Mi"
-	defaultDownloadJobMemoryLimit   = "1Gi"
+	// The download job uses hf_xet (chunk-based Xet storage) for fast downloads.
+	// Memory needs scale with model size — large models (70B+) with many shards
+	// can require several GiB for concurrent chunk assembly and hash verification.
+	defaultDownloadJobCPURequest    = "500m"
+	defaultDownloadJobMemoryRequest = "2Gi"
+	defaultDownloadJobMemoryLimit   = "8Gi"
 )
 
 // NeedsDownloadJob returns true when a model download Job should be created:

--- a/controller/pkg/storage/download_test.go
+++ b/controller/pkg/storage/download_test.go
@@ -141,6 +141,13 @@ func TestEnsureDownloadJobCreation(t *testing.T) {
 	if job.Spec.Template.Spec.Containers[0].Image != DefaultDownloadJobImage {
 		t.Errorf("expected image %s, got %s", DefaultDownloadJobImage, job.Spec.Template.Spec.Containers[0].Image)
 	}
+	expectedBackoffLimit := int32(6)
+	if job.Spec.BackoffLimit == nil {
+		t.Fatal("expected backoff limit to be set")
+	}
+	if *job.Spec.BackoffLimit != expectedBackoffLimit {
+		t.Errorf("expected backoff limit %d, got %d", expectedBackoffLimit, *job.Spec.BackoffLimit)
+	}
 
 	// Verify args use exec form (not shell) to prevent injection.
 	// The container image has ENTRYPOINT ["hf"], so Args appends to it.
@@ -184,21 +191,21 @@ func TestEnsureDownloadJobCreation(t *testing.T) {
 	}
 
 	// Verify resource requests and limits
-	expectedCPURequest := resource.MustParse("100m")
+	expectedCPURequest := resource.MustParse("500m")
 	if cpuReq, ok := container.Resources.Requests[corev1.ResourceCPU]; !ok {
 		t.Error("expected CPU request to be set")
 	} else if !cpuReq.Equal(expectedCPURequest) {
 		t.Errorf("expected CPU request %s, got %s", expectedCPURequest.String(), cpuReq.String())
 	}
 
-	expectedMemoryRequest := resource.MustParse("512Mi")
+	expectedMemoryRequest := resource.MustParse("2Gi")
 	if memReq, ok := container.Resources.Requests[corev1.ResourceMemory]; !ok {
 		t.Error("expected memory request to be set")
 	} else if !memReq.Equal(expectedMemoryRequest) {
 		t.Errorf("expected memory request %s, got %s", expectedMemoryRequest.String(), memReq.String())
 	}
 
-	expectedMemoryLimit := resource.MustParse("1Gi")
+	expectedMemoryLimit := resource.MustParse("8Gi")
 	if memLim, ok := container.Resources.Limits[corev1.ResourceMemory]; !ok {
 		t.Error("expected memory limit to be set")
 	} else if !memLim.Equal(expectedMemoryLimit) {


### PR DESCRIPTION
## Description

Increase the default model download Job retry budget and resource requests so large HuggingFace downloads have more room to complete successfully.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
create a new branch and create pr for unstaged chaneges
```

**AI Tool:** OpenAI Codex

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

None.

## Changes Made

- Increase the default download Job backoff limit from `3` to `6`.
- Increase default download Job resources to `500m` CPU, `2Gi` memory request, and `8Gi` memory limit.
- Update the download Job unit test to verify the new retry and resource defaults.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [ ] Manual testing performed
- [ ] Tested with a Kubernetes cluster

Validated controller changes with:
- `go build ./...`
- `go test ./...`

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

N/A.

## Additional Notes

- This PR intentionally excludes local `.claude/` workspace files.
