### PR TITLE
fix(dynamo): set vLLM side channel host from pod IP

### DIFF
--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -49,6 +49,10 @@ const (
 	// Sub-component types for disaggregated mode
 	SubComponentTypePrefill = "prefill"
 	SubComponentTypeDecode  = "decode"
+
+	// vLLM connector modes used by Dynamo.
+	VLLMConnectorNIXL = "nixl"
+	VLLMConnectorNone = "none"
 )
 
 // DynamoOverrides contains Dynamo-specific override configuration
@@ -511,6 +515,15 @@ func (t *Transformer) buildEngineArgs(md *airunwayv1alpha1.ModelDeployment) ([]s
 		}
 	}
 
+	// Aggregated vLLM deployments do not need a KV transfer connector, so make the
+	// default explicit instead of inheriting Dynamo's runtime default.
+	if md.ResolvedEngineType() == airunwayv1alpha1.EngineTypeVLLM {
+		if _, hasConnectorOverride := md.Spec.Engine.Args["connector"]; !hasConnectorOverride &&
+			t.resolvedServingMode(md) == airunwayv1alpha1.ServingModeAggregated {
+			args = append(args, "--connector", VLLMConnectorNone)
+		}
+	}
+
 	// Add custom engine args with key validation (sorted for deterministic output)
 	keys := make([]string, 0, len(md.Spec.Engine.Args))
 	for k := range md.Spec.Engine.Args {
@@ -530,6 +543,29 @@ func (t *Transformer) buildEngineArgs(md *airunwayv1alpha1.ModelDeployment) ([]s
 	}
 
 	return args, nil
+}
+
+func (t *Transformer) resolvedServingMode(md *airunwayv1alpha1.ModelDeployment) airunwayv1alpha1.ServingMode {
+	if md.Spec.Serving != nil && md.Spec.Serving.Mode != "" {
+		return md.Spec.Serving.Mode
+	}
+	return airunwayv1alpha1.ServingModeAggregated
+}
+
+func (t *Transformer) effectiveVLLMConnector(md *airunwayv1alpha1.ModelDeployment) string {
+	if md.ResolvedEngineType() != airunwayv1alpha1.EngineTypeVLLM {
+		return ""
+	}
+
+	if connector, hasConnectorOverride := md.Spec.Engine.Args["connector"]; hasConnectorOverride {
+		return connector
+	}
+
+	if t.resolvedServingMode(md) == airunwayv1alpha1.ServingModeAggregated {
+		return VLLMConnectorNone
+	}
+
+	return VLLMConnectorNIXL
 }
 
 // engineCommand returns the command slice for the given engine type
@@ -672,9 +708,9 @@ func hasEnvVar(md *airunwayv1alpha1.ModelDeployment, name string) bool {
 	return false
 }
 
-// maybeInjectVLLMSideChannelHost ensures each vLLM worker advertises its own pod IP.
+// maybeInjectVLLMSideChannelHost ensures each NIXL-backed vLLM worker advertises its own pod IP.
 func (t *Transformer) maybeInjectVLLMSideChannelHost(service map[string]interface{}, md *airunwayv1alpha1.ModelDeployment) {
-	if md.ResolvedEngineType() != airunwayv1alpha1.EngineTypeVLLM {
+	if !strings.EqualFold(t.effectiveVLLMConnector(md), VLLMConnectorNIXL) {
 		return
 	}
 

--- a/providers/dynamo/transformer_test.go
+++ b/providers/dynamo/transformer_test.go
@@ -236,7 +236,7 @@ func TestBuildEngineArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := []string{"--model", "meta-llama/Llama-2-7b-chat-hf"}
+	expected := []string{"--model", "meta-llama/Llama-2-7b-chat-hf", "--connector", VLLMConnectorNone}
 	if !sliceEqual(args, expected) {
 		t.Errorf("unexpected args: %v, expected %v", args, expected)
 	}
@@ -260,7 +260,7 @@ func TestBuildEngineArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected = []string{"--model", "meta-llama/Llama-2-7b-chat-hf", "--max-model-len", "4096"}
+	expected = []string{"--model", "meta-llama/Llama-2-7b-chat-hf", "--max-model-len", "4096", "--connector", VLLMConnectorNone}
 	if !sliceEqual(args, expected) {
 		t.Errorf("unexpected args: %v, expected %v", args, expected)
 	}
@@ -711,6 +711,58 @@ func TestBuildEngineArgsWithCustomArgs(t *testing.T) {
 	}
 }
 
+func TestBuildEngineArgsDefaultsAggregatedVLLMConnectorToNone(t *testing.T) {
+	tr := NewTransformer()
+	md := newTestMD("test", "default")
+
+	args, err := tr.buildEngineArgs(md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertArg(t, args, "--connector", VLLMConnectorNone)
+}
+
+func TestBuildEngineArgsPreservesExplicitConnectorOverride(t *testing.T) {
+	tr := NewTransformer()
+	md := newTestMD("test", "default")
+	md.Spec.Engine.Args = map[string]string{
+		"connector": VLLMConnectorNIXL,
+	}
+
+	args, err := tr.buildEngineArgs(md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertArg(t, args, "--connector", VLLMConnectorNIXL)
+
+	connectorFlags := 0
+	for _, arg := range args {
+		if arg == "--connector" {
+			connectorFlags++
+		}
+	}
+	if connectorFlags != 1 {
+		t.Fatalf("expected exactly one --connector flag, got %d in %v", connectorFlags, args)
+	}
+}
+
+func TestBuildEngineArgsDisaggregatedLeavesConnectorToRuntimeDefault(t *testing.T) {
+	tr := NewTransformer()
+	md := newTestMD("test", "default")
+	md.Spec.Serving = &airunwayv1alpha1.ServingSpec{
+		Mode: airunwayv1alpha1.ServingModeDisaggregated,
+	}
+
+	args, err := tr.buildEngineArgs(md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertNoArg(t, args, "--connector")
+}
+
 func TestBuildEngineArgsDeterministicOrder(t *testing.T) {
 	tr := NewTransformer()
 	md := newTestMD("test", "default")
@@ -1101,9 +1153,31 @@ func TestTransformWithCustomImage(t *testing.T) {
 	}
 }
 
-func TestTransformVLLMWorkersInjectNixlSideChannelHost(t *testing.T) {
+func TestTransformAggregatedVLLMWorkersDoNotInjectNixlSideChannelHostByDefault(t *testing.T) {
 	tr := NewTransformer()
 	md := newTestMD("test-model", "default")
+
+	resources, err := tr.Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dgd := resources[0]
+	spec, _, _ := unstructured.NestedMap(dgd.Object, "spec")
+	services, _ := spec["services"].(map[string]interface{})
+	worker, _ := services["VllmWorker"].(map[string]interface{})
+
+	if env := findEnvVar(worker, "VLLM_NIXL_SIDE_CHANNEL_HOST"); env != nil {
+		t.Fatalf("did not expect VLLM_NIXL_SIDE_CHANNEL_HOST for aggregated vLLM worker, got %v", env)
+	}
+}
+
+func TestTransformAggregatedVLLMWorkersInjectNixlSideChannelHostWhenConnectorIsNixl(t *testing.T) {
+	tr := NewTransformer()
+	md := newTestMD("test-model", "default")
+	md.Spec.Engine.Args = map[string]string{
+		"connector": VLLMConnectorNIXL,
+	}
 
 	resources, err := tr.Transform(context.Background(), md)
 	if err != nil {
@@ -1628,5 +1702,30 @@ func assertFieldRefEnvVar(t *testing.T, service map[string]interface{}, name, fi
 	fieldRef, _ := valueFrom["fieldRef"].(map[string]interface{})
 	if fieldRef["fieldPath"] != fieldPath {
 		t.Fatalf("expected %s fieldPath %q, got %v", name, fieldPath, fieldRef["fieldPath"])
+	}
+}
+
+func assertArg(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			if args[i+1] != value {
+				t.Fatalf("expected %s value %q, got %q in %v", flag, value, args[i+1], args)
+			}
+			return
+		}
+	}
+
+	t.Fatalf("expected %s %q in args: %v", flag, value, args)
+}
+
+func assertNoArg(t *testing.T, args []string, flag string) {
+	t.Helper()
+
+	for _, arg := range args {
+		if arg == flag {
+			t.Fatalf("did not expect %s in args: %v", flag, args)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- default aggregated Dynamo vLLM deployments to `--connector none` unless the user explicitly overrides the connector
- only inject `VLLM_NIXL_SIDE_CHANNEL_HOST` when the effective vLLM connector is `nixl`
- add coverage for aggregated default behavior, explicit connector overrides, and disaggregated behavior

## Why
Aggregated vLLM deployments do not need KV transfer between workers, so inheriting Dynamo's runtime connector default can enable NIXL side-channel setup unnecessarily. Making the aggregated default explicit avoids that path, while still preserving NIXL for cases that explicitly request it or rely on disaggregated behavior.

This also narrows `VLLM_NIXL_SIDE_CHANNEL_HOST` injection to the deployments that actually use a NIXL-backed connector, instead of setting it on every vLLM worker.

## Validation
- `go build ./...`
- `go test ./...`
