### PR TITLE
build: add optional push and platform flags to image targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ DASHBOARD_IMG ?= ghcr.io/kaito-project/airunway/dashboard:latest
 # Model downloader image
 MODEL_DOWNLOADER_IMG ?= ghcr.io/kaito-project/airunway/model-downloader:latest
 
+# Image build settings
+PLATFORM ?= linux/amd64
+PUSH ?= false
+PUSH_ENABLED := $(filter true TRUE 1 yes YES on ON,$(PUSH))
+IMAGE_OUTPUT_FLAG := $(if $(PUSH_ENABLED),--push,--load)
+
 # Gateway API Inference Extension version
 GAIE_VERSION ?= v1.3.1
 
@@ -43,6 +49,10 @@ help:
 	@echo "  controller-deploy      Deploy controller to cluster"
 	@echo "  controller-generate    Generate CRD manifests and code"
 	@echo "  generate-deploy-manifests  Generate deploy/controller.yaml"
+	@echo ""
+	@echo "Image Build Variables:"
+	@echo "  PLATFORM=<platform>    Target platform for image builds (default: linux/amd64)"
+	@echo "  PUSH=true              Push image instead of loading it locally (default: false)"
 	@echo ""
 	@echo "  help                   Show this help message"
 
@@ -118,8 +128,8 @@ controller-build:
 
 # Build controller Docker image
 controller-docker-build:
-	docker build -f controller/Dockerfile -t $(CONTROLLER_IMG) .
-	@echo "✅ Controller image built: $(CONTROLLER_IMG)"
+	docker buildx build --platform $(PLATFORM) $(IMAGE_OUTPUT_FLAG) -f controller/Dockerfile -t $(CONTROLLER_IMG) .
+	@echo "✅ Controller image built: $(CONTROLLER_IMG) ($(PLATFORM), $(if $(PUSH_ENABLED),pushed,loaded locally))"
 
 # Generate CRD manifests and deep copy code
 controller-generate:
@@ -170,5 +180,5 @@ generate-deploy-manifests:
 
 # Build model downloader Docker image
 model-downloader-docker-build:
-	docker build -f images/model-downloader/Dockerfile -t $(MODEL_DOWNLOADER_IMG) images/model-downloader
-	@echo "✅ Model downloader image built: $(MODEL_DOWNLOADER_IMG)"
+	docker buildx build --platform $(PLATFORM) $(IMAGE_OUTPUT_FLAG) -f images/model-downloader/Dockerfile -t $(MODEL_DOWNLOADER_IMG) images/model-downloader
+	@echo "✅ Model downloader image built: $(MODEL_DOWNLOADER_IMG) ($(PLATFORM), $(if $(PUSH_ENABLED),pushed,loaded locally))"

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,6 +43,11 @@ make controller-generate
 # Build the docker container image
 make controller-docker-build CONTROLLER_IMG=<YOUR IMAGE>
 
+# Defaults: PUSH=false and PLATFORM=linux/amd64
+
+# Optional: push instead of load, or target a different platform
+make controller-docker-build CONTROLLER_IMG=<YOUR IMAGE> PUSH=true PLATFORM=linux/amd64,linux/arm64
+
 # Install CRDs into the cluster
 make controller-install
 
@@ -238,6 +243,11 @@ cd providers/llmd && make build
 # Build provider Docker image
 cd providers/kaito && make docker-build IMG=<YOUR IMAGE>
 cd providers/llmd && make docker-build IMG=<YOUR IMAGE>
+
+# Defaults: PUSH=false and PLATFORM=linux/amd64
+
+# Optional: push instead of load, or target a different platform
+cd providers/llmd && make docker-build IMG=<YOUR IMAGE> PUSH=true PLATFORM=linux/amd64,linux/arm64
 
 # Deploy provider to cluster
 cd providers/kaito && make deploy IMG=<YOUR IMAGE>

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -1,5 +1,9 @@
 KUSTOMIZE ?= ../../controller/bin/kustomize
 IMG ?= ghcr.io/kaito-project/airunway/dynamo-provider:latest
+PLATFORM ?= linux/amd64
+PUSH ?= false
+PUSH_ENABLED := $(filter true TRUE 1 yes YES on ON,$(PUSH))
+IMAGE_OUTPUT_FLAG := $(if $(PUSH_ENABLED),--push,--load)
 
 .PHONY: build docker-build deploy generate-deploy-manifests test-e2e
 
@@ -10,8 +14,8 @@ build:
 
 ## Build provider Docker image
 docker-build:
-	docker build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t $(IMG) ../..
-	@echo "✅ Dynamo provider image built: $(IMG)"
+	docker buildx build --platform $(PLATFORM) $(IMAGE_OUTPUT_FLAG) -f Dockerfile -t $(IMG) ../..
+	@echo "✅ Dynamo provider image built: $(IMG) ($(PLATFORM), $(if $(PUSH_ENABLED),pushed,loaded locally))"
 
 ## Deploy provider to the K8s cluster
 deploy:

--- a/providers/kaito/Makefile
+++ b/providers/kaito/Makefile
@@ -1,5 +1,9 @@
 KUSTOMIZE ?= ../../controller/bin/kustomize
 IMG ?= ghcr.io/kaito-project/airunway/kaito-provider:latest
+PLATFORM ?= linux/amd64
+PUSH ?= false
+PUSH_ENABLED := $(filter true TRUE 1 yes YES on ON,$(PUSH))
+IMAGE_OUTPUT_FLAG := $(if $(PUSH_ENABLED),--push,--load)
 
 .PHONY: build docker-build deploy generate-deploy-manifests
 
@@ -10,8 +14,8 @@ build:
 
 ## Build provider Docker image
 docker-build:
-	docker build -f Dockerfile -t $(IMG) ../..
-	@echo "✅ KAITO provider image built: $(IMG)"
+	docker buildx build --platform $(PLATFORM) $(IMAGE_OUTPUT_FLAG) -f Dockerfile -t $(IMG) ../..
+	@echo "✅ KAITO provider image built: $(IMG) ($(PLATFORM), $(if $(PUSH_ENABLED),pushed,loaded locally))"
 
 ## Deploy provider to the K8s cluster
 deploy:

--- a/providers/kuberay/Makefile
+++ b/providers/kuberay/Makefile
@@ -1,5 +1,9 @@
 KUSTOMIZE ?= ../../controller/bin/kustomize
 IMG ?= ghcr.io/kaito-project/airunway/kuberay-provider:latest
+PLATFORM ?= linux/amd64
+PUSH ?= false
+PUSH_ENABLED := $(filter true TRUE 1 yes YES on ON,$(PUSH))
+IMAGE_OUTPUT_FLAG := $(if $(PUSH_ENABLED),--push,--load)
 
 .PHONY: build docker-build deploy generate-deploy-manifests
 
@@ -10,8 +14,8 @@ build:
 
 ## Build provider Docker image
 docker-build:
-	docker build -f Dockerfile -t $(IMG) ../..
-	@echo "✅ KubeRay provider image built: $(IMG)"
+	docker buildx build --platform $(PLATFORM) $(IMAGE_OUTPUT_FLAG) -f Dockerfile -t $(IMG) ../..
+	@echo "✅ KubeRay provider image built: $(IMG) ($(PLATFORM), $(if $(PUSH_ENABLED),pushed,loaded locally))"
 
 ## Deploy provider to the K8s cluster
 deploy:

--- a/providers/llmd/Makefile
+++ b/providers/llmd/Makefile
@@ -1,5 +1,9 @@
 KUSTOMIZE ?= ../../controller/bin/kustomize
 IMG ?= ghcr.io/kaito-project/airunway/llmd-provider:latest
+PLATFORM ?= linux/amd64
+PUSH ?= false
+PUSH_ENABLED := $(filter true TRUE 1 yes YES on ON,$(PUSH))
+IMAGE_OUTPUT_FLAG := $(if $(PUSH_ENABLED),--push,--load)
 
 .PHONY: build docker-build deploy generate-deploy-manifests
 
@@ -10,8 +14,8 @@ build:
 
 ## Build provider Docker image
 docker-build:
-	docker build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t $(IMG) ../..
-	@echo "✅ llm-d provider image built: $(IMG)"
+	docker buildx build --platform $(PLATFORM) $(IMAGE_OUTPUT_FLAG) -f Dockerfile -t $(IMG) ../..
+	@echo "✅ llm-d provider image built: $(IMG) ($(PLATFORM), $(if $(PUSH_ENABLED),pushed,loaded locally))"
 
 ## Deploy provider to the K8s cluster
 deploy:


### PR DESCRIPTION
## Summary
- add `PUSH` and `PLATFORM` variables to the root image build targets with defaults of `false` and `linux/amd64`
- switch image builds to `docker buildx build`, using `--load` by default and `--push` when requested
- align provider image Makefiles and development docs with the same optional push/platform behavior

## Testing
- `make -n controller-docker-build`
- `make -n controller-docker-build PUSH=true PLATFORM=linux/amd64,linux/arm64`
- `make -n model-downloader-docker-build`
- `cd providers/kaito && make -n docker-build`
- `cd providers/dynamo && make -n docker-build PUSH=true PLATFORM=linux/amd64,linux/arm64`
- `cd providers/llmd && make -n docker-build`