### PR TITLE
fix(ui): use full cluster GPU capacity in fit badges

### DIFF
--- a/frontend/src/components/models/GpuFitIndicator.test.tsx
+++ b/frontend/src/components/models/GpuFitIndicator.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GpuFitIndicator } from './GpuFitIndicator';
+
+describe('GpuFitIndicator', () => {
+  it('renders the full cluster topology label when provided', () => {
+    render(
+      <GpuFitIndicator
+        estimatedGpuMemoryGb={906}
+        clusterCapacityGb={80}
+        gpuCount={16}
+        capacityLabel="2x8x80 GB"
+      />
+    );
+
+    expect(screen.getByText('906.0 / 1280 GB (2x8x80 GB)')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/models/GpuFitIndicator.tsx
+++ b/frontend/src/components/models/GpuFitIndicator.tsx
@@ -15,8 +15,10 @@ export type GpuFitLevel = 'perfect' | 'good' | 'marginal' | 'too-large' | 'unkno
 interface GpuFitIndicatorProps {
   estimatedGpuMemoryGb?: number;
   clusterCapacityGb?: number;
-  /** Number of GPUs available — capacity is multiplied by this (default 1) */
+  /** Number of GPUs contributing to the displayed cluster capacity */
   gpuCount?: number;
+  /** Optional user-facing topology label such as 2x8x80 GB */
+  capacityLabel?: string;
   /** Whether this is a CPU (RAM) or GPU (VRAM) fit indicator */
   mode?: 'gpu' | 'cpu';
   className?: string;
@@ -134,17 +136,14 @@ export function GpuFitIndicator({
   estimatedGpuMemoryGb,
   clusterCapacityGb,
   gpuCount = 1,
+  capacityLabel,
   mode = 'gpu',
   className
 }: GpuFitIndicatorProps) {
   const memLabel = mode === 'cpu' ? 'RAM' : 'VRAM';
-  // Multiply per-GPU capacity by the number of available GPUs.
-  // When gpuCount is 0 (fully allocated cluster), effective capacity is 0 → "Won't fit".
+  // Multiply per-GPU capacity by the number of GPUs represented in the badge.
   const effectiveCapacityGb = clusterCapacityGb !== undefined ? clusterCapacityGb * gpuCount : undefined;
-  // A cluster with known per-GPU capacity but 0 available GPUs is "too-large", not "unknown"
-  const noAvailableGpus = clusterCapacityGb !== undefined && clusterCapacityGb > 0 && gpuCount === 0;
-
-  const level = noAvailableGpus ? 'too-large' as GpuFitLevel : getGpuFitLevel(estimatedGpuMemoryGb, effectiveCapacityGb);
+  const level = getGpuFitLevel(estimatedGpuMemoryGb, effectiveCapacityGb);
   const config = fitConfig[level];
   const Icon = config.icon;
   const upgradeDelta = getUpgradeDelta(estimatedGpuMemoryGb, effectiveCapacityGb);
@@ -176,7 +175,7 @@ export function GpuFitIndicator({
               </span>
               {estimatedGpuMemoryGb !== undefined && effectiveCapacityGb !== undefined && (
                 <span className="text-xs text-slate-400 tabular-nums">
-                  {estimatedGpuMemoryGb.toFixed(1)} / {effectiveCapacityGb} GB{gpuCount > 1 ? ` (${gpuCount}×${clusterCapacityGb} GB)` : ''}
+                  {estimatedGpuMemoryGb.toFixed(1)} / {effectiveCapacityGb} GB{capacityLabel ? ` (${capacityLabel})` : gpuCount > 1 ? ` (${gpuCount}x${clusterCapacityGb} GB)` : ''}
                 </span>
               )}
             </div>

--- a/frontend/src/components/models/HfModelCard.tsx
+++ b/frontend/src/components/models/HfModelCard.tsx
@@ -10,6 +10,7 @@ interface HfModelCardProps {
   model: HfModelSearchResult;
   gpuCapacityGb?: number;
   gpuCount?: number;
+  gpuCapacityLabel?: string;
 }
 
 /**
@@ -25,7 +26,7 @@ function formatCount(count: number): string {
   return count.toString();
 }
 
-export function HfModelCard({ model, gpuCapacityGb, gpuCount }: HfModelCardProps) {
+export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: HfModelCardProps) {
   const navigate = useNavigate();
 
   const handleDeploy = () => {
@@ -78,6 +79,7 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount }: HfModelCardProps
             estimatedGpuMemoryGb={model.estimatedGpuMemoryGb}
             clusterCapacityGb={gpuCapacityGb}
             gpuCount={gpuCount}
+            capacityLabel={gpuCapacityLabel}
           />
         </div>
 

--- a/frontend/src/components/models/HfModelSearch.tsx
+++ b/frontend/src/components/models/HfModelSearch.tsx
@@ -7,14 +7,16 @@ import { useDebounce } from '@/hooks/useDebounce';
 import { useGpuCapacity } from '@/hooks/useGpuOperator';
 import { Search, Loader2, AlertCircle, LogIn } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { getGpuFitCapacityDisplay } from '@/lib/gpu-fit-capacity';
 
 interface HfModelSearchProps {
   onLoginClick?: () => void;
   gpuCapacityGb?: number;
   gpuCount?: number;
+  gpuCapacityLabel?: string;
 }
 
-export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount }: HfModelSearchProps) {
+export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapacityLabel }: HfModelSearchProps) {
   const [query, setQuery] = useState('');
   const [offset, setOffset] = useState(0);
   const limit = 20;
@@ -28,10 +30,12 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount }: HfModel
 
   const { data: hfStatus, isLoading: hfStatusLoading } = useHuggingFaceStatus();
   const { data: gpuCapacity } = useGpuCapacity();
+  const defaultFitCapacity = getGpuFitCapacityDisplay(gpuCapacity);
 
   // Use provided GPU capacity or estimate from cluster
   const maxGpuMemoryGb = gpuCapacityGb ?? gpuCapacity?.totalMemoryGb;
-  const effectiveGpuCount = gpuCount ?? gpuCapacity?.maxContiguousAvailable;
+  const effectiveGpuCount = gpuCount ?? defaultFitCapacity.gpuCount;
+  const effectiveCapacityLabel = gpuCapacityLabel ?? defaultFitCapacity.capacityLabel;
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
@@ -131,6 +135,7 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount }: HfModel
                 model={model}
                 gpuCapacityGb={maxGpuMemoryGb}
                 gpuCount={effectiveGpuCount}
+                gpuCapacityLabel={effectiveCapacityLabel}
               />
             ))}
           </div>

--- a/frontend/src/components/models/ModelCard.tsx
+++ b/frontend/src/components/models/ModelCard.tsx
@@ -10,6 +10,7 @@ interface ModelCardProps {
   model: Model
   gpuCapacityGb?: number
   gpuCount?: number
+  gpuCapacityLabel?: string
 }
 
 /**
@@ -53,7 +54,7 @@ function estimateGgufRamGb(sizeStr?: string): number | undefined {
   return Math.ceil(billions * 0.6 + 2)
 }
 
-export function ModelCard({ model, gpuCapacityGb, gpuCount }: ModelCardProps) {
+export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: ModelCardProps) {
   const navigate = useNavigate()
 
   const handleDeploy = () => {
@@ -102,6 +103,7 @@ export function ModelCard({ model, gpuCapacityGb, gpuCount }: ModelCardProps) {
                 estimatedGpuMemoryGb={estimatedGpuMemoryGb}
                 clusterCapacityGb={gpuCapacityGb}
                 gpuCount={gpuCount}
+                capacityLabel={gpuCapacityLabel}
               />
             ) : (
               <span className="truncate">GPU: {model.minGpuMemory || 'N/A'}</span>

--- a/frontend/src/components/models/ModelGrid.tsx
+++ b/frontend/src/components/models/ModelGrid.tsx
@@ -7,9 +7,10 @@ interface ModelGridProps {
   models: Model[]
   gpuCapacityGb?: number
   gpuCount?: number
+  gpuCapacityLabel?: string
 }
 
-export function ModelGrid({ models, gpuCapacityGb, gpuCount }: ModelGridProps) {
+export function ModelGrid({ models, gpuCapacityGb, gpuCount, gpuCapacityLabel }: ModelGridProps) {
   const navigate = useNavigate()
 
   if (models.length === 0) {
@@ -36,7 +37,12 @@ export function ModelGrid({ models, gpuCapacityGb, gpuCount }: ModelGridProps) {
           className="animate-slide-up"
           style={{ animationDelay: `${Math.min(index, 12) * 50}ms`, animationFillMode: 'both' }}
         >
-          <ModelCard model={model} gpuCapacityGb={gpuCapacityGb} gpuCount={gpuCount} />
+          <ModelCard
+            model={model}
+            gpuCapacityGb={gpuCapacityGb}
+            gpuCount={gpuCount}
+            gpuCapacityLabel={gpuCapacityLabel}
+          />
         </div>
       ))}
     </div>

--- a/frontend/src/lib/gpu-fit-capacity.test.ts
+++ b/frontend/src/lib/gpu-fit-capacity.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { ClusterGpuCapacity, DetailedClusterCapacity } from '@/lib/api';
+import { getGpuFitCapacityDisplay } from './gpu-fit-capacity';
+
+function createClusterGpuCapacity(
+  overrides: Partial<ClusterGpuCapacity> = {}
+): ClusterGpuCapacity {
+  return {
+    totalGpus: 16,
+    allocatedGpus: 0,
+    availableGpus: 16,
+    maxContiguousAvailable: 8,
+    totalMemoryGb: 80,
+    nodes: [
+      {
+        nodeName: 'gpu-node-1',
+        totalGpus: 8,
+        allocatedGpus: 0,
+        availableGpus: 8,
+      },
+      {
+        nodeName: 'gpu-node-2',
+        totalGpus: 8,
+        allocatedGpus: 0,
+        availableGpus: 8,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function createDetailedClusterCapacity(
+  overrides: Partial<DetailedClusterCapacity> = {}
+): DetailedClusterCapacity {
+  return {
+    totalGpus: 16,
+    allocatedGpus: 0,
+    availableGpus: 16,
+    maxContiguousAvailable: 8,
+    maxNodeGpuCapacity: 8,
+    gpuNodeCount: 2,
+    totalMemoryGb: 80,
+    nodePools: [
+      {
+        name: 'gpu',
+        gpuCount: 16,
+        nodeCount: 2,
+        availableGpus: 16,
+        gpuModel: 'NVIDIA-H100-80GB',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('getGpuFitCapacityDisplay', () => {
+  it('uses total cluster GPUs for fit math and shows homogeneous node topology', () => {
+    const result = getGpuFitCapacityDisplay(createClusterGpuCapacity());
+
+    expect(result.gpuCount).toBe(16);
+    expect(result.capacityLabel).toBe('2x8x80 GB');
+  });
+
+  it('derives the same topology label from detailed node-pool data', () => {
+    const result = getGpuFitCapacityDisplay(createDetailedClusterCapacity());
+
+    expect(result.gpuCount).toBe(16);
+    expect(result.capacityLabel).toBe('2x8x80 GB');
+  });
+
+  it('falls back to a cluster-wide label for mixed node sizes', () => {
+    const result = getGpuFitCapacityDisplay(
+      createDetailedClusterCapacity({
+        totalGpus: 12,
+        gpuNodeCount: 2,
+        nodePools: [
+          {
+            name: 'large',
+            gpuCount: 8,
+            nodeCount: 1,
+            availableGpus: 8,
+          },
+          {
+            name: 'small',
+            gpuCount: 4,
+            nodeCount: 1,
+            availableGpus: 4,
+          },
+        ],
+      })
+    );
+
+    expect(result.gpuCount).toBe(12);
+    expect(result.capacityLabel).toBe('12x80 GB across 2 nodes');
+  });
+});

--- a/frontend/src/lib/gpu-fit-capacity.ts
+++ b/frontend/src/lib/gpu-fit-capacity.ts
@@ -1,0 +1,99 @@
+import type { ClusterGpuCapacity, DetailedClusterCapacity } from '@/lib/api';
+
+export interface GpuFitCapacityDisplay {
+  gpuCount?: number;
+  capacityLabel?: string;
+}
+
+type BasicGpuFitCapacity = Pick<ClusterGpuCapacity, 'totalGpus' | 'totalMemoryGb' | 'nodes'>;
+type DetailedGpuFitCapacity = Pick<DetailedClusterCapacity, 'totalGpus' | 'totalMemoryGb' | 'nodePools' | 'gpuNodeCount'>;
+type GpuFitCapacitySource = BasicGpuFitCapacity | DetailedGpuFitCapacity;
+
+export function getGpuFitCapacityDisplay(
+  capacity?: GpuFitCapacitySource
+): GpuFitCapacityDisplay {
+  if (!capacity) {
+    return {};
+  }
+
+  return {
+    gpuCount: capacity.totalGpus,
+    capacityLabel: formatGpuTopologyLabel(capacity),
+  };
+}
+
+function formatGpuTopologyLabel(capacity: GpuFitCapacitySource): string | undefined {
+  const totalMemoryGb = capacity.totalMemoryGb;
+  if (!totalMemoryGb || totalMemoryGb <= 0 || capacity.totalGpus <= 0) {
+    return undefined;
+  }
+
+  if ('nodes' in capacity) {
+    const perNodeGpuCounts = capacity.nodes
+      .map((node) => node.totalGpus)
+      .filter((gpuCount) => gpuCount > 0);
+
+    return formatFromPerNodeCounts(perNodeGpuCounts, capacity.totalGpus, totalMemoryGb);
+  }
+
+  const perNodeGpuCounts = capacity.nodePools.flatMap((pool) => {
+    if (pool.nodeCount <= 0 || pool.gpuCount <= 0 || pool.gpuCount % pool.nodeCount !== 0) {
+      return [];
+    }
+
+    const gpusPerNode = pool.gpuCount / pool.nodeCount;
+    return Array.from({ length: pool.nodeCount }, () => gpusPerNode);
+  });
+
+  if (perNodeGpuCounts.length > 0) {
+    return formatFromPerNodeCounts(perNodeGpuCounts, capacity.totalGpus, totalMemoryGb);
+  }
+
+  return formatFallbackLabel(capacity.totalGpus, capacity.gpuNodeCount, totalMemoryGb);
+}
+
+function formatFromPerNodeCounts(
+  perNodeGpuCounts: number[],
+  totalGpus: number,
+  totalMemoryGb: number
+): string | undefined {
+  if (perNodeGpuCounts.length === 0) {
+    return formatFallbackLabel(totalGpus, undefined, totalMemoryGb);
+  }
+
+  const nodeGroups = new Map<number, number>();
+  for (const gpuCount of perNodeGpuCounts) {
+    nodeGroups.set(gpuCount, (nodeGroups.get(gpuCount) || 0) + 1);
+  }
+
+  if (nodeGroups.size === 1) {
+    const [gpusPerNode, nodeCount] = Array.from(nodeGroups.entries())[0];
+    if (nodeCount > 1) {
+      return `${nodeCount}x${gpusPerNode}x${totalMemoryGb} GB`;
+    }
+
+    if (gpusPerNode > 1) {
+      return `${gpusPerNode}x${totalMemoryGb} GB`;
+    }
+
+    return `${totalMemoryGb} GB`;
+  }
+
+  return formatFallbackLabel(totalGpus, perNodeGpuCounts.length, totalMemoryGb);
+}
+
+function formatFallbackLabel(
+  totalGpus: number,
+  nodeCount: number | undefined,
+  totalMemoryGb: number
+): string {
+  if (nodeCount && nodeCount > 1) {
+    return `${totalGpus}x${totalMemoryGb} GB across ${nodeCount} nodes`;
+  }
+
+  if (totalGpus > 1) {
+    return `${totalGpus}x${totalMemoryGb} GB`;
+  }
+
+  return `${totalMemoryGb} GB`;
+}

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Loader2, ArrowLeft, Cpu, HardDrive, Layers, ExternalLink } from 'lucide-react'
 import { GpuFitIndicator } from '@/components/models/GpuFitIndicator'
+import { getGpuFitCapacityDisplay } from '@/lib/gpu-fit-capacity'
 
 export function DeployPage() {
   const { modelId } = useParams<{ modelId: string }>()
@@ -23,6 +24,7 @@ export function DeployPage() {
   const { data: detailedCapacity } = useDetailedCapacity()
   const { data: autoscaler } = useAutoscalerDetection()
   const { data: runtimesData, isLoading: runtimesLoading } = useRuntimesStatus()
+  const gpuFitCapacity = getGpuFitCapacityDisplay(detailedCapacity)
 
   // Wait for both model and runtimes to load before showing the form
   // This ensures the runtime selector is visible when the form renders
@@ -102,7 +104,8 @@ export function DeployPage() {
                 <GpuFitIndicator
                   estimatedGpuMemoryGb={model.estimatedGpuMemoryGb}
                   clusterCapacityGb={detailedCapacity.totalMemoryGb}
-                  gpuCount={detailedCapacity.maxContiguousAvailable}
+                  gpuCount={gpuFitCapacity.gpuCount}
+                  capacityLabel={gpuFitCapacity.capacityLabel}
                 />
             ) : (
               <span>GPU: {model.estimatedGpuMemory || model.minGpuMemory || 'N/A'}</span>

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -8,6 +8,7 @@ import { SkeletonGrid } from '@/components/ui/skeleton'
 import { BookMarked, Search, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { Engine } from '@airunway/shared'
+import { getGpuFitCapacityDisplay } from '@/lib/gpu-fit-capacity'
 
 type Tab = 'curated' | 'huggingface'
 
@@ -17,9 +18,7 @@ export function ModelsPage() {
   const [search, setSearch] = useState('')
   const [selectedEngines, setSelectedEngines] = useState<Engine[]>([])
   const [activeTab, setActiveTab] = useState<Tab>('curated')
-
-  // Max available GPUs on a single node (accounts for allocated workloads)
-  const maxContiguousAvailable = gpuCapacity?.maxContiguousAvailable
+  const gpuFitCapacity = getGpuFitCapacityDisplay(gpuCapacity)
 
   const filteredModels = useMemo(() => {
     if (!models) return []
@@ -138,13 +137,22 @@ export function ModelsPage() {
             selectedEngines={selectedEngines}
             onEngineToggle={handleEngineToggle}
           />
-          <ModelGrid models={filteredModels} gpuCapacityGb={gpuCapacity?.totalMemoryGb} gpuCount={maxContiguousAvailable} />
+          <ModelGrid
+            models={filteredModels}
+            gpuCapacityGb={gpuCapacity?.totalMemoryGb}
+            gpuCount={gpuFitCapacity.gpuCount}
+            gpuCapacityLabel={gpuFitCapacity.capacityLabel}
+          />
         </>
       )}
 
       {/* HuggingFace search tab */}
       {activeTab === 'huggingface' && (
-        <HfModelSearch gpuCapacityGb={gpuCapacity?.totalMemoryGb} gpuCount={maxContiguousAvailable} />
+        <HfModelSearch
+          gpuCapacityGb={gpuCapacity?.totalMemoryGb}
+          gpuCount={gpuFitCapacity.gpuCount}
+          gpuCapacityLabel={gpuFitCapacity.capacityLabel}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Description

Fix the GPU fit badge math so it uses the full cluster GPU capacity instead of only the largest single-node block. This updates the catalog and deploy summary to show multi-node topology correctly, so a cluster with 2 nodes and 8 GPUs per node now renders as `2x8x80 GB` and computes against 1280 GB total instead of `8x80 GB` / 640 GB.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
[Image]
i think we are doing the math wrong, it should be 2x8x80gb since i have 2 nodes with 8 gpus each
create pr
```

**AI Tool:** OpenAI Codex

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

<!-- None linked -->

## Changes Made

- Added a shared helper that derives total fit capacity and a user-facing topology label from cluster GPU capacity and node-pool data.
- Updated the model catalog, HuggingFace search results, and deploy summary to use full-cluster GPU capacity for fit badges.
- Added regression tests for multi-node topology labeling and the fit badge display string.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [ ] Manual testing performed
- [ ] Tested with a Kubernetes cluster

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

## Additional Notes

- `bun run --filter '@airunway/frontend' test` passed.
- `bun run --filter '@airunway/frontend' build` passed.
- `bun run test` still fails in existing backend timeouts in `backend/src/routes/costs.test.ts` for the three `GET /api/costs/node-pools` cases.
- `bun run --filter '@airunway/frontend' lint` could not run because ESLint did not find a configuration file in this workspace.
