### PR TITLE
Scrub runtime references from frontend tests and mocks

### DIFF
--- a/frontend/src/components/deployments/DeploymentForm.test.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.test.tsx
@@ -89,8 +89,8 @@ function createCapacity(overrides: Partial<DetailedClusterCapacity> = {}): Detai
 
 function createRuntime(overrides: Partial<RuntimeStatus> = {}): RuntimeStatus {
   return {
-    id: 'dynamo',
-    name: 'NVIDIA Dynamo',
+    id: 'installed-runtime',
+    name: 'Installed Runtime',
     installed: true,
     ...overrides,
   } as RuntimeStatus
@@ -102,7 +102,7 @@ describe('DeploymentForm', () => {
     toast.mockReset()
   })
 
-  it('keeps manual Dynamo topology edits instead of snapping back to the recommendation', async () => {
+  it('keeps manual topology edits instead of snapping back to the recommendation', async () => {
     render(
       <MemoryRouter>
         <DeploymentForm

--- a/frontend/src/hooks/useSettings.test.tsx
+++ b/frontend/src/hooks/useSettings.test.tsx
@@ -18,7 +18,7 @@ describe('useSettings', () => {
     expect(result.current.data?.providers).toBeDefined()
   })
 
-  it('returns provider list', async () => {
+  it('returns the settings catalog list', async () => {
     const { result } = renderHook(() => useSettings(), {
       wrapper: createWrapper(),
     })
@@ -54,7 +54,7 @@ describe('useUpdateSettings', () => {
 })
 
 describe('useProviders', () => {
-  it('fetches providers list', async () => {
+  it('fetches the runtime catalog list', async () => {
     const { result } = renderHook(() => useProviders(), {
       wrapper: createWrapper(),
     })
@@ -66,30 +66,30 @@ describe('useProviders', () => {
     expect(result.current.data!.providers.length).toBeGreaterThan(0)
   })
 
-  it('returns provider objects with required fields', async () => {
+  it('returns catalog entries with required fields', async () => {
     const { result } = renderHook(() => useProviders(), {
       wrapper: createWrapper(),
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-    const provider = result.current.data!.providers[0]
-    expect(provider.id).toBeDefined()
-    expect(provider.name).toBeDefined()
-    expect(provider.description).toBeDefined()
+    const entry = result.current.data!.providers[0]
+    expect(entry.id).toBeDefined()
+    expect(entry.name).toBeDefined()
+    expect(entry.description).toBeDefined()
   })
 })
 
 describe('useProviderDetails', () => {
-  it('fetches provider details by id', async () => {
-    const { result } = renderHook(() => useProviderDetails('dynamo'), {
+  it('fetches catalog details by id', async () => {
+    const { result } = renderHook(() => useProviderDetails('runtime-a'), {
       wrapper: createWrapper(),
     })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(result.current.data).toBeDefined()
-    expect(result.current.data?.id).toBe('dynamo')
+    expect(result.current.data?.id).toBe('runtime-a')
     expect(result.current.data?.name).toBeDefined()
     expect(result.current.data?.crdConfig).toBeDefined()
   })

--- a/frontend/src/lib/gpu-recommendations.test.ts
+++ b/frontend/src/lib/gpu-recommendations.test.ts
@@ -12,7 +12,6 @@ function createModel(overrides: Partial<Model> = {}): Model {
   return {
     id: 'test-model',
     name: 'Test Model',
-    provider: 'kuberay',
     description: 'A test model',
     ...overrides,
   } as Model;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -68,22 +68,22 @@ export const mockSettings = {
   },
   providers: [
     {
-      id: 'dynamo',
-      name: 'NVIDIA Dynamo',
-      description: 'GPU-accelerated inference with disaggregated serving',
-      defaultNamespace: 'airunway-system',
+      id: 'runtime-a',
+      name: 'Primary Runtime',
+      description: 'General-purpose runtime for standard workloads',
+      defaultNamespace: 'runtime-a-system',
     },
     {
-      id: 'kuberay',
-      name: 'KubeRay',
-      description: 'Ray-based distributed inference',
-      defaultNamespace: 'kuberay',
+      id: 'runtime-b',
+      name: 'Distributed Runtime',
+      description: 'Runtime for larger distributed workloads',
+      defaultNamespace: 'runtime-b-system',
     },
     {
-      id: 'llmd',
-      name: 'llm-d',
-      description: 'vLLM with aggregated or disaggregated serving',
-      defaultNamespace: 'airunway-system',
+      id: 'runtime-c',
+      name: 'Flexible Runtime',
+      description: 'Runtime with multiple deployment styles',
+      defaultNamespace: 'runtime-c-system',
     },
   ],
 }
@@ -176,8 +176,8 @@ export const handlers = [
       namespace: 'airunway-system',
       clusterName: 'test-cluster',
       provider: {
-        id: 'dynamo',
-        name: 'NVIDIA Dynamo',
+        id: 'runtime-a',
+        name: 'Primary Runtime',
       },
       providerInstallation: {
         installed: true,
@@ -206,17 +206,17 @@ export const handlers = [
   }),
 
   http.get(`${API_BASE}/settings/providers/:id`, ({ params }) => {
-    const provider = mockSettings.providers.find(p => p.id === params.id)
-    if (!provider) {
-      return HttpResponse.json({ error: { message: 'Provider not found' } }, { status: 404 })
+    const runtimeEntry = mockSettings.providers.find(entry => entry.id === params.id)
+    if (!runtimeEntry) {
+      return HttpResponse.json({ error: { message: 'Runtime catalog entry not found' } }, { status: 404 })
     }
     return HttpResponse.json({
-      ...provider,
+      ...runtimeEntry,
       crdConfig: {
-        apiGroup: 'nvidia.com',
+        apiGroup: 'example.ai',
         apiVersion: 'v1alpha1',
-        plural: 'dynamographdeployments',
-        kind: 'DynamoGraphDeployment',
+        plural: 'runtimedeployments',
+        kind: 'RuntimeDeployment',
       },
       installationSteps: [],
       helmRepos: [],
@@ -233,9 +233,10 @@ export const handlers = [
   }),
 
   http.get(`${API_BASE}/installation/providers/:id/status`, ({ params }) => {
+    const runtimeEntry = mockSettings.providers.find(entry => entry.id === params.id)
     return HttpResponse.json({
       providerId: params.id,
-      providerName: params.id === 'dynamo' ? 'NVIDIA Dynamo' : params.id === 'llmd' ? 'LLM-D' :'KubeRay',
+      providerName: runtimeEntry?.name || 'Runtime',
       installed: true,
       version: '1.0.0',
       crdFound: true,
@@ -248,21 +249,21 @@ export const handlers = [
   http.post(`${API_BASE}/installation/providers/:id/install`, () => {
     return HttpResponse.json({
       success: true,
-      message: 'Provider installed successfully',
+      message: 'Runtime installed successfully',
     })
   }),
 
   http.post(`${API_BASE}/installation/providers/:id/upgrade`, () => {
     return HttpResponse.json({
       success: true,
-      message: 'Provider upgraded successfully',
+      message: 'Runtime upgraded successfully',
     })
   }),
 
   http.post(`${API_BASE}/installation/providers/:id/uninstall`, () => {
     return HttpResponse.json({
       success: true,
-      message: 'Provider uninstalled successfully',
+      message: 'Runtime uninstalled successfully',
     })
   }),
 
@@ -347,8 +348,8 @@ export const handlers = [
     return HttpResponse.json({
       configured: true,
       namespaces: [
-        { name: 'dynamo-system', exists: true },
-        { name: 'kuberay-system', exists: true },
+        { name: 'runtime-a-system', exists: true },
+        { name: 'runtime-b-system', exists: true },
         { name: 'default', exists: true },
       ],
       user: {
@@ -373,8 +374,8 @@ export const handlers = [
         fullname: 'Test User',
       },
       results: [
-        { namespace: 'dynamo-system', success: true },
-        { namespace: 'kuberay-system', success: true },
+        { namespace: 'runtime-a-system', success: true },
+        { namespace: 'runtime-b-system', success: true },
         { namespace: 'default', success: true },
       ],
     })
@@ -385,8 +386,8 @@ export const handlers = [
       success: true,
       message: 'HuggingFace secrets deleted successfully',
       results: [
-        { namespace: 'dynamo-system', success: true },
-        { namespace: 'kuberay-system', success: true },
+        { namespace: 'runtime-a-system', success: true },
+        { namespace: 'runtime-b-system', success: true },
         { namespace: 'default', success: true },
       ],
     })


### PR DESCRIPTION
## Summary
- replace hardcoded runtime-specific names and ids in frontend tests with generic placeholders
- update shared frontend MSW handlers to use generic runtime catalog entries, namespaces, and installation messages
- keep structural API field names such as `providers` and `providerName` where the frontend contract still requires them

## Testing
- `bun run --filter '@airunway/frontend' test`