### PR TITLE
Fix Hugging Face settings UI readability

### DIFF
--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -7,6 +7,25 @@ const mutateAsync = vi.fn()
 const refetch = vi.fn()
 const startOAuth = vi.fn()
 const toast = vi.fn()
+let mockGpuStatus = {
+  installed: false,
+  gpusAvailable: false,
+  operatorRunning: false,
+  totalGPUs: 0,
+  message: '',
+  gpuNodes: [] as string[],
+  helmCommands: [] as string[],
+}
+let mockHfStatus: {
+  configured: boolean
+  user?: {
+    name: string
+    fullname?: string
+    avatarUrl?: string
+  }
+} = {
+  configured: false,
+}
 
 vi.mock('@/hooks/useSettings', () => ({
   useSettings: () => ({ isLoading: false }),
@@ -82,13 +101,7 @@ vi.mock('@/hooks/useAutoscaler', () => ({
 
 vi.mock('@/hooks/useGpuOperator', () => ({
   useGpuOperatorStatus: () => ({
-    data: {
-      installed: false,
-      gpusAvailable: false,
-      message: '',
-      gpuNodes: [],
-      helmCommands: [],
-    },
+    data: mockGpuStatus,
     isLoading: false,
     refetch,
   }),
@@ -116,9 +129,7 @@ vi.mock('@/hooks/useGateway', () => ({
 
 vi.mock('@/hooks/useHuggingFace', () => ({
   useHuggingFaceStatus: () => ({
-    data: {
-      configured: false,
-    },
+    data: mockHfStatus,
     isLoading: false,
     refetch,
   }),
@@ -147,6 +158,18 @@ describe('SettingsPage', () => {
     refetch.mockReset()
     startOAuth.mockReset()
     toast.mockReset()
+    mockGpuStatus = {
+      installed: false,
+      gpusAvailable: false,
+      operatorRunning: false,
+      totalGPUs: 0,
+      message: '',
+      gpuNodes: [],
+      helmCommands: [],
+    }
+    mockHfStatus = {
+      configured: false,
+    }
   })
 
   it('renders runtime cards without inline accent border styles', () => {
@@ -161,5 +184,43 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Available Runtime')).toBeInTheDocument()
     expect(container.querySelector('[style*="border-top-color"]')).toBeNull()
     expect(container.querySelector('[style*="border-top-width"]')).toBeNull()
+  })
+
+  it('uses success badge styling for readable integration connection states', () => {
+    mockGpuStatus = {
+      installed: true,
+      gpusAvailable: true,
+      operatorRunning: true,
+      totalGPUs: 4,
+      message: 'GPU support is ready',
+      gpuNodes: ['worker-a'],
+      helmCommands: [],
+    }
+    mockHfStatus = {
+      configured: true,
+      user: {
+        name: 'test-user',
+        fullname: 'Test User',
+      },
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=integrations']}>
+        <SettingsPage />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('GPUs Enabled')).toHaveClass('bg-green-500/15', 'text-green-600', 'dark:text-green-400')
+    expect(screen.getByText('Connected')).toHaveClass('bg-green-500/15', 'text-green-600', 'dark:text-green-400')
+  })
+
+  it('uses the Hugging Face emoji on the connect button', () => {
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=integrations']}>
+        <SettingsPage />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('button', { name: /sign in with hugging face/i })).toHaveTextContent('🤗')
   })
 })

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -693,7 +693,7 @@ export function SettingsPage() {
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium">GPU Status</span>
-                    <Badge variant="default" className="bg-green-500">
+                    <Badge variant="success">
                       <CheckCircle className="h-3 w-3 mr-1" />
                       GPUs Enabled
                     </Badge>
@@ -1018,7 +1018,7 @@ export function SettingsPage() {
                         )}
                       </div>
                     </div>
-                    <Badge variant="default" className="bg-green-500">
+                    <Badge variant="success">
                       <CheckCircle className="h-3 w-3 mr-1" />
                       Connected
                     </Badge>
@@ -1094,14 +1094,7 @@ export function SettingsPage() {
                       </>
                     ) : (
                       <>
-                        <svg className="h-5 w-5 mr-2" viewBox="0 0 95 88" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M47.2119 76.5C54.4518 76.5 60.7119 70.24 60.7119 63V50.5H47.2119C39.9719 50.5 33.7119 56.76 33.7119 64C33.7119 70.9 39.6319 76.5 47.2119 76.5Z" fill="currentColor"/>
-                          <path d="M47.2119 88C61.5765 88 73.2119 76.3645 73.2119 62C73.2119 47.6355 61.5765 36 47.2119 36C32.8474 36 21.2119 47.6355 21.2119 62C21.2119 76.3645 32.8474 88 47.2119 88Z" fill="currentColor"/>
-                          <ellipse cx="35.7119" cy="30" rx="12" ry="12" fill="currentColor"/>
-                          <ellipse cx="59.7119" cy="30" rx="12" ry="12" fill="currentColor"/>
-                          <ellipse cx="35.7119" cy="30" rx="5" ry="5" fill="white"/>
-                          <ellipse cx="59.7119" cy="30" rx="5" ry="5" fill="white"/>
-                        </svg>
+                        <span aria-hidden="true" className="mr-2 text-base leading-none">🤗</span>
                         Sign in with Hugging Face
                       </>
                     )}


### PR DESCRIPTION
## Summary
- use the shared success badge styling for the GPU and Hugging Face connected pills in Settings so the text stays readable
- replace the broken custom Hugging Face icon with the actual 🤗 emoji on the connect button
- add Settings page regression coverage for the success badge styling and emoji button rendering

## Testing
- bun run --filter '@airunway/frontend' test -- src/pages/SettingsPage.test.tsx
- bun run --filter '@airunway/frontend' build