### PR TITLE
Reduce /metrics request pressure on inference services

### DIFF
--- a/backend/src/services/metrics.test.ts
+++ b/backend/src/services/metrics.test.ts
@@ -1,19 +1,8 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
 import type { RawMetricValue, MetricsResponse } from '@airunway/shared';
+import { buildMetricsUrl, mapMetricsErrorMessage, MetricsService } from './metrics';
 
 describe('MetricsService - buildMetricsUrl', () => {
-  // Test the URL building logic (unit test the pattern)
-  function buildMetricsUrl(
-    deploymentName: string,
-    namespace: string,
-    servicePattern: string,
-    port: number,
-    endpointPath: string
-  ): string {
-    const serviceName = servicePattern.replace('{name}', deploymentName);
-    return `http://${serviceName}.${namespace}.svc.cluster.local:${port}${endpointPath}`;
-  }
-
   test('builds correct URL with service pattern', () => {
     const url = buildMetricsUrl(
       'my-model',
@@ -49,59 +38,114 @@ describe('MetricsService - buildMetricsUrl', () => {
 });
 
 describe('MetricsService - Error Message Handling', () => {
-  // Test error message mapping logic
-  function mapErrorMessage(errorMessage: string): string {
-    if (errorMessage.includes('ENOTFOUND') || errorMessage.includes('getaddrinfo')) {
-      return 'Cannot resolve service DNS. The deployment service may not exist yet.';
-    } else if (errorMessage.includes('ECONNREFUSED')) {
-      return 'Connection refused. The deployment may not be ready yet.';
-    } else if (errorMessage.includes('abort')) {
-      return 'Request timed out. The deployment may be under heavy load or not responding.';
-    } else if (errorMessage.includes('HTTP 404') || errorMessage.includes('404')) {
-      return 'Metrics endpoint not found. The deployment may not expose metrics.';
-    } else if (errorMessage.includes('HTTP 503') || errorMessage.includes('503')) {
-      return 'Service unavailable. The deployment is starting up.';
-    } else if (errorMessage.includes('fetch failed') || errorMessage.includes('TypeError')) {
-      return 'Cannot connect to metrics endpoint. Verify the deployment is running.';
-    } else if (errorMessage.includes('connect ECONNREFUSED') || errorMessage.includes('no cluster')) {
-      return 'Cannot connect to the Kubernetes cluster. Check your kubeconfig.';
-    }
-    return errorMessage;
-  }
-
   test('maps DNS resolution errors', () => {
-    expect(mapErrorMessage('getaddrinfo ENOTFOUND service.namespace.svc')).toContain('Cannot resolve service DNS');
-    expect(mapErrorMessage('Error: ENOTFOUND')).toContain('not exist yet');
+    expect(mapMetricsErrorMessage('getaddrinfo ENOTFOUND service.namespace.svc')).toContain('Cannot resolve service DNS');
+    expect(mapMetricsErrorMessage('Error: ENOTFOUND')).toContain('not exist yet');
   });
 
   test('maps connection refused errors', () => {
-    expect(mapErrorMessage('connect ECONNREFUSED 10.0.0.1:8000')).toContain('Connection refused');
-    expect(mapErrorMessage('ECONNREFUSED')).toContain('not be ready');
+    expect(mapMetricsErrorMessage('connect ECONNREFUSED 10.0.0.1:8000')).toContain('Cannot connect to the Kubernetes cluster');
+    expect(mapMetricsErrorMessage('ECONNREFUSED')).toContain('not be ready');
   });
 
   test('maps timeout errors', () => {
-    expect(mapErrorMessage('The operation was aborted')).toContain('timed out');
-    expect(mapErrorMessage('signal was aborted')).toContain('heavy load');
+    expect(mapMetricsErrorMessage('The operation was aborted')).toContain('timed out');
+    expect(mapMetricsErrorMessage('signal was aborted')).toContain('heavy load');
   });
 
   test('maps HTTP 404 errors', () => {
-    expect(mapErrorMessage('HTTP 404: Not Found')).toContain('endpoint not found');
-    expect(mapErrorMessage('HTTP 404')).toContain('not expose metrics');
+    expect(mapMetricsErrorMessage('HTTP 404: Not Found')).toContain('endpoint not found');
+    expect(mapMetricsErrorMessage('HTTP 404')).toContain('not expose metrics');
   });
 
   test('maps HTTP 503 errors', () => {
-    expect(mapErrorMessage('HTTP 503: Service Unavailable')).toContain('Service unavailable');
-    expect(mapErrorMessage('HTTP 503')).toContain('starting up');
+    expect(mapMetricsErrorMessage('HTTP 503: Service Unavailable')).toContain('Service unavailable');
+    expect(mapMetricsErrorMessage('HTTP 503')).toContain('starting up');
   });
 
   test('maps fetch errors', () => {
-    expect(mapErrorMessage('fetch failed')).toContain('Verify the deployment');
-    expect(mapErrorMessage('TypeError: Failed to fetch')).toContain('Verify the deployment');
+    expect(mapMetricsErrorMessage('fetch failed')).toContain('Verify the deployment');
+    expect(mapMetricsErrorMessage('TypeError: Failed to fetch')).toContain('Verify the deployment');
   });
 
   test('returns original message for unknown errors', () => {
-    expect(mapErrorMessage('Some unknown error')).toBe('Some unknown error');
-    expect(mapErrorMessage('Unexpected condition')).toBe('Unexpected condition');
+    expect(mapMetricsErrorMessage('Some unknown error')).toBe('Some unknown error');
+    expect(mapMetricsErrorMessage('Unexpected condition')).toBe('Unexpected condition');
+  });
+});
+
+describe('MetricsService - Caching', () => {
+  test('reuses cached successful responses within the cache window', async () => {
+    let now = 1700000000000;
+    const fetchRawMetrics = mock(async () => 'vllm:num_requests_running 5\n');
+    const service = new MetricsService({
+      fetchRawMetrics,
+      checkInCluster: () => true,
+      now: () => now,
+      successCacheTtlMs: 15000,
+      errorCacheTtlMs: 5000,
+    });
+
+    const first = await service.getDeploymentMetrics('demo', 'default');
+    now += 1000;
+    const second = await service.getDeploymentMetrics('demo', 'default');
+
+    expect(fetchRawMetrics).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  test('deduplicates concurrent requests for the same deployment', async () => {
+    let resolveFetch: ((value: string) => void) | undefined;
+    const fetchRawMetrics = mock(() =>
+      new Promise<string>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const service = new MetricsService({
+      fetchRawMetrics,
+      checkInCluster: () => true,
+      now: () => 1700000000000,
+      successCacheTtlMs: 15000,
+      errorCacheTtlMs: 5000,
+    });
+
+    const firstPromise = service.getDeploymentMetrics('demo', 'default');
+    const secondPromise = service.getDeploymentMetrics('demo', 'default');
+
+    expect(fetchRawMetrics).toHaveBeenCalledTimes(1);
+    expect(resolveFetch).toBeDefined();
+
+    resolveFetch?.('vllm:num_requests_running 5\n');
+
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+    expect(second).toEqual(first);
+  });
+
+  test('briefly caches failures to avoid hammering unhealthy endpoints', async () => {
+    let now = 1700000000000;
+    const fetchRawMetrics = mock(async () => {
+      throw new Error('HTTP 503: Service Unavailable');
+    });
+
+    const service = new MetricsService({
+      fetchRawMetrics,
+      checkInCluster: () => true,
+      now: () => now,
+      successCacheTtlMs: 15000,
+      errorCacheTtlMs: 5000,
+    });
+
+    const first = await service.getDeploymentMetrics('demo', 'default');
+    now += 1000;
+    const second = await service.getDeploymentMetrics('demo', 'default');
+    now += 5000;
+    const third = await service.getDeploymentMetrics('demo', 'default');
+
+    expect(fetchRawMetrics).toHaveBeenCalledTimes(2);
+    expect(first.error).toContain('Service unavailable');
+    expect(second).toEqual(first);
+    expect(third.timestamp).not.toBe(first.timestamp);
   });
 });
 

--- a/backend/src/services/metrics.ts
+++ b/backend/src/services/metrics.ts
@@ -22,6 +22,10 @@ const DEFAULT_METRICS_CONFIG = {
   endpointPath: '/metrics',
 };
 
+// Keep metrics reasonably fresh while collapsing duplicate scrapes from multiple UI consumers.
+const METRICS_SUCCESS_CACHE_TTL_MS = 15000;
+const METRICS_ERROR_CACHE_TTL_MS = 5000;
+
 /**
  * Check if AI Runway is running inside a Kubernetes cluster
  * This is determined by the presence of the service account token
@@ -47,7 +51,7 @@ function checkInCluster(): boolean {
 /**
  * Build the metrics URL for a deployment
  */
-function buildMetricsUrl(
+export function buildMetricsUrl(
   deploymentName: string,
   namespace: string,
   servicePattern: string,
@@ -88,15 +92,109 @@ async function fetchRawMetrics(url: string): Promise<string> {
   }
 }
 
+export function mapMetricsErrorMessage(errorMessage: string): string {
+  if (errorMessage.includes('ENOTFOUND') || errorMessage.includes('getaddrinfo')) {
+    return 'Cannot resolve service DNS. The deployment service may not exist yet.';
+  }
+  if (errorMessage.includes('no cluster') || errorMessage.includes('connect ECONNREFUSED')) {
+    return 'Cannot connect to the Kubernetes cluster. Check your kubeconfig.';
+  }
+  if (errorMessage.includes('ECONNREFUSED')) {
+    return 'Connection refused. The deployment may not be ready yet.';
+  }
+  if (errorMessage.includes('abort')) {
+    return 'Request timed out. The deployment may be under heavy load or not responding.';
+  }
+  if (errorMessage.includes('HTTP 404') || errorMessage.includes('404')) {
+    return 'Metrics endpoint not found. The deployment may not expose metrics.';
+  }
+  if (errorMessage.includes('HTTP 503') || errorMessage.includes('503')) {
+    return 'Service unavailable. The deployment is starting up.';
+  }
+  if (errorMessage.includes('fetch failed') || errorMessage.includes('TypeError')) {
+    return 'Cannot connect to metrics endpoint. Verify the deployment is running.';
+  }
+
+  return errorMessage;
+}
+
+interface MetricsServiceCacheEntry {
+  response: MetricsResponse;
+  expiresAt: number;
+}
+
+interface MetricsServiceOptions {
+  fetchRawMetrics?: (url: string) => Promise<string>;
+  proxyServiceGet?: (serviceName: string, namespace: string, port: number, path: string) => Promise<string>;
+  checkInCluster?: () => boolean;
+  now?: () => number;
+  successCacheTtlMs?: number;
+  errorCacheTtlMs?: number;
+}
+
 /**
  * MetricsService class for fetching deployment metrics
  */
-class MetricsService {
+export class MetricsService {
+  private readonly responseCache = new Map<string, MetricsServiceCacheEntry>();
+  private readonly inFlightRequests = new Map<string, Promise<MetricsResponse>>();
+  private readonly fetchRawMetricsFn: (url: string) => Promise<string>;
+  private readonly proxyServiceGetFn: (serviceName: string, namespace: string, port: number, path: string) => Promise<string>;
+  private readonly checkInClusterFn: () => boolean;
+  private readonly nowFn: () => number;
+  private readonly successCacheTtlMs: number;
+  private readonly errorCacheTtlMs: number;
+
+  constructor(options: MetricsServiceOptions = {}) {
+    this.fetchRawMetricsFn = options.fetchRawMetrics ?? fetchRawMetrics;
+    this.proxyServiceGetFn = options.proxyServiceGet ?? ((serviceName, namespace, port, path) =>
+      kubernetesService.proxyServiceGet(serviceName, namespace, port, path));
+    this.checkInClusterFn = options.checkInCluster ?? checkInCluster;
+    this.nowFn = options.now ?? Date.now;
+    this.successCacheTtlMs = options.successCacheTtlMs ?? METRICS_SUCCESS_CACHE_TTL_MS;
+    this.errorCacheTtlMs = options.errorCacheTtlMs ?? METRICS_ERROR_CACHE_TTL_MS;
+  }
+
   /**
    * Check if metrics fetching is available (requires cluster connection)
    */
   isMetricsAvailable(): boolean {
     return true;
+  }
+
+  clearCache(): void {
+    this.responseCache.clear();
+    this.inFlightRequests.clear();
+  }
+
+  private buildCacheKey(deploymentName: string, namespace: string, providerId?: string): string {
+    return `${namespace}/${deploymentName}/${providerId ?? 'default'}`;
+  }
+
+  private getCachedResponse(cacheKey: string): MetricsResponse | null {
+    const cached = this.responseCache.get(cacheKey);
+    if (!cached) {
+      return null;
+    }
+
+    if (cached.expiresAt <= this.nowFn()) {
+      this.responseCache.delete(cacheKey);
+      return null;
+    }
+
+    return cached.response;
+  }
+
+  private cacheResponse(cacheKey: string, response: MetricsResponse): void {
+    const ttlMs = response.available ? this.successCacheTtlMs : this.errorCacheTtlMs;
+    if (ttlMs <= 0) {
+      return;
+    }
+
+    this.responseCache.set(cacheKey, {
+      response,
+      expiresAt: this.nowFn() + ttlMs,
+    });
   }
 
   /**
@@ -107,9 +205,35 @@ class MetricsService {
    * @param providerId - Optional provider ID (for future use)
    * @returns MetricsResponse with available metrics or error
    */
-  async getDeploymentMetrics(deploymentName: string, namespace: string, _providerId?: string): Promise<MetricsResponse> {
-    const timestamp = new Date().toISOString();
-    const inCluster = checkInCluster();
+  async getDeploymentMetrics(deploymentName: string, namespace: string, providerId?: string): Promise<MetricsResponse> {
+    const cacheKey = this.buildCacheKey(deploymentName, namespace, providerId);
+    const cachedResponse = this.getCachedResponse(cacheKey);
+    if (cachedResponse) {
+      logger.debug({ deploymentName, namespace }, 'Serving cached deployment metrics');
+      return cachedResponse;
+    }
+
+    const inFlightRequest = this.inFlightRequests.get(cacheKey);
+    if (inFlightRequest) {
+      logger.debug({ deploymentName, namespace }, 'Joining in-flight deployment metrics request');
+      return inFlightRequest;
+    }
+
+    const request = this.fetchDeploymentMetrics(deploymentName, namespace, cacheKey).finally(() => {
+      this.inFlightRequests.delete(cacheKey);
+    });
+
+    this.inFlightRequests.set(cacheKey, request);
+    return request;
+  }
+
+  private async fetchDeploymentMetrics(
+    deploymentName: string,
+    namespace: string,
+    cacheKey: string
+  ): Promise<MetricsResponse> {
+    const timestamp = new Date(this.nowFn()).toISOString();
+    const inCluster = this.checkInClusterFn();
 
     try {
       // Use default metrics configuration
@@ -129,12 +253,12 @@ class MetricsService {
         );
 
         logger.debug({ url, deploymentName, namespace }, 'Fetching metrics from deployment (in-cluster)');
-        rawText = await fetchRawMetrics(url);
+        rawText = await this.fetchRawMetricsFn(url);
       } else {
         // Off-cluster: proxy through the K8s API server via kubeconfig
         const path = metricsConfig.endpointPath.replace(/^\//, ''); // strip leading slash
         logger.debug({ deploymentName, namespace, port: metricsConfig.port, path }, 'Fetching metrics via K8s API proxy (off-cluster)');
-        rawText = await kubernetesService.proxyServiceGet(serviceName, namespace, metricsConfig.port, path);
+        rawText = await this.proxyServiceGetFn(serviceName, namespace, metricsConfig.port, path);
       }
 
       // Parse Prometheus format
@@ -145,44 +269,32 @@ class MetricsService {
         'Successfully fetched and parsed metrics'
       );
 
-      return {
+      const response: MetricsResponse = {
         available: true,
         timestamp,
         metrics,
       };
+
+      this.cacheResponse(cacheKey, response);
+      return response;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
-      // Provide helpful error messages based on error type
-      let userMessage = errorMessage;
-
-      if (errorMessage.includes('ENOTFOUND') || errorMessage.includes('getaddrinfo')) {
-        userMessage = 'Cannot resolve service DNS. The deployment service may not exist yet.';
-      } else if (errorMessage.includes('no cluster') || errorMessage.includes('connect ECONNREFUSED')) {
-        userMessage = 'Cannot connect to the Kubernetes cluster. Check your kubeconfig.';
-      } else if (errorMessage.includes('ECONNREFUSED')) {
-        userMessage = 'Connection refused. The deployment may not be ready yet.';
-      } else if (errorMessage.includes('abort')) {
-        userMessage = 'Request timed out. The deployment may be under heavy load or not responding.';
-      } else if (errorMessage.includes('HTTP 404') || errorMessage.includes('404')) {
-        userMessage = 'Metrics endpoint not found. The deployment may not expose metrics.';
-      } else if (errorMessage.includes('HTTP 503') || errorMessage.includes('503')) {
-        userMessage = 'Service unavailable. The deployment is starting up.';
-      } else if (errorMessage.includes('fetch failed') || errorMessage.includes('TypeError')) {
-        userMessage = 'Cannot connect to metrics endpoint. Verify the deployment is running.';
-      }
+      const userMessage = mapMetricsErrorMessage(errorMessage);
 
       logger.warn(
         { deploymentName, namespace, error: errorMessage },
         'Failed to fetch deployment metrics'
       );
 
-      return {
+      const response: MetricsResponse = {
         available: false,
         error: userMessage,
         timestamp,
         metrics: [],
       };
+
+      this.cacheResponse(cacheKey, response);
+      return response;
     }
   }
 

--- a/frontend/src/components/metrics/MetricsTab.tsx
+++ b/frontend/src/components/metrics/MetricsTab.tsx
@@ -74,13 +74,13 @@ export function MetricsTab({ deploymentName, namespace, provider, className }: M
   const [autoRefresh, setAutoRefresh] = useState(true)
   const [activeCategory, setActiveCategory] = useState<MetricCategory>('all')
 
-  const { metrics, isLoading, error, dataUpdatedAt } = useMetrics(
+  const { metrics, isLoading, error } = useMetrics(
     deploymentName,
     namespace,
     provider,
     {
       enabled: true,
-      refetchInterval: autoRefresh ? 10000 : undefined,
+      refetchInterval: autoRefresh ? 30000 : undefined,
     }
   )
 
@@ -106,7 +106,7 @@ export function MetricsTab({ deploymentName, namespace, provider, className }: M
           <div className="flex items-center gap-2">
             {metrics?.available && (
               <span className="text-xs text-muted-foreground">
-                Updated {formatLastUpdated(new Date(dataUpdatedAt))}
+                Updated {formatLastUpdated(metrics.lastUpdated)}
               </span>
             )}
             <Button

--- a/frontend/src/hooks/useMetrics.ts
+++ b/frontend/src/hooks/useMetrics.ts
@@ -186,8 +186,10 @@ export function useMetrics(
       return computeMetrics(response, provider)
     },
     enabled: options?.enabled !== false && !!deploymentName,
-    refetchInterval: options?.refetchInterval ?? 10000, // Default 10 seconds
-    staleTime: 5000, // Consider data stale after 5 seconds
+    refetchInterval: options?.refetchInterval ?? 30000, // Default 30 seconds
+    staleTime: 30000, // Keep metrics fresh without re-fetching on every focus change
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
     retry: false, // Don't retry on failure (metrics might not be available)
   })
 


### PR DESCRIPTION
## Summary
- coalesce concurrent deployment metrics requests and cache recent results in the backend so repeated UI polls do not hammer inference servers
- briefly cache failed scrapes as well, which reduces retry pressure while a metrics endpoint is unhealthy or starting up
- slow the frontend metrics auto-refresh to 30 seconds, disable focus/reconnect refetches, and show the server scrape timestamp in the UI
- add unit coverage for metrics request caching and de-duplication

## Testing
- `bun test backend/src/services/metrics.test.ts`
- `bun run --filter '@airunway/frontend' build`
- `bun run test` *(still fails in the existing `/api/costs/node-pools` timeout tests, unrelated to this change)*