### PR TITLE
feat(ui): extend glass styling across key surfaces

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -48,20 +48,22 @@ export function Header() {
   const breadcrumbs = useBreadcrumbs()
 
   return (
-    <header className="sticky top-0 z-30 h-14 bg-white/[0.03] backdrop-blur-md border-b border-white/5">
-      <div className="flex h-full items-center justify-between px-4 md:px-6 gap-4">
-        <div className="flex items-center gap-3 min-w-0">
+    <header className="sticky top-0 z-30 px-4 pt-3 md:px-6">
+      <div className="glass-elevated relative flex h-14 items-center justify-between gap-4 overflow-hidden px-4 md:px-5">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_45%)]" />
+
+        <div className="relative flex min-w-0 items-center gap-3">
           <Button
             variant="ghost"
             size="icon"
-            className="md:hidden shrink-0 -ml-2"
+            className="md:hidden shrink-0 -ml-1 text-white/70 hover:bg-white/10 hover:text-white"
             onClick={toggle}
             aria-label="Toggle navigation menu"
           >
             <Menu className="h-5 w-5" />
           </Button>
 
-          <nav className="hidden md:flex items-center gap-1 min-w-0 text-sm">
+          <nav className="hidden min-w-0 items-center gap-1 rounded-full border border-white/8 bg-black/10 px-2.5 py-1.5 text-sm backdrop-blur-md md:flex">
             {breadcrumbs.map((crumb, i) => (
               <span key={crumb.path} className="flex items-center gap-1 min-w-0">
                 {i > 0 && <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />}
@@ -80,7 +82,7 @@ export function Header() {
           </nav>
         </div>
 
-        <div className="flex items-center gap-2 md:gap-3 shrink-0">
+        <div className="relative flex shrink-0 items-center gap-2 md:gap-3">
           <div className="flex items-center">
             {isLoading ? (
               <Badge variant="outline" pulse className="gap-1.5">
@@ -103,12 +105,11 @@ export function Header() {
           {clusterStatus?.clusterName && (
             <Badge
               variant="outline"
-              className="hidden lg:inline-flex max-w-[150px] bg-white/[0.05] border-white/10 font-mono text-xs"
+              className="hidden max-w-[170px] font-mono text-[11px] tracking-wide lg:inline-flex"
             >
               <span className="truncate">{clusterStatus.clusterName}</span>
             </Badge>
           )}
-
         </div>
       </div>
     </header>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -88,10 +88,15 @@ export function MainLayout({ children }: MainLayoutProps) {
         </div>
 
         {/* Main content */}
-        <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="relative isolate flex flex-1 flex-col overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 overflow-hidden">
+            <div className="absolute -left-24 top-20 h-72 w-72 rounded-full bg-cyan-400/10 blur-3xl" />
+            <div className="absolute right-[-5rem] top-[-3rem] h-80 w-80 rounded-full bg-blue-500/10 blur-3xl" />
+            <div className="absolute bottom-[-8rem] left-1/3 h-96 w-96 rounded-full bg-sky-300/5 blur-3xl" />
+          </div>
           <Header />
-          <main className="flex-1 overflow-auto bg-decor">
-            <div className="max-w-[1400px] mx-auto p-4 md:p-6">
+          <main className="relative flex-1 overflow-auto bg-decor">
+            <div className="relative mx-auto max-w-[1400px] p-4 md:p-6">
               {children}
             </div>
           </main>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -35,9 +35,9 @@ function ClusterStatusDot() {
   }
 
   return (
-    <div className="flex items-center gap-2 px-3 py-2">
+    <div className="glass-subtle flex items-center gap-2 rounded-2xl px-3 py-2">
       <span className={dotClass} />
-      <span className="text-xs text-slate-400">{label}</span>
+      <span className="text-xs text-slate-300">{label}</span>
     </div>
   )
 }
@@ -52,12 +52,15 @@ export function Sidebar({ onNavigate }: SidebarProps) {
   return (
     <div
       className={cn(
-        'flex h-full w-60 flex-col bg-background border-r border-white/5 overflow-hidden',
-        onNavigate && 'shadow-soft-sm'
+        'relative flex h-full w-64 flex-col overflow-hidden border-r border-white/10 bg-[#0F1419]/55 backdrop-blur-2xl',
+        'shadow-[inset_-1px_0_0_rgba(255,255,255,0.05)]',
+        onNavigate && 'shadow-[0_24px_60px_rgba(2,8,23,0.35)]'
       )}
     >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.06),_transparent_40%),linear-gradient(180deg,_rgba(255,255,255,0.04)_0%,_transparent_40%)]" />
+
       {/* Logo */}
-      <div className="flex h-14 items-center border-b border-white/5 px-4 shrink-0">
+      <div className="relative flex h-14 shrink-0 items-center border-b border-white/10 px-4">
         <Link
           to="/"
           className="flex items-center gap-2 min-w-0"
@@ -83,7 +86,7 @@ export function Sidebar({ onNavigate }: SidebarProps) {
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 flex flex-col items-stretch gap-1 px-2 py-4">
+      <nav className="relative flex flex-1 flex-col items-stretch gap-1.5 px-3 py-4">
         {navigation.map((item) => {
           const isActive =
             location.pathname === item.href ||
@@ -95,11 +98,11 @@ export function Sidebar({ onNavigate }: SidebarProps) {
               to={item.href}
               onClick={handleNavClick}
               className={cn(
-                'relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium',
-                'transition-all duration-150 ease-out',
+                'group relative flex items-center gap-3 rounded-2xl border px-3 py-2.5 text-sm font-medium backdrop-blur-md',
+                'transition-all duration-200 ease-out',
                 isActive
-                  ? 'text-primary'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground active:scale-[0.98]'
+                  ? 'border-cyan-400/20 bg-cyan-400/10 text-cyan-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]'
+                  : 'border-transparent text-muted-foreground hover:border-white/8 hover:bg-white/[0.05] hover:text-slate-100 active:scale-[0.98]'
               )}
             >
               <span
@@ -112,11 +115,11 @@ export function Sidebar({ onNavigate }: SidebarProps) {
               />
               <item.icon
                 className={cn(
-                  'h-5 w-5 shrink-0 transition-transform duration-150',
-                  isActive && 'scale-110'
+                  'h-5 w-5 shrink-0 transition-all duration-150',
+                  isActive ? 'scale-110' : 'group-hover:scale-105'
                 )}
               />
-              <span className="whitespace-nowrap text-slate-300">
+              <span className="whitespace-nowrap text-slate-300 transition-colors duration-150">
                 {item.name}
               </span>
             </Link>
@@ -125,7 +128,7 @@ export function Sidebar({ onNavigate }: SidebarProps) {
       </nav>
 
       {/* Cluster status */}
-      <div className="shrink-0 border-t border-white/5 py-3 px-2">
+      <div className="relative shrink-0 border-t border-white/10 px-3 py-3">
         <ClusterStatusDot />
       </div>
     </div>

--- a/frontend/src/components/models/HfModelCard.tsx
+++ b/frontend/src/components/models/HfModelCard.tsx
@@ -37,13 +37,15 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }
   return (
     <div
       className={cn(
-        "flex flex-col rounded-2xl p-5 group",
-        "bg-white/[0.03] border border-white/5",
+        "group relative flex h-full flex-col overflow-hidden rounded-[24px] p-5",
+        "border border-white/10 bg-white/[0.05] backdrop-blur-xl",
+        "shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_20px_45px_rgba(2,8,23,0.20)]",
         "transition-all duration-200 ease-out",
-        "hover:border-cyan-500/30 hover:shadow-glow-card hover:-translate-y-0.5"
+        "before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-gradient-to-b before:from-white/[0.08] before:to-transparent before:content-['']",
+        "hover:border-cyan-500/30 hover:shadow-glow-card hover:-translate-y-1"
       )}
     >
-      <div className="pb-2">
+      <div className="relative pb-2">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
             <h3 className="text-lg font-semibold text-white leading-tight truncate group-hover:text-cyan-400 transition-colors duration-200">{model.name}</h3>
@@ -60,7 +62,7 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }
         </div>
       </div>
 
-      <div className="flex-1 pt-2">
+      <div className="relative flex-1 pt-2">
         {/* Stats row */}
         <div className="flex items-center gap-4 text-sm text-slate-400 mb-3">
           <div className="flex items-center gap-1">
@@ -93,7 +95,7 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }
         </div>
       </div>
 
-      <div className="pt-4">
+      <div className="relative pt-4">
         <Button 
           variant="ghost"
           onClick={handleDeploy} 

--- a/frontend/src/components/models/HfModelSearch.tsx
+++ b/frontend/src/components/models/HfModelSearch.tsx
@@ -51,49 +51,51 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapaci
 
   return (
     <div className="space-y-4">
-      {/* Search input */}
-      <div className="relative">
-        <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
-        <Input
-          type="text"
-          placeholder="Search HuggingFace models (e.g., llama, mistral, qwen)..."
-          value={query}
-          onChange={handleSearch}
-          className="pl-12 h-12 rounded-2xl bg-white/[0.03] border-white/5 text-base placeholder:text-slate-500"
-        />
-        {isFetching && (
-          <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+      <div className="glass-panel !p-4 space-y-4 md:!p-5">
+        {/* Search input */}
+        <div className="relative">
+          <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
+          <Input
+            type="text"
+            placeholder="Search HuggingFace models (e.g., llama, mistral, qwen)..."
+            value={query}
+            onChange={handleSearch}
+            className="h-12 rounded-2xl pl-12 text-base placeholder:text-slate-500"
+          />
+          {isFetching && (
+            <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+          )}
+        </div>
+
+        {/* Login prompt for gated models */}
+        {showLoginPrompt && (
+          <Alert>
+            <LogIn className="h-4 w-4" />
+            <AlertDescription className="flex items-center justify-between">
+              <span>Log in with HuggingFace to access gated models like Llama and Mistral.</span>
+              {onLoginClick && (
+                <Button variant="outline" size="sm" onClick={onLoginClick} className="ml-2">
+                  Login
+                </Button>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Error state */}
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              {error instanceof Error ? error.message : 'Failed to search models'}
+            </AlertDescription>
+          </Alert>
         )}
       </div>
 
-      {/* Login prompt for gated models */}
-      {showLoginPrompt && (
-        <Alert>
-          <LogIn className="h-4 w-4" />
-          <AlertDescription className="flex items-center justify-between">
-            <span>Log in with HuggingFace to access gated models like Llama and Mistral.</span>
-            {onLoginClick && (
-              <Button variant="outline" size="sm" onClick={onLoginClick} className="ml-2">
-                Login
-              </Button>
-            )}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {/* Error state */}
-      {error && (
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertDescription>
-            {error instanceof Error ? error.message : 'Failed to search models'}
-          </AlertDescription>
-        </Alert>
-      )}
-
       {/* Empty state */}
       {query.length < 2 && (
-        <div className="text-center py-16 text-slate-400">
+        <div className="glass-panel py-16 text-center text-slate-400">
           <Search className="h-12 w-12 mx-auto mb-4 text-slate-600" />
           <p className="text-slate-300">Enter at least 2 characters to search HuggingFace models</p>
           <p className="text-sm mt-2 text-slate-500">
@@ -104,7 +106,7 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapaci
 
       {/* Loading state for initial search */}
       {isLoading && query.length >= 2 && (
-        <div className="text-center py-16">
+        <div className="glass-panel py-16 text-center">
           <Loader2 className="h-8 w-8 mx-auto animate-spin text-cyan-400" />
           <p className="mt-4 text-slate-400">Searching compatible models...</p>
         </div>
@@ -112,7 +114,7 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapaci
 
       {/* No results */}
       {searchResults && searchResults.models.length === 0 && !isLoading && (
-        <div className="text-center py-16 text-slate-400">
+        <div className="glass-panel py-16 text-center text-slate-400">
           <AlertCircle className="h-12 w-12 mx-auto mb-4 text-slate-600" />
           <p className="text-slate-300">No compatible models found for &ldquo;{debouncedQuery}&rdquo;</p>
           <p className="text-sm mt-2 text-slate-500">
@@ -124,7 +126,7 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapaci
       {/* Results grid */}
       {searchResults && searchResults.models.length > 0 && (
         <>
-          <div className="text-sm text-muted-foreground">
+          <div className="glass-subtle inline-flex rounded-full px-3 py-1.5 text-sm text-muted-foreground">
             Showing {searchResults.models.length} of {searchResults.total} compatible models
           </div>
           

--- a/frontend/src/components/models/ModelCard.tsx
+++ b/frontend/src/components/models/ModelCard.tsx
@@ -68,13 +68,15 @@ export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: 
   return (
     <div
       className={cn(
-        "flex flex-col h-full group rounded-2xl p-5",
-        "bg-white/[0.03] border border-white/5",
+        "group relative flex h-full flex-col overflow-hidden rounded-[24px] p-5",
+        "border border-white/10 bg-white/[0.05] backdrop-blur-xl",
+        "shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_20px_45px_rgba(2,8,23,0.20)]",
         "transition-all duration-200 ease-out",
-        "hover:border-cyan-500/30 hover:shadow-glow-card hover:-translate-y-0.5"
+        "before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-gradient-to-b before:from-white/[0.08] before:to-transparent before:content-['']",
+        "hover:border-cyan-500/30 hover:shadow-glow-card hover:-translate-y-1"
       )}
     >
-      <div className="pb-3">
+      <div className="relative pb-3">
         <div className="flex items-start justify-between gap-2">
           <h3 className="text-lg font-semibold text-white leading-tight truncate group-hover:text-cyan-400 transition-colors duration-200">
             {model.name}
@@ -88,7 +90,7 @@ export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: 
         </p>
       </div>
 
-      <div className="flex-1">
+      <div className="relative flex-1">
         <p className="text-sm text-slate-500 mb-4 line-clamp-2">
           {model.description}
         </p>
@@ -136,7 +138,7 @@ export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: 
         </div>
       </div>
 
-      <div className="pt-4">
+      <div className="relative pt-4">
         <Button
           variant="ghost"
           onClick={handleDeploy}

--- a/frontend/src/components/models/ModelSearch.tsx
+++ b/frontend/src/components/models/ModelSearch.tsx
@@ -24,14 +24,14 @@ export function ModelSearch({
   onEngineToggle,
 }: ModelSearchProps) {
   return (
-    <div className="space-y-4">
+    <div className="glass-panel !p-4 space-y-4 md:!p-5">
       <div className="relative">
         <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
         <Input
           placeholder="Search models..."
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
-          className="pl-12 h-12 rounded-2xl bg-white/[0.03] border-white/5 text-base placeholder:text-slate-500"
+          className="h-12 rounded-2xl pl-12 text-base placeholder:text-slate-500"
         />
       </div>
 
@@ -42,10 +42,10 @@ export function ModelSearch({
             <button
               key={engine.value}
               className={cn(
-                'px-3 py-1.5 text-sm rounded-full transition-all duration-200 border',
+                'rounded-full border px-3 py-1.5 text-sm transition-all duration-200 backdrop-blur-md',
                 isSelected
-                  ? 'border-cyan-400 bg-cyan-400/10 text-cyan-400'
-                  : 'border-white/5 bg-white/[0.03] text-slate-400 hover:border-white/10 hover:text-slate-300'
+                  ? 'border-cyan-400/30 bg-cyan-400/12 text-cyan-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]'
+                  : 'border-white/10 bg-white/[0.04] text-slate-400 hover:border-white/15 hover:bg-white/[0.07] hover:text-slate-200'
               )}
               onClick={() => onEngineToggle(engine.value)}
             >

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -16,14 +16,14 @@ const badgeVariants = cva(
           "hover:bg-primary/25",
         ],
         secondary: [
-          "border-white/10 bg-white/[0.06] text-secondary-foreground",
+          "border-white/10 bg-white/[0.06] text-secondary-foreground backdrop-blur-md shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]",
           "hover:bg-white/[0.1]",
         ],
         destructive: [
           "border-transparent bg-destructive/15 text-destructive",
           "hover:bg-destructive/25",
         ],
-        outline: "text-foreground border-white/10",
+        outline: "border-white/12 bg-white/[0.04] text-foreground backdrop-blur-md shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]",
         success: [
           "border-transparent bg-green-500/15 text-green-600",
           "dark:bg-green-500/20 dark:text-green-400",

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -25,8 +25,8 @@ const buttonVariants = cva(
           "hover:bg-red-500/20",
         ],
         outline: [
-          "border border-white/10 bg-white/[0.03]",
-          "hover:bg-white/[0.06] hover:text-accent-foreground hover:border-white/20",
+          "border border-white/12 bg-white/[0.05] backdrop-blur-md shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]",
+          "hover:bg-white/[0.08] hover:text-accent-foreground hover:border-white/20",
         ],
         secondary: [
           "bg-secondary text-secondary-foreground",

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -8,10 +8,10 @@ const cardVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-white/[0.03] border-white/5 shadow-soft-sm",
-        elevated: "bg-white/[0.05] border-white/10 shadow-soft-md",
-        outline: "bg-transparent border-white/10 shadow-none",
-        glass: "bg-white/[0.03] border-white/5 backdrop-blur-xl shadow-soft-sm",
+        default: "overflow-hidden bg-white/[0.05] border-white/10 backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_18px_40px_rgba(2,8,23,0.18)]",
+        elevated: "overflow-hidden bg-white/[0.08] border-white/12 backdrop-blur-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_24px_50px_rgba(2,8,23,0.22)]",
+        outline: "bg-white/[0.02] border-white/10 backdrop-blur-lg shadow-none",
+        glass: "overflow-hidden bg-white/[0.06] border-white/10 backdrop-blur-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_24px_50px_rgba(2,8,23,0.20)]",
       },
       interactive: {
         true: [

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-white/10 bg-[#0F1419]/95 backdrop-blur-xl p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-3xl border border-white/12 bg-[#0F1419]/88 p-6 backdrop-blur-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_30px_80px_rgba(2,8,23,0.55)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -82,7 +82,7 @@ const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
       <div
         ref={ref}
         className={cn(
-          "flex flex-col items-center justify-center text-center py-12 px-6",
+          "glass-panel flex flex-col items-center justify-center px-6 py-12",
           "animate-fade-in",
           className
         )}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-2xl border border-white/5 bg-white/[0.03] px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-2xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/50 focus-visible:bg-white/[0.07] focus-visible:ring-2 focus-visible:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-2xl border border-white/5 bg-white/[0.03] px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:border-primary/50 focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-2xl border border-white/10 bg-white/[0.05] px-3 py-2 text-sm backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:border-primary/50 focus:bg-white/[0.07] focus:ring-2 focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border border-white/10 bg-[#0F1419]/95 backdrop-blur-xl text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-2xl border border-white/12 bg-[#0F1419]/88 text-popover-foreground backdrop-blur-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_24px_60px_rgba(2,8,23,0.45)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -116,7 +116,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-xl py-2 pl-8 pr-2 text-sm outline-none focus:bg-white/[0.08] focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ const TabsList = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center gap-1 border-b border-white/10 bg-transparent text-muted-foreground",
+      "inline-flex h-auto items-center justify-center gap-1 rounded-2xl border border-white/10 bg-white/[0.04] p-1.5 text-muted-foreground backdrop-blur-xl shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]",
       className
     )}
     {...props}
@@ -67,10 +67,10 @@ const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
         aria-selected={isSelected}
         onClick={() => onValueChange(value)}
         className={cn(
-          "inline-flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-b-2 -mb-px",
+          "inline-flex items-center justify-center whitespace-nowrap rounded-xl border border-transparent px-4 py-2 text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
           isSelected
-            ? "border-primary text-primary"
-            : "border-transparent text-slate-500 hover:text-foreground",
+            ? "bg-white/[0.08] text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_12px_28px_rgba(2,8,23,0.18)]"
+            : "text-slate-400 hover:bg-white/[0.05] hover:text-foreground",
           className
         )}
         {...props}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -136,28 +136,32 @@
 @layer components {
   /* Glassmorphism utilities */
   .glass {
-    @apply bg-white/70 dark:bg-white/[0.03] backdrop-blur-md border border-white/20 dark:border-white/5;
+    @apply border border-white/15 bg-white/[0.08] backdrop-blur-xl dark:border-white/10 dark:bg-white/[0.05];
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 24px 50px rgba(2, 8, 23, 0.18);
   }
 
   .glass-subtle {
-    @apply bg-white/50 dark:bg-white/[0.02] backdrop-blur-sm border border-white/10 dark:border-white/5;
+    @apply border border-white/10 bg-white/[0.04] backdrop-blur-lg dark:border-white/10 dark:bg-white/[0.03];
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
   }
 
   .glass-panel {
-    background: rgba(255, 255, 255, 0.03);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    border-radius: 16px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, rgba(255, 255, 255, 0.03) 100%);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 24px;
     padding: 24px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 24px 60px rgba(2, 8, 23, 0.22);
   }
 
   .glass-elevated {
-    background: rgba(255, 255, 255, 0.06);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 16px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.10) 0%, rgba(255, 255, 255, 0.05) 100%);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 24px;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.10), 0 28px 70px rgba(2, 8, 23, 0.28);
   }
 
   /* Gradient text utility */
@@ -219,6 +223,27 @@
 
   /* Background decor — kept minimal, no radial gradients */
   .bg-decor {
-    /* intentionally empty — clean dark background */
+    position: relative;
+    background:
+      radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 30%),
+      radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 24%),
+      linear-gradient(180deg, rgba(15, 20, 25, 0.94) 0%, rgba(11, 17, 24, 0.98) 100%);
+  }
+
+  .bg-decor::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(circle at 15% 20%, rgba(0, 217, 255, 0.09), transparent 32%),
+      radial-gradient(circle at 82% 14%, rgba(59, 130, 246, 0.10), transparent 26%),
+      radial-gradient(circle at 50% 100%, rgba(34, 211, 238, 0.06), transparent 34%);
+    opacity: 0.9;
+  }
+
+  .bg-decor > * {
+    position: relative;
+    z-index: 1;
   }
 }

--- a/frontend/src/pages/DeploymentsPage.tsx
+++ b/frontend/src/pages/DeploymentsPage.tsx
@@ -9,7 +9,7 @@ export function DeploymentsPage() {
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-center">
+      <div className="glass-panel flex flex-col items-center justify-center py-12 text-center">
         <p className="text-lg font-medium text-destructive">
           Failed to load deployments
         </p>
@@ -25,7 +25,7 @@ export function DeploymentsPage() {
 
   return (
     <div className="space-y-6 animate-slide-up">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      <div className="glass-panel flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-heading tracking-tight flex items-center gap-2">
             <Layers className="h-7 w-7 text-cyan-500" />

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -49,7 +49,7 @@ export function ModelsPage() {
   if (isLoading && activeTab === 'curated') {
     return (
       <div className="space-y-6">
-        <div className="text-center py-8">
+        <div className="glass-panel py-8 text-center">
           <h1 className="font-heading text-4xl flex items-center justify-center gap-3">
             Model Catalog
             <Sparkles className="h-7 w-7 text-cyan-400" />
@@ -65,7 +65,7 @@ export function ModelsPage() {
 
   if (error && activeTab === 'curated') {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-center">
+      <div className="glass-panel flex flex-col items-center justify-center py-12 text-center">
         <p className="text-lg font-medium text-destructive">
           Failed to load models
         </p>
@@ -79,53 +79,66 @@ export function ModelsPage() {
   return (
     <div className="space-y-6 animate-slide-up">
       {/* Hero section */}
-      <div className="text-center py-8">
-        <h1 className="font-heading text-4xl flex items-center justify-center gap-3">
-          Model Catalog
-          <Sparkles className="h-7 w-7 text-cyan-400" />
-        </h1>
-        <p className="text-slate-400 mt-2">
-          Browse curated models or search HuggingFace Hub
-        </p>
-        {models && (
-          <p className="text-xs text-slate-500 mt-1 tabular-nums">
-            {filteredModels.length} of {models.length} models
-          </p>
-        )}
-      </div>
+      <div className="glass-panel relative overflow-hidden">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.16),_transparent_34%),radial-gradient(circle_at_bottom_right,_rgba(59,130,246,0.12),_transparent_32%)]" />
 
-      {/* Tab navigation — underline variant */}
-      <div className="flex gap-6 border-b border-white/5">
-        <button
-          onClick={() => setActiveTab('curated')}
-          className={cn(
-            'flex items-center gap-2 px-1 py-2.5 text-sm font-medium transition-all duration-200 border-b-2 -mb-px',
-            activeTab === 'curated'
-              ? 'border-cyan-400 text-white'
-              : 'border-transparent text-slate-500 hover:text-slate-300'
-          )}
-        >
-          <BookMarked className={cn(
-            "h-4 w-4 transition-transform duration-200",
-            activeTab === 'curated' && "scale-110"
-          )} />
-          Curated Models
-        </button>
-        <button
-          onClick={() => setActiveTab('huggingface')}
-          className={cn(
-            'flex items-center gap-2 px-1 py-2.5 text-sm font-medium transition-all duration-200 border-b-2 -mb-px',
-            activeTab === 'huggingface'
-              ? 'border-cyan-400 text-white'
-              : 'border-transparent text-slate-500 hover:text-slate-300'
-          )}
-        >
-          <Search className={cn(
-            "h-4 w-4 transition-transform duration-200",
-            activeTab === 'huggingface' && "scale-110"
-          )} />
-          HuggingFace Hub
-        </button>
+        <div className="relative flex flex-col gap-6">
+          <div className="text-center">
+            <h1 className="font-heading text-4xl flex items-center justify-center gap-3">
+              Model Catalog
+              <Sparkles className="h-7 w-7 text-cyan-400" />
+            </h1>
+            <p className="text-slate-400 mt-2">
+              Browse curated models or search HuggingFace Hub
+            </p>
+          </div>
+
+          <div className="flex justify-center">
+            <div className="glass-subtle inline-flex flex-wrap items-center justify-center gap-1 rounded-2xl p-1.5">
+              <button
+                onClick={() => setActiveTab('curated')}
+                className={cn(
+                  'flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-all duration-200',
+                  activeTab === 'curated'
+                    ? 'bg-white/[0.08] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_12px_28px_rgba(2,8,23,0.18)]'
+                    : 'text-slate-400 hover:bg-white/[0.05] hover:text-slate-200'
+                )}
+              >
+                <BookMarked className={cn(
+                  "h-4 w-4 transition-transform duration-200",
+                  activeTab === 'curated' && "scale-110"
+                )} />
+                Curated Models
+              </button>
+              <button
+                onClick={() => setActiveTab('huggingface')}
+                className={cn(
+                  'flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-all duration-200',
+                  activeTab === 'huggingface'
+                    ? 'bg-white/[0.08] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_12px_28px_rgba(2,8,23,0.18)]'
+                    : 'text-slate-400 hover:bg-white/[0.05] hover:text-slate-200'
+                )}
+              >
+                <Search className={cn(
+                  "h-4 w-4 transition-transform duration-200",
+                  activeTab === 'huggingface' && "scale-110"
+                )} />
+                HuggingFace Hub
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-center gap-2 text-xs text-slate-300">
+            <div className="glass-subtle rounded-full px-3 py-1.5">
+              Curated picks and live hub search in one place
+            </div>
+            {models && (
+              <div className="glass-subtle rounded-full px-3 py-1.5 tabular-nums">
+                {filteredModels.length} of {models.length} ready to explore
+              </div>
+            )}
+          </div>
+        </div>
       </div>
 
       {/* Curated models tab */}


### PR DESCRIPTION
## Summary
- strengthen the shared glass tokens and ambient background so blur reads consistently across the app shell
- add glass treatments to the header, sidebar, model catalog hero, search panels, and model cards
- update shared controls like inputs, selects, tabs, cards, and empty states so the look carries through tastefully

## Testing
- `bun run --filter '@airunway/frontend' build`
- `bun run test` *(fails in existing backend timeout cases for `GET /api/costs/node-pools` in `backend/src/routes/costs.test.ts`, unrelated to these frontend-only changes)*