### PR TITLE
Fix deployment port-forward commands for runtime service ports

### DIFF
--- a/backend/src/services/deploymentStatus.test.ts
+++ b/backend/src/services/deploymentStatus.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'bun:test';
+import { toDeploymentStatus, type ModelDeployment } from '@airunway/shared';
+
+interface ModelDeploymentOverrides {
+  metadata?: Partial<ModelDeployment['metadata']>;
+  spec?: Partial<ModelDeployment['spec']>;
+  status?: Partial<NonNullable<ModelDeployment['status']>>;
+}
+
+function createModelDeployment(overrides: ModelDeploymentOverrides = {}): ModelDeployment {
+  return {
+    apiVersion: 'airunway.ai/v1alpha1',
+    kind: 'ModelDeployment',
+    metadata: {
+      name: 'test-deploy',
+      namespace: 'default',
+      creationTimestamp: '2026-03-17T00:00:00Z',
+      ...overrides.metadata,
+    },
+    spec: {
+      model: {
+        id: 'meta-llama/Llama-3.2-1B-Instruct',
+      },
+      engine: {
+        type: 'vllm',
+      },
+      serving: {
+        mode: 'aggregated',
+      },
+      ...overrides.spec,
+    },
+    status: {
+      phase: 'Running',
+      provider: {
+        name: 'kaito',
+      },
+      replicas: {
+        desired: 1,
+        ready: 1,
+        available: 1,
+      },
+      ...overrides.status,
+    },
+  };
+}
+
+describe('toDeploymentStatus', () => {
+  test('uses the provider endpoint service and service port for frontend access', () => {
+    const deployment = createModelDeployment({
+      metadata: {
+        name: 'llama3-2-1b-3aeb',
+        namespace: 'kaito-workspace',
+      },
+      spec: {
+        model: {
+          id: 'meta-llama/Llama-3.2-1B-Instruct',
+        },
+        engine: {
+          type: 'llamacpp',
+        },
+      },
+      status: {
+        endpoint: {
+          service: 'llama3-2-1b-3aeb',
+          port: 80,
+        },
+      },
+    });
+
+    expect(toDeploymentStatus(deployment).frontendService).toBe('llama3-2-1b-3aeb:80');
+  });
+
+  test('falls back to the deployment name when the provider endpoint is missing', () => {
+    const deployment = createModelDeployment({
+      metadata: {
+        name: 'legacy-deploy',
+      },
+      status: {
+        endpoint: undefined,
+      },
+    });
+
+    expect(toDeploymentStatus(deployment).frontendService).toBe('legacy-deploy');
+  });
+});

--- a/frontend/src/lib/port-forward.test.ts
+++ b/frontend/src/lib/port-forward.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { buildPortForwardCommand } from '@airunway/shared'
+
+describe('buildPortForwardCommand', () => {
+  it('uses the frontend service port for AIKit llama.cpp deployments', () => {
+    const command = buildPortForwardCommand({
+      name: 'llama3-2-1b-3aeb',
+      namespace: 'kaito-workspace',
+      frontendService: 'llama3-2-1b-3aeb:80',
+    })
+
+    expect(command).toBe('kubectl port-forward svc/llama3-2-1b-3aeb 8000:80 -n kaito-workspace')
+  })
+
+  it('respects an explicitly encoded frontend service port', () => {
+    const command = buildPortForwardCommand({
+      name: 'qwen3-0-6b-vllm-abc123',
+      namespace: 'airunway-system',
+      frontendService: 'qwen3-0-6b-vllm-abc123-frontend:9000',
+    })
+
+    expect(command).toBe('kubectl port-forward svc/qwen3-0-6b-vllm-abc123-frontend 8000:9000 -n airunway-system')
+  })
+})

--- a/frontend/src/pages/DeploymentDetailsPage.tsx
+++ b/frontend/src/pages/DeploymentDetailsPage.tsx
@@ -9,6 +9,7 @@ import { MetricsTab } from '@/components/metrics'
 import { formatRelativeTime, generateAynaUrl } from '@/lib/utils'
 import { Loader2, ArrowLeft, Trash2, Copy, Terminal, MessageSquare, Globe, HardDrive } from 'lucide-react'
 import { useState } from 'react'
+import { buildPortForwardCommand } from '@airunway/shared'
 import {
   Dialog,
   DialogContent,
@@ -68,9 +69,7 @@ export function DeploymentDetailsPage() {
 
   const copyPortForwardCommand = () => {
     if (!deployment) return
-    // Parse frontendService which may include port (e.g., "name:8000" or "name-vllm:8000")
-    const [serviceName, servicePort] = (deployment.frontendService || `${deployment.name}-frontend:8000`).split(':')
-    const command = `kubectl port-forward svc/${serviceName} 8000:${servicePort || '8000'} -n ${deployment.namespace}`
+    const command = buildPortForwardCommand(deployment)
     navigator.clipboard.writeText(command)
     toast({
       title: 'Copied to clipboard',
@@ -102,9 +101,7 @@ export function DeploymentDetailsPage() {
     )
   }
 
-  // Parse frontendService which may include port (e.g., "name:5000" or "name-vllm:8000")
-  const [serviceName, servicePort] = (deployment.frontendService || `${deployment.name}-frontend:8000`).split(':')
-  const portForwardCommand = `kubectl port-forward svc/${serviceName} 8000:${servicePort || '8000'} -n ${deployment.namespace}`
+  const portForwardCommand = buildPortForwardCommand(deployment)
 
   // Gateway endpoint (when available)
   const hasGateway = !!deployment.gateway?.endpoint

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -58,7 +58,7 @@ export const mockDeployments = [
       },
     ],
     createdAt: new Date().toISOString(),
-    frontendService: 'qwen3-0-6b-vllm-abc123-frontend',
+    frontendService: 'qwen3-0-6b-vllm-abc123-frontend:8000',
   },
 ]
 

--- a/plugins/headlamp/src/lib/port-forward.test.ts
+++ b/plugins/headlamp/src/lib/port-forward.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { buildPortForwardCommand } from '@airunway/shared';
+
+describe('buildPortForwardCommand', () => {
+  it('builds the AIKit llama.cpp port-forward command with the service port', () => {
+    const command = buildPortForwardCommand({
+      name: 'llama3-2-1b-3aeb',
+      namespace: 'kaito-workspace',
+      frontendService: 'llama3-2-1b-3aeb:80',
+    });
+
+    expect(command).toBe('kubectl port-forward svc/llama3-2-1b-3aeb 8000:80 -n kaito-workspace');
+  });
+
+  it('keeps using an explicit frontend service port when one is provided', () => {
+    const command = buildPortForwardCommand({
+      name: 'custom-runtime-deploy',
+      namespace: 'airunway-system',
+      frontendService: 'custom-runtime-deploy-frontend:7000',
+    });
+
+    expect(command).toBe('kubectl port-forward svc/custom-runtime-deploy-frontend 8000:7000 -n airunway-system');
+  });
+});

--- a/plugins/headlamp/src/pages/DeploymentDetails.tsx
+++ b/plugins/headlamp/src/pages/DeploymentDetails.tsx
@@ -21,6 +21,7 @@ import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { Icon } from '@iconify/react';
+import { buildPortForwardCommand } from '@airunway/shared';
 import { useApiClient } from '../lib/api-client';
 import type { DeploymentStatus, PodStatus, MetricsResponse, PodLogsResponse, DeploymentPhase } from '@airunway/shared';
 import { MetricsPanel } from '../components/MetricsPanel';
@@ -151,8 +152,7 @@ export function DeploymentDetails() {
   // Copy port-forward command
   const copyPortForwardCommand = useCallback(() => {
     if (!deployment) return;
-    const [serviceName, servicePort] = (deployment.frontendService || `${deployment.name}-frontend:8000`).split(':');
-    const command = `kubectl port-forward svc/${serviceName} 8000:${servicePort || '8000'} -n ${deployment.namespace}`;
+    const command = buildPortForwardCommand(deployment);
     navigator.clipboard.writeText(command);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
@@ -200,8 +200,7 @@ export function DeploymentDetails() {
   }
 
   // Generate port-forward command
-  const [serviceName, servicePort] = (deployment.frontendService || `${deployment.name}-frontend:8000`).split(':');
-  const portForwardCommand = `kubectl port-forward svc/${serviceName} 8000:${servicePort || '8000'} -n ${deployment.namespace}`;
+  const portForwardCommand = buildPortForwardCommand(deployment);
 
   // Tab content components
   const OverviewContent = (

--- a/shared/types/deployment.ts
+++ b/shared/types/deployment.ts
@@ -191,6 +191,11 @@ export interface GatewayModelInfo {
   ready: boolean;
 }
 
+export interface EndpointStatus {
+  service?: string;
+  port?: number;
+}
+
 export interface ModelDeploymentStatus {
   phase?: DeploymentPhase;
   message?: string;
@@ -204,7 +209,7 @@ export interface ModelDeploymentStatus {
     desired: number;
     ready: number;
   };
-  endpoint?: string;
+  endpoint?: EndpointStatus;
   gateway?: GatewayStatus;
   conditions?: Condition[];
   observedGeneration?: number;
@@ -251,6 +256,7 @@ export interface DeploymentStatus {
   conditions?: Condition[];
   pods: PodStatus[];
   createdAt: string;
+  // Service reference in "name[:port]" form used by the UI/plugin for access commands.
   frontendService?: string;
   storage?: StorageSpec;
   prefillReplicas?: {
@@ -265,6 +271,62 @@ export interface DeploymentStatus {
 }
 
 // ==================== Conversion Functions ====================
+
+const LEGACY_FRONTEND_SERVICE_PORT = 8000;
+
+export interface FrontendServiceRef {
+  serviceName: string;
+  servicePort?: number;
+}
+
+export function formatFrontendService(serviceName?: string, servicePort?: number): string | undefined {
+  if (!serviceName) {
+    return undefined;
+  }
+
+  if (servicePort && servicePort > 0) {
+    return `${serviceName}:${servicePort}`;
+  }
+
+  return serviceName;
+}
+
+export function parseFrontendService(frontendService?: string): FrontendServiceRef | undefined {
+  if (!frontendService) {
+    return undefined;
+  }
+
+  const [serviceName, rawServicePort] = frontendService.split(':', 2);
+
+  if (!serviceName) {
+    return undefined;
+  }
+
+  if (!rawServicePort) {
+    return { serviceName };
+  }
+
+  const servicePort = Number.parseInt(rawServicePort, 10);
+  if (Number.isNaN(servicePort) || servicePort <= 0) {
+    return { serviceName };
+  }
+
+  return {
+    serviceName,
+    servicePort,
+  };
+}
+
+export function buildPortForwardCommand(
+  deployment: Pick<DeploymentStatus, 'name' | 'namespace' | 'frontendService'>,
+  localPort = LEGACY_FRONTEND_SERVICE_PORT
+): string {
+  const frontendService = parseFrontendService(deployment.frontendService);
+  const serviceName = frontendService?.serviceName || `${deployment.name}-frontend`;
+  const servicePort = frontendService?.servicePort || LEGACY_FRONTEND_SERVICE_PORT;
+
+  return `kubectl port-forward svc/${serviceName} ${localPort}:${servicePort} -n ${deployment.namespace}`;
+}
 
 export function toModelDeploymentSpec(config: DeploymentConfig): ModelDeploymentSpec {
   const spec: ModelDeploymentSpec = {
@@ -336,6 +398,7 @@ export function toModelDeploymentSpec(config: DeploymentConfig): ModelDeployment
 export function toDeploymentStatus(md: ModelDeployment, pods: PodStatus[] = []): DeploymentStatus {
   const status = md.status || {};
   const spec = md.spec;
+  const frontendServiceName = status.endpoint?.service || md.metadata.name;
 
   return {
     name: md.metadata.name,
@@ -354,7 +417,7 @@ export function toDeploymentStatus(md: ModelDeployment, pods: PodStatus[] = []):
     conditions: status.conditions,
     pods,
     createdAt: md.metadata.creationTimestamp || new Date().toISOString(),
-    frontendService: md.metadata.name,
+    frontendService: formatFrontendService(frontendServiceName, status.endpoint?.port),
     prefillReplicas: status.prefillReplicas,
     decodeReplicas: status.decodeReplicas,
     gateway: status.gateway,


### PR DESCRIPTION
## Summary
- preserve provider endpoint service ports in deployment status instead of dropping them before the UI sees them
- use a shared port-forward command builder in both the main UI and the Headlamp plugin
- add coverage for AIKit/llama.cpp service port 80 and explicit frontend service ports

## Root Cause
`toDeploymentStatus()` was always collapsing `frontendService` to the deployment name, so the UI and Headlamp plugin had to guess the port and fell back to `8000` when no `:port` suffix was present. That was wrong for AIKit/llama.cpp, where the Service exposes port `80` even though the target port is `5000`.

## Testing
- `bun run --filter @airunway/shared build`\n- `bun run --filter @airunway/frontend build`\n- `bun run --filter @airunway/frontend test -- src/lib/port-forward.test.ts`\n- `cd backend && bun test src/services/deploymentStatus.test.ts`\n- `cd backend && bunx tsc --noEmit --pretty false --target ES2020 --module CommonJS --moduleResolution node --strict --esModuleInterop --skipLibCheck --resolveJsonModule src/services/deploymentStatus.test.ts`\n- `cd plugins/headlamp && bun run test -- src/lib/port-forward.test.ts`\n\n## Notes\n- `bun run test` still surfaces existing unrelated timeouts in `backend/src/routes/costs.test.ts` around `/api/costs/node-pools`.\n- `cd plugins/headlamp && bun run tsc` still reports existing package-wide type errors unrelated to this port-forward change.