### PR TITLE
Fix KAITO CPU manifest preview showing GPU resources

### DIFF
--- a/backend/src/routes/deployments.test.ts
+++ b/backend/src/routes/deployments.test.ts
@@ -147,6 +147,35 @@ describe('Deployment Routes', () => {
       expect(data.resources[0].manifest.spec.image).toBe('ghcr.io/kaito-project/aikit/llama3.2:3b');
       expect(data.resources[0].manifest.spec.provider.name).toBe('kaito');
     });
+
+    test('omits GPU resources for KAITO CPU preview manifests', async () => {
+      restores.push(
+        mockServiceMethod(configService, 'getDefaultNamespace', async () => 'kaito-workspace'),
+      );
+
+      const res = await app.request('/api/deployments/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...validDeploymentBody,
+          namespace: 'kaito-workspace',
+          provider: 'kaito',
+          engine: 'llamacpp',
+          modelId: 'unsloth/NVIDIA-Nemotron-3-Nano-4B-GGUF',
+          modelSource: 'huggingface',
+          ggufFile: 'NVIDIA-Nemotron-3-Nano-4B-Q4_K_M.gguf',
+          ggufRunMode: 'direct',
+          computeType: 'cpu',
+          resources: { gpu: 1 },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.resources[0].manifest.spec.resources).toBeUndefined();
+      expect(data.resources[0].manifest.spec.engine.type).toBe('llamacpp');
+    });
   });
 
   describe('POST /api/deployments - storage validation', () => {

--- a/backend/src/services/gpuValidation.test.ts
+++ b/backend/src/services/gpuValidation.test.ts
@@ -157,6 +157,21 @@ describe('calculateRequiredGpus', () => {
     expect(result.prefillPerWorker).toBe(2);
     expect(result.decodePerWorker).toBe(1);
   });
+
+  test('treats CPU deployments as requiring zero GPUs', () => {
+    const result = calculateRequiredGpus({
+      ...baseConfig,
+      provider: 'kaito',
+      engine: 'llamacpp',
+      computeType: 'cpu',
+      resources: { gpu: 4 },
+    });
+
+    expect(result.total).toBe(0);
+    expect(result.maxPerWorker).toBe(0);
+    expect(result.prefillPerWorker).toBe(0);
+    expect(result.decodePerWorker).toBe(0);
+  });
 });
 
 describe('validateGpuFit', () => {
@@ -227,6 +242,23 @@ describe('validateGpuFit', () => {
     );
     expect(result.fits).toBe(false);
     expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('skips GPU warnings for CPU deployments', () => {
+    const result = validateGpuFit(
+      {
+        ...baseConfig,
+        provider: 'kaito',
+        engine: 'llamacpp',
+        computeType: 'cpu',
+        resources: { gpu: 4 },
+      },
+      clusterWithCapacity(0, 0),
+      4
+    );
+
+    expect(result.fits).toBe(true);
+    expect(result.warnings).toHaveLength(0);
   });
 });
 

--- a/backend/src/services/gpuValidation.ts
+++ b/backend/src/services/gpuValidation.ts
@@ -1,4 +1,4 @@
-import type { DeploymentConfig } from '@airunway/shared';
+import { isCpuOnlyDeployment, type DeploymentConfig } from '@airunway/shared';
 import type { ClusterGpuCapacity } from './kubernetes';
 
 /**
@@ -93,6 +93,15 @@ export function calculateRequiredGpus(config: DeploymentConfig): {
   prefillPerWorker: number;
   decodePerWorker: number;
 } {
+  if (isCpuOnlyDeployment(config)) {
+    return {
+      total: 0,
+      maxPerWorker: 0,
+      prefillPerWorker: 0,
+      decodePerWorker: 0,
+    };
+  }
+
   const gpusPerReplica = config.resources?.gpu ?? 1;
 
   if (config.mode === 'disaggregated') {
@@ -149,6 +158,13 @@ export function validateGpuFit(
   capacity: ClusterGpuCapacity,
   modelMinGpus: number = 1
 ): GpuFitResult {
+  if (isCpuOnlyDeployment(config)) {
+    return {
+      fits: true,
+      warnings: [],
+    };
+  }
+
   const warnings: GpuWarning[] = [];
   const required = calculateRequiredGpus(config);
 

--- a/shared/types/deployment.ts
+++ b/shared/types/deployment.ts
@@ -391,7 +391,12 @@ function resolveEngineType(config: DeploymentConfig): EngineType {
   return config.engine as EngineType;
 }
 
+export function isCpuOnlyDeployment(config: Pick<DeploymentConfig, 'computeType'>): boolean {
+  return config.computeType === 'cpu';
+}
+
 export function toModelDeploymentSpec(config: DeploymentConfig): ModelDeploymentSpec {
+  const cpuOnlyDeployment = isCpuOnlyDeployment(config);
   const spec: ModelDeploymentSpec = {
     model: {
       id: config.modelId,
@@ -424,7 +429,7 @@ export function toModelDeploymentSpec(config: DeploymentConfig): ModelDeployment
     spec.scaling = {
       replicas: config.replicas,
     };
-    if (config.resources?.gpu) {
+    if (!cpuOnlyDeployment && config.resources?.gpu) {
       spec.resources = {
         gpu: {
           count: config.resources.gpu,
@@ -437,11 +442,15 @@ export function toModelDeploymentSpec(config: DeploymentConfig): ModelDeployment
     spec.scaling = {
       prefill: {
         replicas: config.prefillReplicas || 1,
-        gpu: config.prefillGpus ? { count: config.prefillGpus, type: 'nvidia.com/gpu' } : undefined,
+        gpu: !cpuOnlyDeployment && config.prefillGpus
+          ? { count: config.prefillGpus, type: 'nvidia.com/gpu' }
+          : undefined,
       },
       decode: {
         replicas: config.decodeReplicas || 1,
-        gpu: config.decodeGpus ? { count: config.decodeGpus, type: 'nvidia.com/gpu' } : undefined,
+        gpu: !cpuOnlyDeployment && config.decodeGpus
+          ? { count: config.decodeGpus, type: 'nvidia.com/gpu' }
+          : undefined,
       },
     };
   }


### PR DESCRIPTION
## Description

Fixes the KAITO CPU configuration path so manifest previews no longer show stale GPU resources after selecting CPU compute.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
User report: we selected cpu but manifest preview is showing gpu in resources

Trace the KAITO configuration flow, fix the bug so CPU selections propagate correctly into the manifest preview and backend validation path, add regression tests, run the relevant tests, and then create a PR.
```

**AI Tool:** Codex

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

- Relates to a user-reported KAITO CPU manifest preview mismatch.

## Changes Made

- Prevent CPU-only deployments from emitting GPU resource requests in the shared manifest conversion path.
- Treat KAITO CPU deployments as requiring zero GPUs in backend GPU-fit validation.
- Add regression coverage for KAITO CPU preview manifests and CPU GPU-fit behavior.

## Testing

- [x] Unit tests pass (`bun run test`)
- [ ] Manual testing performed
- [ ] Tested with a Kubernetes cluster

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Screenshots

## Additional Notes

- `bun run lint` currently fails before linting because this checkout does not include an ESLint config file.
- `bun run build` succeeds for `shared` and `frontend`, but the backend TypeScript build hit a local Node heap out-of-memory condition.
