### PR TITLE
Retry gateway model-name discovery for KAITO llama.cpp

### DIFF
--- a/controller/internal/controller/gateway_reconciler.go
+++ b/controller/internal/controller/gateway_reconciler.go
@@ -45,12 +45,12 @@ import (
 
 // reconcileGateway creates or updates InferencePool and HTTPRoute resources
 // for a ModelDeployment that has gateway integration enabled.
-func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *airunwayv1alpha1.ModelDeployment) error {
+func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *airunwayv1alpha1.ModelDeployment) (bool, error) {
 	logger := log.FromContext(ctx)
 
 	// Skip if no gateway detector configured
 	if r.GatewayDetector == nil {
-		return nil
+		return false, nil
 	}
 
 	// Skip if gateway CRDs are not available
@@ -60,13 +60,13 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 			logger.Info("Gateway explicitly enabled but Gateway API Inference Extension CRDs not found", "name", md.Name)
 			r.setCondition(md, airunwayv1alpha1.ConditionTypeGatewayReady, metav1.ConditionFalse, "CRDsNotAvailable", "Gateway API Inference Extension CRDs are not installed in the cluster")
 		}
-		return nil
+		return false, nil
 	}
 
 	// Skip if explicitly disabled
 	if md.Spec.Gateway != nil && md.Spec.Gateway.Enabled != nil && !*md.Spec.Gateway.Enabled {
 		logger.V(1).Info("Gateway integration explicitly disabled", "name", md.Name)
-		return nil
+		return false, nil
 	}
 
 	// Resolve gateway configuration
@@ -74,7 +74,7 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 	if err != nil {
 		logger.Info("No gateway found for routing, skipping gateway reconciliation", "reason", err.Error())
 		r.setCondition(md, airunwayv1alpha1.ConditionTypeGatewayReady, metav1.ConditionFalse, "NoGateway", err.Error())
-		return nil
+		return false, nil
 	}
 
 	// Determine target port for InferencePool (needs the pod/container port, not service port)
@@ -97,17 +97,18 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 	// Create or update InferencePool
 	if err := r.reconcileInferencePool(ctx, md, port); err != nil {
 		r.setCondition(md, airunwayv1alpha1.ConditionTypeGatewayReady, metav1.ConditionFalse, "InferencePoolFailed", err.Error())
-		return fmt.Errorf("reconciling InferencePool: %w", err)
+		return false, fmt.Errorf("reconciling InferencePool: %w", err)
 	}
 
 	// Create or update EPP (Endpoint Picker Proxy) for the InferencePool
 	if err := r.reconcileEPP(ctx, md); err != nil {
 		r.setCondition(md, airunwayv1alpha1.ConditionTypeGatewayReady, metav1.ConditionFalse, "EPPFailed", err.Error())
-		return fmt.Errorf("reconciling EPP: %w", err)
+		return false, fmt.Errorf("reconciling EPP: %w", err)
 	}
 
 	// Resolve model name early (needed for HTTPRoute header match and status)
-	modelName := r.resolveModelName(ctx, md)
+	resolution := r.resolveModelNameResolution(ctx, md)
+	modelName := resolution.name
 
 	// Create or update HTTPRoute (skip if user provides their own)
 	if md.Spec.Gateway != nil && md.Spec.Gateway.HTTPRouteRef != "" {
@@ -115,7 +116,7 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 	} else {
 		if err := r.reconcileHTTPRoute(ctx, md, gwConfig, modelName); err != nil {
 			r.setCondition(md, airunwayv1alpha1.ConditionTypeGatewayReady, metav1.ConditionFalse, "HTTPRouteFailed", err.Error())
-			return fmt.Errorf("reconciling HTTPRoute: %w", err)
+			return false, fmt.Errorf("reconciling HTTPRoute: %w", err)
 		}
 	}
 
@@ -128,7 +129,7 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 	r.setCondition(md, airunwayv1alpha1.ConditionTypeGatewayReady, metav1.ConditionTrue, "GatewayConfigured", "InferencePool and HTTPRoute created")
 
 	logger.Info("Gateway resources reconciled", "name", md.Name, "gateway", gwConfig.GatewayName, "model", modelName)
-	return nil
+	return resolution.retry, nil
 }
 
 // resolveGatewayConfig determines which Gateway to use as the HTTPRoute parent.
@@ -647,15 +648,24 @@ func (r *ModelDeploymentReconciler) resolveGatewayEndpoint(ctx context.Context, 
 	return ""
 }
 
+type modelNameResolution struct {
+	name  string
+	retry bool
+}
+
 // resolveModelName determines the model name for gateway routing.
 // Priority: spec.gateway.modelName > spec.model.servedName > auto-discovered from /v1/models > spec.model.id
 func (r *ModelDeploymentReconciler) resolveModelName(ctx context.Context, md *airunwayv1alpha1.ModelDeployment) string {
+	return r.resolveModelNameResolution(ctx, md).name
+}
+
+func (r *ModelDeploymentReconciler) resolveModelNameResolution(ctx context.Context, md *airunwayv1alpha1.ModelDeployment) modelNameResolution {
 	// Use explicit overrides first
 	if md.Spec.Gateway != nil && md.Spec.Gateway.ModelName != "" {
-		return md.Spec.Gateway.ModelName
+		return modelNameResolution{name: md.Spec.Gateway.ModelName}
 	}
 	if shouldUseServedNameForGateway(md) {
-		return md.Spec.Model.ServedName
+		return modelNameResolution{name: md.Spec.Model.ServedName}
 	}
 
 	// Auto-discover from the running model server
@@ -670,11 +680,19 @@ func (r *ModelDeploymentReconciler) resolveModelName(ctx context.Context, md *ai
 		}
 		if discovered := r.discoverModelName(ctx, md.Status.Endpoint.Service, md.Namespace, port); discovered != "" {
 			log.FromContext(ctx).Info("Auto-discovered model name from server", "name", md.Name, "modelName", discovered)
-			return discovered
+			return modelNameResolution{name: discovered}
+		}
+
+		return modelNameResolution{
+			name:  md.Spec.Model.ID,
+			retry: shouldRetryGatewayModelNameDiscovery(md),
 		}
 	}
 
-	return md.Spec.Model.ID
+	return modelNameResolution{
+		name:  md.Spec.Model.ID,
+		retry: shouldRetryGatewayModelNameDiscovery(md),
+	}
 }
 
 func shouldUseServedNameForGateway(md *airunwayv1alpha1.ModelDeployment) bool {
@@ -683,6 +701,20 @@ func shouldUseServedNameForGateway(md *airunwayv1alpha1.ModelDeployment) bool {
 	}
 
 	if md.ResolvedEngineType() == airunwayv1alpha1.EngineTypeLlamaCpp && resolvedProviderName(md) == "kaito" {
+		return false
+	}
+
+	return true
+}
+
+func shouldRetryGatewayModelNameDiscovery(md *airunwayv1alpha1.ModelDeployment) bool {
+	if md.ResolvedEngineType() != airunwayv1alpha1.EngineTypeLlamaCpp {
+		return false
+	}
+	if resolvedProviderName(md) != "kaito" {
+		return false
+	}
+	if md.Spec.Gateway != nil && md.Spec.Gateway.ModelName != "" {
 		return false
 	}
 

--- a/controller/internal/controller/gateway_reconciler_test.go
+++ b/controller/internal/controller/gateway_reconciler_test.go
@@ -260,7 +260,7 @@ func TestGateway_DisabledSkipsCreation(t *testing.T) {
 	r := newTestReconciler(scheme, detector, md)
 	ctx := context.Background()
 
-	err := r.reconcileGateway(ctx, md)
+	_, err := r.reconcileGateway(ctx, md)
 	if err != nil {
 		t.Fatalf("reconcileGateway failed: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestGateway_NotAvailableSkipsSilently(t *testing.T) {
 	r := newTestReconciler(scheme, detector, md)
 	ctx := context.Background()
 
-	err := r.reconcileGateway(ctx, md)
+	_, err := r.reconcileGateway(ctx, md)
 	if err != nil {
 		t.Fatalf("expected no error when gateway not available, got: %v", err)
 	}
@@ -415,7 +415,7 @@ func TestGateway_NilDetectorSkipsSilently(t *testing.T) {
 	r := newTestReconciler(scheme, nil, md)
 	ctx := context.Background()
 
-	err := r.reconcileGateway(ctx, md)
+	_, err := r.reconcileGateway(ctx, md)
 	if err != nil {
 		t.Fatalf("expected no error when detector is nil, got: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestGateway_StatusUpdate(t *testing.T) {
 	r := newTestReconciler(scheme, detector, md)
 	ctx := context.Background()
 
-	err := r.reconcileGateway(ctx, md)
+	_, err := r.reconcileGateway(ctx, md)
 	if err != nil {
 		t.Fatalf("reconcileGateway failed: %v", err)
 	}
@@ -480,7 +480,7 @@ func TestGateway_StatusEndpointFromGatewayAddress(t *testing.T) {
 	r := newTestReconciler(scheme, detector, md, gw)
 	ctx := context.Background()
 
-	err := r.reconcileGateway(ctx, md)
+	_, err := r.reconcileGateway(ctx, md)
 	if err != nil {
 		t.Fatalf("reconcileGateway failed: %v", err)
 	}
@@ -503,7 +503,7 @@ func TestGateway_StatusModelNameOverride(t *testing.T) {
 	r := newTestReconciler(scheme, detector, md)
 	ctx := context.Background()
 
-	err := r.reconcileGateway(ctx, md)
+	_, err := r.reconcileGateway(ctx, md)
 	if err != nil {
 		t.Fatalf("reconcileGateway failed: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestGateway_StatusServedNameFallback(t *testing.T) {
 	r := newTestReconciler(scheme, detector, md)
 	ctx := context.Background()
 
-	err := r.reconcileGateway(ctx, md)
+	_, err := r.reconcileGateway(ctx, md)
 	if err != nil {
 		t.Fatalf("reconcileGateway failed: %v", err)
 	}
@@ -601,6 +601,49 @@ func TestGateway_KaitoLlamaCppServedNameFallsBackToModelID(t *testing.T) {
 	name := r.resolveModelName(ctx, md)
 	if name != "meta-llama/Llama-3-8B" {
 		t.Errorf("expected fallback to spec.model.id %q, got %q", "meta-llama/Llama-3-8B", name)
+	}
+}
+
+func TestGateway_KaitoLlamaCppFallbackRequestsRetry(t *testing.T) {
+	scheme := newTestScheme()
+	md := newModelDeployment("test-model", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "kaito"}
+	md.Spec.Engine.Type = airunwayv1alpha1.EngineTypeLlamaCpp
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{
+		Service: "nonexistent-svc",
+		Port:    8080,
+	}
+	detector := fakeDetector(true, "my-gateway", "gateway-ns")
+	r := newTestReconciler(scheme, detector, md)
+	ctx := context.Background()
+
+	resolution := r.resolveModelNameResolution(ctx, md)
+	if resolution.name != "meta-llama/Llama-3-8B" {
+		t.Fatalf("expected fallback to spec.model.id %q, got %q", "meta-llama/Llama-3-8B", resolution.name)
+	}
+	if !resolution.retry {
+		t.Fatal("expected failed Kaito llama.cpp discovery to request a retry")
+	}
+}
+
+func TestGateway_ModelNameOverrideSkipsRetry(t *testing.T) {
+	scheme := newTestScheme()
+	md := newModelDeployment("test-model", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "kaito"}
+	md.Spec.Engine.Type = airunwayv1alpha1.EngineTypeLlamaCpp
+	md.Spec.Gateway = &airunwayv1alpha1.GatewaySpec{
+		ModelName: "stable-name",
+	}
+	detector := fakeDetector(true, "my-gateway", "gateway-ns")
+	r := newTestReconciler(scheme, detector, md)
+	ctx := context.Background()
+
+	resolution := r.resolveModelNameResolution(ctx, md)
+	if resolution.name != "stable-name" {
+		t.Fatalf("expected explicit override %q, got %q", "stable-name", resolution.name)
+	}
+	if resolution.retry {
+		t.Fatal("expected explicit model name override to skip retry")
 	}
 }
 

--- a/controller/internal/controller/modeldeployment_controller.go
+++ b/controller/internal/controller/modeldeployment_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
@@ -47,6 +48,8 @@ type ModelDeploymentReconciler struct {
 	// GatewayDetector checks for Gateway API CRD availability and resolves gateway config
 	GatewayDetector *gateway.Detector
 }
+
+const gatewayModelNameRetryDelay = time.Minute
 
 // +kubebuilder:rbac:groups=airunway.ai,resources=modeldeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=airunway.ai,resources=modeldeployments/status,verbs=get;update;patch
@@ -75,6 +78,7 @@ type ModelDeploymentReconciler struct {
 // matches their name and handle the actual resource creation.
 func (r *ModelDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+	result := ctrl.Result{}
 
 	// Fetch the ModelDeployment
 	var md airunwayv1alpha1.ModelDeployment
@@ -179,7 +183,7 @@ func (r *ModelDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				logger.Error(err, "Failed to clean up gateway resources")
 			}
 		} else {
-			if err := r.reconcileGateway(ctx, &md); err != nil {
+			if retryModelNameDiscovery, err := r.reconcileGateway(ctx, &md); err != nil {
 				logger.Error(err, "Gateway reconciliation failed", "name", md.Name)
 				// If the error suggests CRDs were removed, refresh the detection cache
 				if isNoMatchError(err) && r.GatewayDetector != nil {
@@ -187,6 +191,8 @@ func (r *ModelDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 					r.GatewayDetector.Refresh()
 				}
 				// Non-fatal: don't block overall reconciliation
+			} else if retryModelNameDiscovery {
+				result.RequeueAfter = gatewayModelNameRetryDelay
 			}
 		}
 	}
@@ -194,7 +200,7 @@ func (r *ModelDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	logger.Info("Reconciliation complete", "name", md.Name, "phase", md.Status.Phase, "provider", md.Status.Provider)
 
-	return ctrl.Result{}, r.Status().Patch(ctx, &md, client.MergeFrom(base))
+	return result, r.Status().Patch(ctx, &md, client.MergeFrom(base))
 }
 
 // isNoMatchError checks if an error indicates that a CRD/resource type is not registered.


### PR DESCRIPTION
## Summary

This draft PR retries gateway model-name discovery for KAITO `llama.cpp` deployments when the controller has to fall back to `spec.model.id` because the model server is not ready to answer `/v1/models` yet.

Concretely, it:

- returns a retry signal from `reconcileGateway`
- adds a `modelNameResolution` result so model-name resolution can carry both the resolved name and whether the controller should try again later
- requeues the `ModelDeployment` reconcile after 1 minute when the fallback path is hit for KAITO `llama.cpp`
- adds unit coverage for the retry and explicit-override cases

## Why

`054ba06` changed gateway model-name resolution so KAITO `llama.cpp` deployments do **not** trust `spec.model.servedName` and instead prefer runtime discovery from `/v1/models`. That makes sense because AIKit / LocalAI can expose a served model name derived from the downloaded GGUF file rather than the original Hugging Face ID.

The remaining gap is timing:

1. the `ModelDeployment` reaches `Running`
2. gateway reconciliation runs
3. `/v1/models` is not ready yet, so discovery fails
4. the controller falls back to `spec.model.id`
5. the `HTTPRoute` gets created or updated with the fallback header match

At that point there is no guaranteed later reconcile to correct the route header once the model server becomes ready.

Relevant current behavior:

- the controller watches `ModelDeployment` and owned `InferencePool`s, but not `HTTPRoute`
- auto-created routes are annotated with `airunway.ai/httproute-created`
- missing routes are intentionally not recreated after user deletion
- existing routes are updated on reconcile, but only if a later reconcile actually happens

So this PR is trying to close a controller timing hole where the route can stay pinned to the fallback model name even though the runtime later exposes the correct model name.

## What Changed

### Controller behavior

- `reconcileGateway` now returns `(bool, error)` where the boolean means "please requeue for model-name discovery"
- the main reconcile loop uses `ctrl.Result{RequeueAfter: time.Minute}` when gateway reconciliation requests a retry
- the retry signal is limited to:
  - provider = `kaito`
  - engine = `llamacpp`
  - no explicit `spec.gateway.modelName` override

### Model-name resolution

- introduced `modelNameResolution` with:
  - `name`
  - `retry`
- explicit `spec.gateway.modelName` still wins and suppresses retry
- successful `/v1/models` discovery returns the discovered runtime model name and no retry
- fallback to `spec.model.id` can now also request a later retry

### Tests

Added coverage for:

- KAITO `llama.cpp` fallback requesting retry
- explicit gateway model-name override suppressing retry
- existing gateway tests updated for the new `reconcileGateway` signature

## Investigation Context

This PR came out of reconstructing some local unstaged changes after the original session history was lost.

While investigating, I also checked the current live cluster state. That cluster does **not** have this patch deployed yet, and the live failure I reproduced there appears to be a separate problem:

- current test request:
  - `curl http://102.133.128.103/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "NVIDIA-Nemotron-3-Nano-4B-UD-IQ2_M", "messages": [{"role": "user", "content": "Hello"}]}'`
- gateway response:
  - `503 Service Unavailable`
  - `upstream connect error or disconnect/reset before headers. reset reason: connection termination`
- direct service checks:
  - `GET /v1/models` from the model service returned `200` with `NVIDIA-Nemotron-3-Nano-4B-UD-IQ2_M`
  - direct `POST /v1/chat/completions` also failed
- pod state at the time of investigation:
  - model pod restarted multiple times
  - last termination reason was `OOMKilled` / exit code `137`
  - pod briefly entered `CrashLoopBackOff`
  - current pod spec showed `resources: {}`
  - runner log showed `Default capability (no GPU detected)`

That means the currently observed cluster failure is most likely an upstream model crash / resource issue, not something caused by this PR.

I am including that context here because it is easy to conflate the two:

- **this PR** addresses a controller retry / route-correction gap for KAITO `llama.cpp` gateway model-name discovery
- **the current live cluster failure** looked like a runtime OOM / inference crash path

## Validation

Ran locally in `controller/`:

- `go build ./...`
- `go test ./...`

## Open Questions For Review

Because this is a draft, a few follow-ups are worth deciding explicitly:

- Should the retry be capped instead of continuing indefinitely while discovery keeps failing?
- Should retry be skipped when the user provides `spec.gateway.httpRouteRef` and owns route updates externally?
- Is 1 minute the right retry delay, or should it be shorter / longer for AIKit startup behavior?
