### PR TITLE
Normalize engine args and fallback deployment status

### DIFF
--- a/backend/src/routes/deployments.test.ts
+++ b/backend/src/routes/deployments.test.ts
@@ -148,6 +148,38 @@ describe('Deployment Routes', () => {
       expect(data.resources[0].manifest.spec.provider.name).toBe('kaito');
     });
 
+    test('stringifies numeric engine args in preview manifests', async () => {
+      restores.push(
+        mockServiceMethod(configService, 'getDefaultNamespace', async () => 'dynamo-system'),
+      );
+
+      const res = await app.request('/api/deployments/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...validDeploymentBody,
+          namespace: 'dynamo-system',
+          provider: 'dynamo',
+          engineArgs: {
+            'tensor-parallel-size': 8,
+            'pipeline-parallel-size': 3,
+            'gpu-memory-utilization': 0.95,
+            'enable-chunked-prefill': true,
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.resources[0].manifest.spec.engine.args).toEqual({
+        'tensor-parallel-size': '8',
+        'pipeline-parallel-size': '3',
+        'gpu-memory-utilization': '0.95',
+        'enable-chunked-prefill': 'true',
+      });
+    });
+
     test('omits GPU resources for KAITO CPU preview manifests', async () => {
       restores.push(
         mockServiceMethod(configService, 'getDefaultNamespace', async () => 'kaito-workspace'),

--- a/backend/src/services/deploymentStatus.test.ts
+++ b/backend/src/services/deploymentStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { toDeploymentStatus, type ModelDeployment } from '@airunway/shared';
+import { toDeploymentStatus, type ModelDeployment, type PodStatus } from '@airunway/shared';
 
 interface ModelDeploymentOverrides {
   metadata?: Partial<ModelDeployment['metadata']>;
@@ -81,5 +81,74 @@ describe('toDeploymentStatus', () => {
     });
 
     expect(toDeploymentStatus(deployment).frontendService).toBe('legacy-deploy');
+  });
+
+  test('derives aggregated replica counts from spec when CRD replica status is empty', () => {
+    const deployment = createModelDeployment({
+      spec: {
+        scaling: {
+          replicas: 1,
+        },
+      },
+      status: {
+        replicas: undefined,
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+          },
+        ],
+      },
+    });
+
+    expect(toDeploymentStatus(deployment).replicas).toEqual({
+      desired: 1,
+      ready: 1,
+      available: 1,
+    });
+  });
+
+  test('keeps aggregated deployments deploying when replica status is empty until ready condition flips true', () => {
+    const deployment = createModelDeployment({
+      spec: {
+        scaling: {
+          replicas: 1,
+        },
+      },
+      status: {
+        phase: 'Deploying',
+        replicas: undefined,
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+          },
+        ],
+      },
+    });
+
+    const pods: PodStatus[] = [
+      {
+        name: 'ds-r1-air-frontend',
+        phase: 'Running',
+        ready: true,
+        restarts: 0,
+      },
+      {
+        name: 'ds-r1-air-leader',
+        phase: 'Running',
+        ready: false,
+        restarts: 0,
+      },
+    ];
+
+    const status = toDeploymentStatus(deployment, pods);
+
+    expect(status.phase).toBe('Deploying');
+    expect(status.replicas).toEqual({
+      desired: 1,
+      ready: 0,
+      available: 0,
+    });
   });
 });

--- a/shared/types/deployment.ts
+++ b/shared/types/deployment.ts
@@ -86,7 +86,7 @@ export interface EngineSpec {
   type: EngineType;
   contextLength?: number;
   trustRemoteCode?: boolean;
-  args?: Record<string, unknown>;
+  args?: Record<string, string>;
 }
 
 export interface ServingSpec {
@@ -341,15 +341,60 @@ const FATAL_POD_REASONS = new Set([
   'StartError',
 ]);
 
-function resolveDeploymentPhase(status: ModelDeploymentStatus, pods: PodStatus[]): DeploymentPhase {
+function hasReadyCondition(status: ModelDeploymentStatus): boolean {
+  return status.conditions?.some((condition) => condition.type === 'Ready' && condition.status === 'True') ?? false;
+}
+
+function resolveReplicaStatus(
+  spec: ModelDeploymentSpec,
+  status: ModelDeploymentStatus,
+  pods: PodStatus[],
+): ReplicaStatus {
+  const desired = status.replicas?.desired;
+  const ready = status.replicas?.ready;
+  const available = status.replicas?.available;
+
+  if (desired !== undefined || ready !== undefined || available !== undefined) {
+    return {
+      desired: desired ?? 0,
+      ready: ready ?? 0,
+      available: available ?? 0,
+    };
+  }
+
+  if (spec.serving?.mode === 'disaggregated') {
+    const prefillDesired = status.prefillReplicas?.desired ?? spec.scaling?.prefill?.replicas ?? 0;
+    const decodeDesired = status.decodeReplicas?.desired ?? spec.scaling?.decode?.replicas ?? 0;
+    const prefillReady = status.prefillReplicas?.ready ?? 0;
+    const decodeReady = status.decodeReplicas?.ready ?? 0;
+    const totalReady = prefillReady + decodeReady;
+
+    return {
+      desired: prefillDesired + decodeDesired,
+      ready: totalReady,
+      available: totalReady,
+    };
+  }
+
+  const derivedDesired = spec.scaling?.replicas ?? (pods.length > 0 ? 1 : 0);
+  const allPodsReady = pods.length > 0 && pods.every((pod) => pod.ready);
+  const derivedReady = hasReadyCondition(status) || allPodsReady ? derivedDesired : 0;
+
+  return {
+    desired: derivedDesired,
+    ready: derivedReady,
+    available: derivedReady,
+  };
+}
+
+function resolveDeploymentPhase(spec: ModelDeploymentSpec, status: ModelDeploymentStatus, pods: PodStatus[]): DeploymentPhase {
   const reportedPhase = status.phase;
 
   if (reportedPhase === 'Terminating') {
     return 'Terminating';
   }
 
-  const desiredReplicas = status.replicas?.desired ?? 0;
-  const readyReplicas = status.replicas?.ready ?? 0;
+  const { desired: desiredReplicas, ready: readyReplicas } = resolveReplicaStatus(spec, status, pods);
   const hasReadyPods = pods.some((pod) => pod.ready);
   const hasRunningPods = pods.some((pod) => pod.phase === 'Running');
   const hasScheduledPendingPods = pods.some((pod) => pod.phase === 'Pending' && Boolean(pod.node));
@@ -391,6 +436,30 @@ function resolveEngineType(config: DeploymentConfig): EngineType {
   return config.engine as EngineType;
 }
 
+function normalizeEngineArgs(engineArgs?: Record<string, unknown>): Record<string, string> | undefined {
+  if (!engineArgs) {
+    return undefined;
+  }
+
+  const normalized = Object.entries(engineArgs).flatMap(([key, value]) => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+
+    if (typeof value === 'string') {
+      return [[key, value] as const];
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+      return [[key, String(value)] as const];
+    }
+
+    return [[key, JSON.stringify(value)] as const];
+  });
+
+  return normalized.length > 0 ? Object.fromEntries(normalized) : undefined;
+}
+
 export function isCpuOnlyDeployment(config: Pick<DeploymentConfig, 'computeType'>): boolean {
   return config.computeType === 'cpu';
 }
@@ -407,7 +476,7 @@ export function toModelDeploymentSpec(config: DeploymentConfig): ModelDeployment
       type: resolveEngineType(config),
       contextLength: config.contextLength || config.maxModelLen,
       trustRemoteCode: config.trustRemoteCode,
-      args: config.engineArgs,
+      args: normalizeEngineArgs(config.engineArgs),
     },
     serving: {
       mode: config.mode,
@@ -475,6 +544,7 @@ export function toDeploymentStatus(md: ModelDeployment, pods: PodStatus[] = []):
   const status = md.status || {};
   const spec = md.spec;
   const frontendServiceName = status.endpoint?.service || md.metadata.name;
+  const replicas = resolveReplicaStatus(spec, status, pods);
 
   return {
     name: md.metadata.name,
@@ -483,13 +553,9 @@ export function toDeploymentStatus(md: ModelDeployment, pods: PodStatus[] = []):
     servedModelName: spec.model.servedName,
     engine: (spec.engine?.type as Engine) || undefined,
     mode: spec.serving?.mode || 'aggregated',
-    phase: resolveDeploymentPhase(status, pods),
+    phase: resolveDeploymentPhase(spec, status, pods),
     provider: status.provider?.name || spec.provider?.name || 'unknown',
-    replicas: {
-      desired: status.replicas?.desired ?? 0,
-      ready: status.replicas?.ready ?? 0,
-      available: status.replicas?.available ?? 0,
-    },
+    replicas,
     conditions: status.conditions,
     pods,
     createdAt: md.metadata.creationTimestamp || new Date().toISOString(),


### PR DESCRIPTION
## Summary
- normalize engine args to strings before writing ModelDeployment specs so preview manifests emit valid values
- derive replica and phase status from spec and pod readiness when CRD replica fields are empty
- add regression coverage for preview manifest args and aggregated deployment fallback status handling

## Testing
- bun run test