### PR TITLE
ci: fix Dependabot automerge conditions

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -42,10 +42,18 @@ jobs:
           pr_url="$(jq -r '.url' <<<"$pr_json")"
           auto_merge_enabled="$(jq -r 'if .autoMergeRequest == null then "false" else "true" end' <<<"$pr_json")"
 
-          if [ "$author" != "dependabot[bot]" ]; then
-            echo "skip_reason=not_dependabot" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          echo "Evaluating PR #$PR_NUMBER from author $author"
+
+          # Dependabot PRs may be reported either as the bot user or the
+          # GitHub App, depending on which API surface returns the author.
+          case "$author" in
+            "dependabot[bot]"|"app/dependabot")
+              ;;
+            *)
+              echo "skip_reason=not_dependabot" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
 
           if [ "$state" != "OPEN" ] || [ "$is_draft" != "false" ]; then
             echo "skip_reason=not_open_ready" >> "$GITHUB_OUTPUT"
@@ -115,4 +123,4 @@ jobs:
           PR_URL: ${{ steps.pr.outputs.pr_url }}
           REPO: ${{ github.repository }}
         run: |
-          gh pr merge "$PR_URL" --repo "$REPO" --auto --merge --match-head-commit "$HEAD_SHA"
+          gh pr merge "$PR_URL" --repo "$REPO" --auto --squash --match-head-commit "$HEAD_SHA"


### PR DESCRIPTION
## Description

Fix the Dependabot automerge workflow so it recognizes Dependabot PRs consistently and uses the merge method accepted by the repository.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
merged this pr but doesnt seem to work https://github.com/kaito-project/airunway/pull/168
```

**AI Tool:** Codex

</details>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Related Issues

Relates to #168

## Changes Made

- Accept both `dependabot[bot]` and `app/dependabot` as valid Dependabot PR authors.
- Log the evaluated PR author in the workflow for easier future debugging.
- Use `gh pr merge --auto --squash` instead of `--merge`.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [ ] Tested with a Kubernetes cluster

Manual validation:
- Parsed the workflow as YAML.
- Ran `actionlint` against `.github/workflows/dependabot-automerge.yml`.
- Inspected the existing automerge workflow run for PR #168 and confirmed it skipped before merge enablement because the author login was returned as `app/dependabot`.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

N/A

## Additional Notes

This is a follow-up fix for the Dependabot automerge workflow added in #159.
