### PR TITLE
ci: retry Dependabot automerge on transient failures

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -123,4 +123,28 @@ jobs:
           PR_URL: ${{ steps.pr.outputs.pr_url }}
           REPO: ${{ github.repository }}
         run: |
-          gh pr merge "$PR_URL" --repo "$REPO" --auto --squash --match-head-commit "$HEAD_SHA"
+          set -euo pipefail
+
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt to enable merge for $PR_URL"
+
+            if gh pr merge "$PR_URL" --repo "$REPO" --auto --squash --match-head-commit "$HEAD_SHA"; then
+              exit 0
+            fi
+
+            pr_state="$(gh pr view "$PR_URL" --repo "$REPO" --json state,autoMergeRequest)"
+            state="$(jq -r '.state' <<<"$pr_state")"
+            auto_merge_enabled="$(jq -r 'if .autoMergeRequest == null then "false" else "true" end' <<<"$pr_state")"
+
+            if [ "$state" = "MERGED" ] || [ "$auto_merge_enabled" = "true" ]; then
+              echo "Merge was applied despite the previous CLI error."
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+
+          echo "Failed to enable merge for $PR_URL after retries."
+          exit 1


### PR DESCRIPTION
## Description

Harden the Dependabot automerge workflow against transient GitHub API failures when enabling merge.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
merged worked. but this action failed https://github.com/kaito-project/airunway/actions/runs/23351968295
```

**AI Tool:** Codex

</details>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Related Issues

Relates to workflow run 23351968295

## Changes Made

- Retry `gh pr merge --auto --squash` up to 3 times.
- Re-check pull request state after a CLI error.
- Treat `MERGED` or `autoMergeRequest != null` as success so a post-merge GitHub 502 does not fail the workflow.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [ ] Tested with a Kubernetes cluster

Manual validation:
- Parsed the workflow as YAML.
- Ran `actionlint` against `.github/workflows/dependabot-automerge.yml`.
- Inspected workflow run `23351968295` and confirmed the merge step failed with `502 Bad Gateway` even though PR #171 merged successfully.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

N/A

## Additional Notes

This keeps transient GitHub-side failures from showing up as red workflow runs after the PR has already been merged or auto-merge has already been enabled.
