### PR TITLE
feat(shared): backfill gateway + costs API modules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "typescript": "^5.3.3",
+        "vitest": "^1.1.3",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:backend": "bun run --filter '@airunway/backend' build",
     "compile": "bun run build:frontend && bun run --filter '@airunway/backend' compile",
     "lint": "bun run --filter '@airunway/frontend' lint && bun run --filter '@airunway/backend' lint",
-    "test": "bun run --filter '@airunway/frontend' test && bun run --filter '@airunway/backend' test",
+    "test": "bun run --filter '@airunway/shared' test && bun run --filter '@airunway/frontend' test && bun run --filter '@airunway/backend' test",
     "test:e2e": "bun run --filter '@airunway/frontend' test:e2e"
   },
   "keywords": [

--- a/shared/api/costs.test.ts
+++ b/shared/api/costs.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { createCostsApi } from './costs';
+import { mockRequest } from './test-helpers';
+import type { CostEstimateRequest, CostEstimateResponse } from '../types';
+
+describe('createCostsApi', () => {
+  describe('estimate', () => {
+    it('POSTs to /costs/estimate with the request body and returns the resolved value', async () => {
+      const mockResponse: CostEstimateResponse = {
+        success: true,
+        breakdown: {
+          estimate: {
+            hourly: 1.0,
+            monthly: 730,
+            currency: 'USD',
+            source: 'static',
+            confidence: 'medium',
+          },
+          perGpu: { hourly: 1.0, monthly: 730 },
+          totalGpus: 1,
+          gpuModel: 'A100',
+          normalizedGpuModel: 'A100',
+          notes: [],
+        },
+      };
+      const request = mockRequest(mockResponse);
+
+      const input: CostEstimateRequest = {
+        gpuType: 'A100',
+        gpuCount: 1,
+        replicas: 1,
+      };
+
+      const api = createCostsApi(request);
+      const result = await api.estimate(input);
+
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith('/costs/estimate', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});

--- a/shared/api/costs.test.ts
+++ b/shared/api/costs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createCostsApi } from './costs';
+import { createCostsApi, type NodePoolCostsResponse } from './costs';
 import { mockRequest } from './test-helpers';
 import type { CostEstimateRequest, CostEstimateResponse } from '../types';
 
@@ -40,6 +40,39 @@ describe('createCostsApi', () => {
         body: JSON.stringify(input),
       });
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getNodePoolCosts', () => {
+    it('builds the query string with provided gpuCount/replicas/computeType', async () => {
+      const mockResponse: NodePoolCostsResponse = {
+        success: true,
+        nodePoolCosts: [],
+        pricingSource: 'static',
+        cacheStats: { size: 0, ttlMs: 60_000, maxEntries: 100 },
+      };
+      const request = mockRequest(mockResponse);
+
+      const api = createCostsApi(request);
+      const result = await api.getNodePoolCosts(2, 3, 'gpu');
+
+      expect(request).toHaveBeenCalledWith('/costs/node-pools?gpuCount=2&replicas=3&computeType=gpu');
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('uses default values (gpuCount=1, replicas=1, computeType=gpu) when called with no args', async () => {
+      const mockResponse: NodePoolCostsResponse = {
+        success: true,
+        nodePoolCosts: [],
+        pricingSource: 'realtime-with-fallback',
+        cacheStats: { size: 0, ttlMs: 60_000, maxEntries: 100 },
+      };
+      const request = mockRequest(mockResponse);
+
+      const api = createCostsApi(request);
+      await api.getNodePoolCosts();
+
+      expect(request).toHaveBeenCalledWith('/costs/node-pools?gpuCount=1&replicas=1&computeType=gpu');
     });
   });
 });

--- a/shared/api/costs.test.ts
+++ b/shared/api/costs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createCostsApi, type NodePoolCostsResponse, type GpuModelsResponse } from './costs';
+import { createCostsApi, type NodePoolCostsResponse, type GpuModelsResponse, type NormalizeGpuResponse } from './costs';
 import { mockRequest } from './test-helpers';
 import type { CostEstimateRequest, CostEstimateResponse } from '../types';
 
@@ -93,6 +93,45 @@ describe('createCostsApi', () => {
 
       expect(request).toHaveBeenCalledWith('/costs/gpu-models');
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('normalizeGpu', () => {
+    it('URL-encodes the label and calls /costs/normalize-gpu', async () => {
+      const mockResponse: NormalizeGpuResponse = {
+        success: true,
+        originalLabel: 'NVIDIA A100 80GB',
+        normalizedModel: 'A100-80GB',
+        pricing: null,
+      };
+      const request = mockRequest(mockResponse);
+
+      const api = createCostsApi(request);
+      const result = await api.normalizeGpu('NVIDIA A100 80GB');
+
+      // Spaces must be percent-encoded
+      expect(request).toHaveBeenCalledWith('/costs/normalize-gpu?label=NVIDIA%20A100%2080GB');
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('returns a pricing object when the backend has a match', async () => {
+      const mockResponse: NormalizeGpuResponse = {
+        success: true,
+        originalLabel: 'a100',
+        normalizedModel: 'A100',
+        pricing: {
+          memoryGb: 80,
+          generation: 'ampere',
+          hourlyRate: { aws: 3.0, azure: 3.2, gcp: 2.9 },
+        },
+      };
+      const request = mockRequest(mockResponse);
+
+      const api = createCostsApi(request);
+      const result = await api.normalizeGpu('a100');
+
+      expect(request).toHaveBeenCalledWith('/costs/normalize-gpu?label=a100');
+      expect(result.pricing?.hourlyRate.aws).toBe(3.0);
     });
   });
 });

--- a/shared/api/costs.test.ts
+++ b/shared/api/costs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createCostsApi, type NodePoolCostsResponse, type GpuModelsResponse, type NormalizeGpuResponse } from './costs';
+import { createCostsApi, type NodePoolCostsResponse, type GpuModelsResponse, type CostsNormalizeGpuResponse } from './costs';
 import { mockRequest } from './test-helpers';
 import type { CostEstimateRequest, CostEstimateResponse } from '../types';
 
@@ -98,7 +98,7 @@ describe('createCostsApi', () => {
 
   describe('normalizeGpu', () => {
     it('URL-encodes the label and calls /costs/normalize-gpu', async () => {
-      const mockResponse: NormalizeGpuResponse = {
+      const mockResponse: CostsNormalizeGpuResponse = {
         success: true,
         originalLabel: 'NVIDIA A100 80GB',
         normalizedModel: 'A100-80GB',
@@ -115,7 +115,7 @@ describe('createCostsApi', () => {
     });
 
     it('returns a pricing object when the backend has a match', async () => {
-      const mockResponse: NormalizeGpuResponse = {
+      const mockResponse: CostsNormalizeGpuResponse = {
         success: true,
         originalLabel: 'a100',
         normalizedModel: 'A100',

--- a/shared/api/costs.test.ts
+++ b/shared/api/costs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createCostsApi, type NodePoolCostsResponse } from './costs';
+import { createCostsApi, type NodePoolCostsResponse, type GpuModelsResponse } from './costs';
 import { mockRequest } from './test-helpers';
 import type { CostEstimateRequest, CostEstimateResponse } from '../types';
 
@@ -73,6 +73,26 @@ describe('createCostsApi', () => {
       await api.getNodePoolCosts();
 
       expect(request).toHaveBeenCalledWith('/costs/node-pools?gpuCount=1&replicas=1&computeType=gpu');
+    });
+  });
+
+  describe('getGpuModels', () => {
+    it('calls request with /costs/gpu-models and returns the resolved value', async () => {
+      const mockResponse: GpuModelsResponse = {
+        success: true,
+        models: [
+          { model: 'A100', memoryGb: 80, generation: 'ampere' },
+          { model: 'H100', memoryGb: 80, generation: 'hopper' },
+        ],
+        note: 'Static pricing fallback',
+      };
+      const request = mockRequest(mockResponse);
+
+      const api = createCostsApi(request);
+      const result = await api.getGpuModels();
+
+      expect(request).toHaveBeenCalledWith('/costs/gpu-models');
+      expect(result).toEqual(mockResponse);
     });
   });
 });

--- a/shared/api/costs.ts
+++ b/shared/api/costs.ts
@@ -14,9 +14,26 @@ import type {
   NodePoolCostEstimate,
 } from '../types';
 
+export interface NodePoolCostsResponse {
+  success: boolean;
+  nodePoolCosts: NodePoolCostEstimate[];
+  pricingSource: 'realtime-with-fallback' | 'static';
+  cacheStats: {
+    size: number;
+    ttlMs: number;
+    maxEntries: number;
+  };
+}
+
 export interface CostsApi {
   /** Estimate deployment cost based on GPU configuration */
   estimate: (input: CostEstimateRequest) => Promise<CostEstimateResponse>;
+  /** Get cost estimates for all node pools in the cluster */
+  getNodePoolCosts: (
+    gpuCount?: number,
+    replicas?: number,
+    computeType?: 'gpu' | 'cpu',
+  ) => Promise<NodePoolCostsResponse>;
 }
 
 export function createCostsApi(request: RequestFn): CostsApi {
@@ -26,5 +43,9 @@ export function createCostsApi(request: RequestFn): CostsApi {
         method: 'POST',
         body: JSON.stringify(input),
       }),
+    getNodePoolCosts: (gpuCount = 1, replicas = 1, computeType = 'gpu') =>
+      request<NodePoolCostsResponse>(
+        `/costs/node-pools?gpuCount=${gpuCount}&replicas=${replicas}&computeType=${computeType}`,
+      ),
   };
 }

--- a/shared/api/costs.ts
+++ b/shared/api/costs.ts
@@ -35,7 +35,7 @@ export interface GpuModelsResponse {
   note: string;
 }
 
-export interface NormalizeGpuResponse {
+export interface CostsNormalizeGpuResponse {
   success: boolean;
   originalLabel: string;
   normalizedModel: string;
@@ -58,7 +58,7 @@ export interface CostsApi {
   /** Get list of supported GPU models with specifications */
   getGpuModels: () => Promise<GpuModelsResponse>;
   /** Normalize a GPU model name to our pricing key */
-  normalizeGpu: (label: string) => Promise<NormalizeGpuResponse>;
+  normalizeGpu: (label: string) => Promise<CostsNormalizeGpuResponse>;
 }
 
 export function createCostsApi(request: RequestFn): CostsApi {
@@ -74,7 +74,7 @@ export function createCostsApi(request: RequestFn): CostsApi {
       ),
     getGpuModels: () => request<GpuModelsResponse>('/costs/gpu-models'),
     normalizeGpu: (label) =>
-      request<NormalizeGpuResponse>(
+      request<CostsNormalizeGpuResponse>(
         `/costs/normalize-gpu?label=${encodeURIComponent(label)}`,
       ),
   };

--- a/shared/api/costs.ts
+++ b/shared/api/costs.ts
@@ -35,6 +35,17 @@ export interface GpuModelsResponse {
   note: string;
 }
 
+export interface NormalizeGpuResponse {
+  success: boolean;
+  originalLabel: string;
+  normalizedModel: string;
+  pricing: {
+    memoryGb: number;
+    generation: string;
+    hourlyRate: { aws?: number; azure?: number; gcp?: number };
+  } | null;
+}
+
 export interface CostsApi {
   /** Estimate deployment cost based on GPU configuration */
   estimate: (input: CostEstimateRequest) => Promise<CostEstimateResponse>;
@@ -46,6 +57,8 @@ export interface CostsApi {
   ) => Promise<NodePoolCostsResponse>;
   /** Get list of supported GPU models with specifications */
   getGpuModels: () => Promise<GpuModelsResponse>;
+  /** Normalize a GPU model name to our pricing key */
+  normalizeGpu: (label: string) => Promise<NormalizeGpuResponse>;
 }
 
 export function createCostsApi(request: RequestFn): CostsApi {
@@ -60,5 +73,9 @@ export function createCostsApi(request: RequestFn): CostsApi {
         `/costs/node-pools?gpuCount=${gpuCount}&replicas=${replicas}&computeType=${computeType}`,
       ),
     getGpuModels: () => request<GpuModelsResponse>('/costs/gpu-models'),
+    normalizeGpu: (label) =>
+      request<NormalizeGpuResponse>(
+        `/costs/normalize-gpu?label=${encodeURIComponent(label)}`,
+      ),
   };
 }

--- a/shared/api/costs.ts
+++ b/shared/api/costs.ts
@@ -1,0 +1,30 @@
+/**
+ * Costs API
+ *
+ * Deployment cost estimation across cloud providers and node pools.
+ * Response shapes for `getNodePoolCosts`, `getGpuModels`, and `normalizeGpu`
+ * are inlined because they are endpoint-specific wrappers that don't need
+ * their own type module — matching the pattern in health.ts.
+ */
+
+import type { RequestFn } from './client';
+import type {
+  CostEstimateRequest,
+  CostEstimateResponse,
+  NodePoolCostEstimate,
+} from '../types';
+
+export interface CostsApi {
+  /** Estimate deployment cost based on GPU configuration */
+  estimate: (input: CostEstimateRequest) => Promise<CostEstimateResponse>;
+}
+
+export function createCostsApi(request: RequestFn): CostsApi {
+  return {
+    estimate: (input) =>
+      request<CostEstimateResponse>('/costs/estimate', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+  };
+}

--- a/shared/api/costs.ts
+++ b/shared/api/costs.ts
@@ -25,6 +25,16 @@ export interface NodePoolCostsResponse {
   };
 }
 
+export interface GpuModelsResponse {
+  success: boolean;
+  models: Array<{
+    model: string;
+    memoryGb: number;
+    generation: string;
+  }>;
+  note: string;
+}
+
 export interface CostsApi {
   /** Estimate deployment cost based on GPU configuration */
   estimate: (input: CostEstimateRequest) => Promise<CostEstimateResponse>;
@@ -34,6 +44,8 @@ export interface CostsApi {
     replicas?: number,
     computeType?: 'gpu' | 'cpu',
   ) => Promise<NodePoolCostsResponse>;
+  /** Get list of supported GPU models with specifications */
+  getGpuModels: () => Promise<GpuModelsResponse>;
 }
 
 export function createCostsApi(request: RequestFn): CostsApi {
@@ -47,5 +59,6 @@ export function createCostsApi(request: RequestFn): CostsApi {
       request<NodePoolCostsResponse>(
         `/costs/node-pools?gpuCount=${gpuCount}&replicas=${replicas}&computeType=${computeType}`,
       ),
+    getGpuModels: () => request<GpuModelsResponse>('/costs/gpu-models'),
   };
 }

--- a/shared/api/gateway.test.ts
+++ b/shared/api/gateway.test.ts
@@ -1,15 +1,16 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createGatewayApi } from './gateway';
-import type { RequestFn } from './client';
+import { mockRequest } from './test-helpers';
+import type { GatewayInfo } from '../types';
 
 describe('createGatewayApi', () => {
   describe('getStatus', () => {
     it('calls request with /gateway/status and returns the resolved value', async () => {
-      const mockResponse = {
+      const mockResponse: GatewayInfo = {
         available: true,
         endpoint: 'http://gateway.example.com',
       };
-      const request = vi.fn().mockResolvedValue(mockResponse) as unknown as RequestFn;
+      const request = mockRequest(mockResponse);
 
       const api = createGatewayApi(request);
       const result = await api.getStatus();

--- a/shared/api/gateway.test.ts
+++ b/shared/api/gateway.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createGatewayApi } from './gateway';
 import { mockRequest } from './test-helpers';
-import type { GatewayInfo } from '../types';
+import type { GatewayInfo, GatewayModelInfo } from '../types';
 
 describe('createGatewayApi', () => {
   describe('getStatus', () => {
@@ -17,6 +17,24 @@ describe('createGatewayApi', () => {
 
       expect(request).toHaveBeenCalledTimes(1);
       expect(request).toHaveBeenCalledWith('/gateway/status');
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getModels', () => {
+    it('calls request with /gateway/models and returns the resolved value', async () => {
+      const mockResponse: { models: GatewayModelInfo[] } = {
+        models: [
+          { name: 'llama-3', deploymentName: 'llama-d', ready: true },
+        ],
+      };
+      const request = mockRequest(mockResponse);
+
+      const api = createGatewayApi(request);
+      const result = await api.getModels();
+
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith('/gateway/models');
       expect(result).toEqual(mockResponse);
     });
   });

--- a/shared/api/gateway.test.ts
+++ b/shared/api/gateway.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createGatewayApi } from './gateway';
+import type { RequestFn } from './client';
+
+describe('createGatewayApi', () => {
+  describe('getStatus', () => {
+    it('calls request with /gateway/status and returns the resolved value', async () => {
+      const mockResponse = {
+        available: true,
+        endpoint: 'http://gateway.example.com',
+      };
+      const request = vi.fn().mockResolvedValue(mockResponse) as unknown as RequestFn;
+
+      const api = createGatewayApi(request);
+      const result = await api.getStatus();
+
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith('/gateway/status');
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});

--- a/shared/api/gateway.ts
+++ b/shared/api/gateway.ts
@@ -7,15 +7,20 @@
  */
 
 import type { RequestFn } from './client';
-import type { GatewayInfo } from '../types';
+import type { GatewayInfo, GatewayModelInfo } from '../types';
 
 export interface GatewayApi {
   /** Get gateway readiness and endpoint URL */
   getStatus: () => Promise<GatewayInfo>;
+
+  /** List all models accessible through the gateway */
+  getModels: () => Promise<{ models: GatewayModelInfo[] }>;
 }
 
 export function createGatewayApi(request: RequestFn): GatewayApi {
   return {
     getStatus: () => request<GatewayInfo>('/gateway/status'),
+
+    getModels: () => request<{ models: GatewayModelInfo[] }>('/gateway/models'),
   };
 }

--- a/shared/api/gateway.ts
+++ b/shared/api/gateway.ts
@@ -1,0 +1,21 @@
+/**
+ * Gateway API
+ *
+ * Gateway readiness and model routing information surfaced via the
+ * AI Runway backend. See GatewayInfo / GatewayModelInfo in shared/types/deployment.ts
+ * for the payload shapes.
+ */
+
+import type { RequestFn } from './client';
+import type { GatewayInfo } from '../types';
+
+export interface GatewayApi {
+  /** Get gateway readiness and endpoint URL */
+  getStatus: () => Promise<GatewayInfo>;
+}
+
+export function createGatewayApi(request: RequestFn): GatewayApi {
+  return {
+    getStatus: () => request<GatewayInfo>('/gateway/status'),
+  };
+}

--- a/shared/api/index.test.ts
+++ b/shared/api/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { createApiClient } from './index';
+
+describe('createApiClient', () => {
+  const config = {
+    baseUrl: 'http://localhost:3001',
+    getToken: () => null,
+  };
+
+  it('exposes the gateway API', () => {
+    const client = createApiClient(config);
+    expect(client.gateway).toBeDefined();
+    expect(typeof client.gateway.getStatus).toBe('function');
+    expect(typeof client.gateway.getModels).toBe('function');
+  });
+
+  it('exposes the costs API', () => {
+    const client = createApiClient(config);
+    expect(client.costs).toBeDefined();
+    expect(typeof client.costs.estimate).toBe('function');
+    expect(typeof client.costs.getNodePoolCosts).toBe('function');
+    expect(typeof client.costs.getGpuModels).toBe('function');
+    expect(typeof client.costs.normalizeGpu).toBe('function');
+  });
+});

--- a/shared/api/index.ts
+++ b/shared/api/index.ts
@@ -29,7 +29,7 @@ import {
   type CostsApi,
   type NodePoolCostsResponse,
   type GpuModelsResponse,
-  type NormalizeGpuResponse as CostsNormalizeGpuResponse,
+  type CostsNormalizeGpuResponse,
 } from './costs';
 
 // Re-export API types
@@ -77,7 +77,7 @@ export type {
   CostsApi,
   NodePoolCostsResponse,
   GpuModelsResponse,
-  NormalizeGpuResponse as CostsNormalizeGpuResponse,
+  CostsNormalizeGpuResponse,
 } from './costs';
 
 /**

--- a/shared/api/index.ts
+++ b/shared/api/index.ts
@@ -23,6 +23,14 @@ import { createHuggingFaceApi, type HuggingFaceApi } from './huggingface';
 import { createAikitApi, type AikitApi } from './aikit';
 import { createAIConfiguratorApi, type AIConfiguratorApi } from './aiconfigurator';
 import { createMetricsApi, type MetricsApi } from './metrics';
+import { createGatewayApi, type GatewayApi } from './gateway';
+import {
+  createCostsApi,
+  type CostsApi,
+  type NodePoolCostsResponse,
+  type GpuModelsResponse,
+  type NormalizeGpuResponse as CostsNormalizeGpuResponse,
+} from './costs';
 
 // Re-export API types
 export type { ModelsApi } from './models';
@@ -64,6 +72,13 @@ export type {
 } from './aikit';
 export type { AIConfiguratorApi, NormalizeGpuResponse } from './aiconfigurator';
 export type { MetricsApi } from './metrics';
+export type { GatewayApi } from './gateway';
+export type {
+  CostsApi,
+  NodePoolCostsResponse,
+  GpuModelsResponse,
+  NormalizeGpuResponse as CostsNormalizeGpuResponse,
+} from './costs';
 
 /**
  * Complete API client with all endpoints
@@ -81,6 +96,8 @@ export interface ApiClient {
   aikit: AikitApi;
   aiConfigurator: AIConfiguratorApi;
   metrics: MetricsApi;
+  gateway: GatewayApi;
+  costs: CostsApi;
 }
 
 /**
@@ -124,5 +141,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
     aikit: createAikitApi(request),
     aiConfigurator: createAIConfiguratorApi(request),
     metrics: createMetricsApi(request),
+    gateway: createGatewayApi(request),
+    costs: createCostsApi(request),
   };
 }

--- a/shared/api/test-helpers.ts
+++ b/shared/api/test-helpers.ts
@@ -1,0 +1,20 @@
+/**
+ * Test helpers for shared/api client tests.
+ *
+ * Centralizes the RequestFn mock so individual test files don't need
+ * to repeat the `as unknown as RequestFn` cast required to bridge
+ * vitest's Mock type to our generic RequestFn signature.
+ */
+
+import { vi, type Mock } from 'vitest';
+import type { RequestFn } from './client';
+
+/**
+ * Create a mocked RequestFn that resolves to the given value on every call.
+ *
+ * Returns a `vi.fn()` typed as both `RequestFn` (so it satisfies the factory
+ * signatures) and `Mock` (so tests can use `.toHaveBeenCalledWith` etc.).
+ */
+export function mockRequest<T>(response: T): RequestFn & Mock {
+  return vi.fn().mockResolvedValue(response) as unknown as RequestFn & Mock;
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -19,9 +19,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^1.1.3"
   }
 }

--- a/shared/vitest.config.ts
+++ b/shared/vitest.config.ts
@@ -1,0 +1,11 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['api/**/*.{test,spec}.ts', 'types/**/*.{test,spec}.ts'],
+    exclude: ['node_modules', 'dist'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `gateway.ts` and `costs.ts` API modules to `@airunway/shared/api`, matching the shapes currently hand-rolled in `frontend/src/lib/api.ts` (lines 677–734)
- Wires both new modules into `createApiClient()` so consumers can access `client.gateway.*` and `client.costs.*`
- Bootstraps Vitest in `shared/` (first test infrastructure for the shared package) with 10 unit tests covering all 6 new methods

**Part of:** [#195 — Shared UI Layer + New-User Onboarding](https://github.com/kaito-project/airunway/issues/195) (Phase 1, PR 1 of ~10)

**No consumer changes.** `frontend/src/lib/api.ts` is untouched — PR 3 will flip the frontend to use these shared modules and delete the 734-line duplicate.

## What's new

| Module | Methods | Tests |
|--------|---------|-------|
| `shared/api/gateway.ts` | `getStatus()`, `getModels()` | 2 |
| `shared/api/costs.ts` | `estimate()`, `getNodePoolCosts()`, `getGpuModels()`, `normalizeGpu()` | 6 |
| `shared/api/index.ts` | Wiring + smoke tests | 2 |
| `shared/api/test-helpers.ts` | `mockRequest<T>()` helper | — |

## Test plan

- [x] `cd shared && bun run test` — 10/10 passing
- [x] `bun run test` (root) — 718 total (shared: 10, frontend: 102, backend: 606)
- [x] `cd shared && bun run build` — exit 0, no TypeScript errors
- [x] `git diff origin/main -- frontend/` — empty (no consumer changes)
- [x] Endpoint URLs match `frontend/src/lib/api.ts` exactly (verified side-by-side)
- [x] Default parameter values for `getNodePoolCosts(gpuCount=1, replicas=1, computeType='gpu')` match frontend
- [x] `normalizeGpu` URL-encodes label via `encodeURIComponent` (test verifies `%20` encoding)

