### PR TITLE
fix(kaito): detect Eno-partial installs and refuse-fast on missing upstream controller

### DIFF
--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -3,7 +3,12 @@ import app from '../hono-app';
 import { kubernetesService } from '../services/kubernetes';
 import { helmService } from '../services/helm';
 import { mockServiceMethod } from '../test/helpers';
-import { mockInferenceProviderConfig } from '../test/fixtures';
+import {
+  mockInferenceProviderConfig,
+  mockKaitoCROldShim,
+  mockKaitoCRNewShimHealthy,
+  mockEnoStorageClass,
+} from '../test/fixtures';
 
 describe('Installation Provider Routes', () => {
   const restores: Array<() => void> = [];
@@ -21,6 +26,7 @@ describe('Installation Provider Routes', () => {
     test('returns provider status when found', async () => {
       restores.push(
         mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockInferenceProviderConfig),
+        mockServiceMethod(kubernetesService, 'getStorageClass', async () => null),
       );
 
       const res = await app.request('/api/installation/providers/kaito/status');
@@ -132,6 +138,7 @@ describe('Installation Provider Routes', () => {
       restores.push(
         mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockInferenceProviderConfig),
         mockServiceMethod(helmService, 'checkHelmAvailable', async () => ({ available: true, version: '3.14.0' })),
+        mockServiceMethod(kubernetesService, 'getStorageClass', async () => null),
         mockServiceMethod(helmService, 'installProvider', async () => ({
           success: true,
           results: [{ step: 'install', result: { success: true, stdout: 'ok', stderr: '' } }],
@@ -144,6 +151,70 @@ describe('Installation Provider Routes', () => {
       const data = await res.json();
       expect(data.success).toBe(true);
       expect(data.results).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // GET /api/installation/providers/:providerId/status (health-aware)
+  // ==========================================================================
+
+  describe('GET /api/installation/providers/:providerId/status (health-aware)', () => {
+    test('returns installed=false with Eno-suspected message for old-shim KAITO', async () => {
+      restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCROldShim));
+      restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => mockEnoStorageClass));
+
+      const res = await app.request('/api/installation/providers/kaito/status');
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.installed).toBe(false);
+      expect(data.operatorRunning).toBe(false);
+      expect(data.managedBy).toBe('Eno');
+      expect(data.message).toContain('--enable-ai-toolchain-operator');
+    });
+
+    test('returns installed=true for healthy new-shim KAITO', async () => {
+      restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCRNewShimHealthy));
+      restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => null));
+
+      const res = await app.request('/api/installation/providers/kaito/status');
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.installed).toBe(true);
+      expect(data.operatorRunning).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // POST /api/installation/providers/:providerId/install pre-flight
+  // ==========================================================================
+
+  describe('POST /api/installation/providers/:providerId/install pre-flight', () => {
+    test('returns 409 with structured conflict when Eno owns StorageClass', async () => {
+      restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockInferenceProviderConfig));
+      restores.push(mockServiceMethod(helmService, 'checkHelmAvailable', async () => ({ available: true })));
+      restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => mockEnoStorageClass));
+      let installCalled = 0;
+      restores.push(mockServiceMethod(helmService, 'installProvider', async () => { installCalled++; return { success: true, results: [] }; }));
+
+      const res = await app.request('/api/installation/providers/kaito/install', { method: 'POST' });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('InstallConflict');
+      expect(body.conflict.source).toBe('eno');
+      expect(body.conflict.resource.name).toBe('kaito-local-nvme-disk');
+      expect(installCalled).toBe(0);
+    });
+
+    test('proceeds with helm install when no conflict (happy path)', async () => {
+      restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockInferenceProviderConfig));
+      restores.push(mockServiceMethod(helmService, 'checkHelmAvailable', async () => ({ available: true })));
+      restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => null));
+      let installCalled = 0;
+      restores.push(mockServiceMethod(helmService, 'installProvider', async () => { installCalled++; return { success: true, results: [] }; }));
+
+      const res = await app.request('/api/installation/providers/kaito/install', { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect(installCalled).toBe(1);
     });
   });
 

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -2,7 +2,43 @@ import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { kubernetesService } from '../services/kubernetes';
 import { helmService } from '../services/helm';
+import { getProviderHealth } from '../services/providerHealth';
 import logger from '../lib/logger';
+
+export type InstallConflict = {
+  kind: 'preexisting-resource';
+  source: 'eno' | 'helm' | 'unknown';
+  resource: { apiVersion: string; kind: string; name: string; namespace?: string };
+  message: string;
+};
+
+const ENO_STORAGECLASS_CONFLICT_MESSAGE =
+  'A `kaito-local-nvme-disk` StorageClass already exists and is managed by the ' +
+  'AKS AI toolchain operator (Eno). AI Runway cannot install KAITO on top of ' +
+  'this partial install. Options: (1) disable the AKS extension with ' +
+  '`az aks update --disable-ai-toolchain-operator ...` and retry, or ' +
+  '(2) install the `kaito-workspace` controller manually.';
+
+export async function checkInstallConflicts(providerId: string): Promise<InstallConflict | null> {
+  if (providerId !== 'kaito') return null;
+
+  const sc = await kubernetesService.getStorageClass('kaito-local-nvme-disk');
+  if (!sc) return null;
+
+  const managedBy = sc.metadata?.labels?.['app.kubernetes.io/managed-by'];
+  if (managedBy !== 'Eno') return null;
+
+  return {
+    kind: 'preexisting-resource',
+    source: 'eno',
+    resource: {
+      apiVersion: 'storage.k8s.io/v1',
+      kind: 'StorageClass',
+      name: 'kaito-local-nvme-disk',
+    },
+    message: ENO_STORAGECLASS_CONFLICT_MESSAGE,
+  };
+}
 
 /**
  * Extract provider details from an InferenceProviderConfig CRD object.
@@ -121,17 +157,17 @@ const installation = new Hono()
 
     const provider = extractProviderDetails(config);
     const status = config.status || {};
+    const health = await getProviderHealth(providerId);
 
     return c.json({
       providerId: provider.id,
       providerName: provider.name,
-      installed: status.ready === true,
-      crdFound: true,
-      operatorRunning: status.ready === true,
+      installed: health.healthy,
+      crdFound: health.reason !== 'CRDMissing',
+      operatorRunning: health.healthy,
       version: status.version,
-      message: status.ready
-        ? `${provider.name} is installed and running`
-        : `${provider.name} is registered but not ready`,
+      message: health.message,
+      managedBy: health.managedBy,
       installationSteps: provider.installationSteps,
       helmCommands: helmService.getInstallCommands(provider.helmRepos, provider.helmCharts),
     });
@@ -168,6 +204,18 @@ const installation = new Hono()
       throw new HTTPException(400, {
         message: `Helm CLI not available: ${helmStatus.error}. Please install Helm or use the manual installation commands.`,
       });
+    }
+
+    const conflict = await checkInstallConflicts(providerId);
+    if (conflict) {
+      return c.json(
+        {
+          error: 'InstallConflict',
+          conflict,
+          message: conflict.message,
+        },
+        409,
+      );
     }
 
     logger.info({ providerId }, `Starting installation of ${provider.name}`);

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -94,6 +94,7 @@ class KubernetesService {
   private customObjectsApi: k8s.CustomObjectsApi;
   private coreV1Api: k8s.CoreV1Api;
   private apiExtensionsApi: k8s.ApiextensionsV1Api;
+  private storageV1Api: k8s.StorageV1Api;
   private defaultNamespace: string;
 
   constructor() {
@@ -101,6 +102,7 @@ class KubernetesService {
     this.customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi);
     this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
     this.apiExtensionsApi = this.kc.makeApiClient(k8s.ApiextensionsV1Api);
+    this.storageV1Api = this.kc.makeApiClient(k8s.StorageV1Api);
     this.defaultNamespace = process.env.DEFAULT_NAMESPACE || 'airunway-system';
   }
 
@@ -609,6 +611,27 @@ class KubernetesService {
       return (response as any).body || response;
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Get a StorageClass by name from the cluster.
+   * Returns null if the StorageClass is not found (404).
+   * Throws on other errors.
+   */
+  async getStorageClass(name: string): Promise<any | null> {
+    try {
+      const response = await withRetry(
+        () => this.storageV1Api.readStorageClass(name),
+        { operationName: `getStorageClass:${name}`, maxRetries: 1 }
+      );
+      return (response as any).body || response;
+    } catch (error: any) {
+      const statusCode = error?.statusCode || error?.response?.statusCode;
+      if (statusCode === 404) {
+        return null;
+      }
+      throw error;
     }
   }
 

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -573,13 +573,29 @@ class KubernetesService {
             ? name.charAt(0).toUpperCase() + name.slice(1)
             : name.charAt(0).toUpperCase() + name.slice(1);
 
+          let healthy = status.ready === true;
+          let message: string | undefined = status.ready ? 'Provider ready' : 'Provider not ready';
+          let managedBy: string | undefined;
+
+          try {
+            // Lazy import to avoid circular dependency (providerHealth imports kubernetesService)
+            const { getProviderHealth } = await import('./providerHealth');
+            const health = await getProviderHealth(name);
+            healthy = health.healthy;
+            message = health.message;
+            managedBy = health.managedBy;
+          } catch (err) {
+            logger.warn({ error: (err as Error)?.message, providerId: name }, 'getProviderHealth failed, using fallback');
+          }
+
           runtimes.push({
             id: name,
             name: displayName,
             installed: true,
-            healthy: status.ready === true,
+            healthy,
             version: status.version,
-            message: status.ready ? 'Provider ready' : 'Provider not ready',
+            message,
+            managedBy,
           });
         }
       } catch (error: any) {

--- a/backend/src/services/providerHealth.test.ts
+++ b/backend/src/services/providerHealth.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { getProviderHealth } from './providerHealth';
+import { kubernetesService } from './kubernetes';
+import { mockServiceMethod } from '../test/helpers';
+import {
+  mockKaitoCRNewShimHealthy,
+  mockKaitoCRNewShimEnoPartial,
+  mockKaitoCROldShim,
+  mockKaitoCRStale,
+  mockEnoStorageClass,
+  mockHelmStorageClass,
+} from '../test/fixtures';
+
+describe('getProviderHealth', () => {
+  const restores: Array<() => void> = [];
+  afterEach(() => {
+    restores.forEach((r) => r());
+    restores.length = 0;
+  });
+
+  // --- Passthrough ---
+
+  test('returns healthy for new-shim CR with UpstreamHealthy condition', async () => {
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCRNewShimHealthy));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => null));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.healthy).toBe(true);
+    expect(h.reason).toBe('UpstreamHealthy');
+    expect(h.stale).toBe(false);
+  });
+
+  test('returns unhealthy for new-shim CR with EnoPartialInstall', async () => {
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCRNewShimEnoPartial));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => null));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.healthy).toBe(false);
+    expect(h.reason).toBe('EnoPartialInstall');
+    expect(h.managedBy).toBe('Eno');
+  });
+
+  // --- Staleness ---
+
+  test('returns stale when heartbeat is older than threshold', async () => {
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCRStale));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => null));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.healthy).toBe(false);
+    expect(h.reason).toBe('ShimStale');
+    expect(h.stale).toBe(true);
+  });
+
+  // --- Eno detection ---
+
+  test('sets managedBy=Eno from UpstreamManagedBy condition without StorageClass fallback', async () => {
+    let storageClassCalls = 0;
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCRNewShimEnoPartial));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => { storageClassCalls++; return null; }));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.managedBy).toBe('Eno');
+    expect(storageClassCalls).toBe(0);
+  });
+
+  test('sets managedBy=Eno via KAITO StorageClass fallback when no condition', async () => {
+    const cr = {
+      ...mockKaitoCRNewShimHealthy,
+      status: {
+        ...mockKaitoCRNewShimHealthy.status,
+        conditions: mockKaitoCRNewShimHealthy.status.conditions.filter((c: any) => c.type !== 'UpstreamManagedBy'),
+      },
+    };
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => cr));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => mockEnoStorageClass));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.managedBy).toBe('Eno');
+    expect(h.healthy).toBe(true); // informational, doesn't affect health
+  });
+
+  test('does not set managedBy for non-KAITO providers', async () => {
+    const dynamoCR = { ...mockKaitoCRNewShimHealthy, metadata: { name: 'dynamo' } };
+    let storageClassCalls = 0;
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => dynamoCR));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => { storageClassCalls++; return null; }));
+
+    const h = await getProviderHealth('dynamo');
+    expect(h.managedBy).toBeUndefined();
+    expect(storageClassCalls).toBe(0);
+  });
+
+  // --- Old-shim override ---
+
+  test('fires old-shim override when KAITO + Eno StorageClass + no UpstreamReady condition', async () => {
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCROldShim));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => mockEnoStorageClass));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.healthy).toBe(false);
+    expect(h.reason).toBe('EnoPartialInstallSuspected');
+    expect(h.managedBy).toBe('Eno');
+    expect(h.message).toContain('--enable-ai-toolchain-operator');
+  });
+
+  test('old-shim override does NOT fire against new shims', async () => {
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCRNewShimEnoPartial));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => mockEnoStorageClass));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.reason).toBe('EnoPartialInstall'); // passthrough, not Suspected
+  });
+
+  test('old-shim override does NOT fire without Eno signal', async () => {
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => mockKaitoCROldShim));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => mockHelmStorageClass));
+
+    const h = await getProviderHealth('kaito');
+    expect(h.healthy).toBe(true);
+    expect(h.reason).not.toBe('EnoPartialInstallSuspected');
+  });
+
+  test('old-shim override does NOT fire on non-KAITO providers', async () => {
+    const cr = { ...mockKaitoCROldShim, metadata: { name: 'kuberay' } };
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => cr));
+    restores.push(mockServiceMethod(kubernetesService, 'getStorageClass', async () => mockEnoStorageClass));
+
+    const h = await getProviderHealth('kuberay');
+    expect(h.managedBy).toBeUndefined();
+    expect(h.reason).not.toBe('EnoPartialInstallSuspected');
+  });
+
+  // --- Error ---
+
+  test('throws when provider not found', async () => {
+    restores.push(mockServiceMethod(kubernetesService, 'getInferenceProviderConfig', async () => null));
+
+    await expect(getProviderHealth('nonexistent')).rejects.toThrow('provider not found');
+  });
+});

--- a/backend/src/services/providerHealth.ts
+++ b/backend/src/services/providerHealth.ts
@@ -1,0 +1,86 @@
+import { kubernetesService } from './kubernetes';
+
+export type ProviderHealth = {
+  providerId: string;
+  healthy: boolean;
+  reason: string;
+  message: string;
+  managedBy?: 'Eno' | 'Helm' | 'Unknown';
+  stale: boolean;
+  lastHeartbeat?: string;
+};
+
+const STALENESS_THRESHOLD_MS = Number(process.env.PROVIDER_HEALTH_STALENESS_MS ?? 180_000);
+
+const ENO_PARTIAL_INSTALL_SUSPECTED_MESSAGE =
+  'This cluster appears to have been set up with `--enable-ai-toolchain-operator`. ' +
+  'The deployed KAITO shim is too old to detect this and is reporting stale health. ' +
+  'Upgrade the KAITO shim image to get accurate status and prevent stalled deployments.';
+
+const KAITO_ENO_STORAGECLASS = 'kaito-local-nvme-disk';
+
+export async function getProviderHealth(providerId: string): Promise<ProviderHealth> {
+  const config = await kubernetesService.getInferenceProviderConfig(providerId);
+  if (!config) {
+    throw new Error(`provider not found: ${providerId}`);
+  }
+
+  const status = config.status ?? {};
+  const conditions: Array<any> = status.conditions ?? [];
+  const upstreamReady = conditions.find((c: any) => c.type === 'UpstreamReady');
+  const upstreamManagedBy = conditions.find((c: any) => c.type === 'UpstreamManagedBy');
+  const lastHeartbeat: string | undefined = status.lastHeartbeat;
+  const ready: boolean = status.ready === true;
+
+  // Step 4: staleness override
+  const stale = lastHeartbeat
+    ? Date.now() - new Date(lastHeartbeat).getTime() > STALENESS_THRESHOLD_MS
+    : true;
+
+  if (stale) {
+    return {
+      providerId,
+      healthy: false,
+      reason: 'ShimStale',
+      message: 'The provider is not reporting status. Check that the AI Runway provider shim is running.',
+      stale: true,
+      lastHeartbeat,
+    };
+  }
+
+  // Step 5: passthrough
+  let health: ProviderHealth = {
+    providerId,
+    healthy: ready,
+    reason: upstreamReady?.reason ?? (ready ? 'Ready' : 'NotReady'),
+    message: upstreamReady?.message ?? (ready ? 'Provider is installed and running' : 'Provider is not ready'),
+    stale: false,
+    lastHeartbeat,
+  };
+
+  // Step 6: managedBy detection
+  if (upstreamManagedBy?.reason === 'Eno') {
+    health.managedBy = 'Eno';
+  } else if (providerId === 'kaito') {
+    const sc = await kubernetesService.getStorageClass(KAITO_ENO_STORAGECLASS);
+    if (sc?.metadata?.labels?.['app.kubernetes.io/managed-by'] === 'Eno') {
+      health.managedBy = 'Eno';
+    } else if (sc?.metadata?.labels?.['app.kubernetes.io/managed-by'] === 'Helm') {
+      health.managedBy = 'Helm';
+    } else if (sc) {
+      health.managedBy = 'Unknown';
+    }
+  }
+
+  // Step 7: old-shim override
+  if (providerId === 'kaito' && health.managedBy === 'Eno' && !upstreamReady) {
+    return {
+      ...health,
+      healthy: false,
+      reason: 'EnoPartialInstallSuspected',
+      message: ENO_PARTIAL_INSTALL_SUSPECTED_MESSAGE,
+    };
+  }
+
+  return health;
+}

--- a/backend/src/test/fixtures.ts
+++ b/backend/src/test/fixtures.ts
@@ -168,6 +168,7 @@ export const mockInferenceProviderConfig = {
   status: {
     ready: true,
     version: '0.9.0',
+    lastHeartbeat: new Date().toISOString(),
   },
 };
 
@@ -319,4 +320,78 @@ export const mockInferenceProviderConfigNotReady = {
     ready: false,
     // No version — provider is not yet installed/ready
   },
+};
+
+// ============================================================================
+// Provider health fixtures (issue #179)
+// ============================================================================
+
+const freshHeartbeat = new Date(Date.now() - 30_000).toISOString();
+const staleHeartbeat = new Date(Date.now() - 5 * 60_000).toISOString();
+
+export const mockKaitoCRNewShimHealthy = {
+  ...mockInferenceProviderConfig,
+  status: {
+    ready: true,
+    version: 'kaito-provider:v0.1.0',
+    lastHeartbeat: freshHeartbeat,
+    conditions: [
+      { type: 'UpstreamReady', status: 'True', reason: 'UpstreamHealthy', message: 'KAITO workspace controller kaito-workspace/kaito-workspace is ready' },
+    ],
+  },
+};
+
+export const mockKaitoCRNewShimEnoPartial = {
+  ...mockInferenceProviderConfig,
+  status: {
+    ready: false,
+    version: 'kaito-provider:v0.1.0',
+    lastHeartbeat: freshHeartbeat,
+    conditions: [
+      { type: 'UpstreamReady', status: 'False', reason: 'EnoPartialInstall', message: 'This cluster was set up with --enable-ai-toolchain-operator...' },
+      { type: 'UpstreamManagedBy', status: 'True', reason: 'Eno', message: 'Upstream KAITO resources are managed by the AKS AI toolchain operator (Eno).' },
+    ],
+  },
+};
+
+export const mockKaitoCROldShim = {
+  ...mockInferenceProviderConfig,
+  status: {
+    ready: true,
+    version: 'kaito-provider:v0.0.9',
+    lastHeartbeat: freshHeartbeat,
+    conditions: [],
+  },
+};
+
+export const mockKaitoCRStale = {
+  ...mockInferenceProviderConfig,
+  status: {
+    ready: true,
+    version: 'kaito-provider:v0.1.0',
+    lastHeartbeat: staleHeartbeat,
+    conditions: [
+      { type: 'UpstreamReady', status: 'True', reason: 'UpstreamHealthy', message: 'ok' },
+    ],
+  },
+};
+
+export const mockEnoStorageClass = {
+  apiVersion: 'storage.k8s.io/v1',
+  kind: 'StorageClass',
+  metadata: {
+    name: 'kaito-local-nvme-disk',
+    labels: { 'app.kubernetes.io/managed-by': 'Eno' },
+  },
+  provisioner: 'test',
+};
+
+export const mockHelmStorageClass = {
+  apiVersion: 'storage.k8s.io/v1',
+  kind: 'StorageClass',
+  metadata: {
+    name: 'kaito-local-nvme-disk',
+    labels: { 'app.kubernetes.io/managed-by': 'Helm' },
+  },
+  provisioner: 'test',
 };

--- a/providers/kaito/cmd/main.go
+++ b/providers/kaito/cmd/main.go
@@ -116,7 +116,7 @@ func main() {
 	}
 
 	// Set up the ProviderConfigManager for self-registration and heartbeat
-	configManager := kaito.NewProviderConfigManager(mgr.GetClient())
+	configManager := kaito.NewProviderConfigManager(mgr.GetClient(), mgr.GetClient())
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		setupLog.Info("registering KAITO provider config")
 		if err := configManager.Register(ctx); err != nil {

--- a/providers/kaito/cmd/main.go
+++ b/providers/kaito/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -108,15 +109,26 @@ func main() {
 		os.Exit(1)
 	}
 
+	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		setupLog.Error(err, "unable to build direct client for upstream probe")
+		os.Exit(1)
+	}
+
 	// Set up the KAITO provider reconciler
-	reconciler := kaito.NewKaitoProviderReconciler(mgr.GetClient(), mgr.GetScheme())
+	reconciler := kaito.NewKaitoProviderReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		directClient,
+		mgr.GetEventRecorderFor("kaito-provider"),
+	)
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KaitoProvider")
 		os.Exit(1)
 	}
 
 	// Set up the ProviderConfigManager for self-registration and heartbeat
-	configManager := kaito.NewProviderConfigManager(mgr.GetClient(), mgr.GetClient())
+	configManager := kaito.NewProviderConfigManager(mgr.GetClient(), directClient)
 	if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		setupLog.Info("registering KAITO provider config")
 		if err := configManager.Register(ctx); err != nil {

--- a/providers/kaito/config.go
+++ b/providers/kaito/config.go
@@ -46,13 +46,15 @@ const (
 
 // ProviderConfigManager handles registration and heartbeat for the KAITO provider
 type ProviderConfigManager struct {
-	client client.Client
+	client       client.Client
+	directClient client.Client
 }
 
 // NewProviderConfigManager creates a new provider config manager
-func NewProviderConfigManager(c client.Client) *ProviderConfigManager {
+func NewProviderConfigManager(c client.Client, direct client.Client) *ProviderConfigManager {
 	return &ProviderConfigManager{
-		client: c,
+		client:       c,
+		directClient: direct,
 	}
 }
 
@@ -154,7 +156,9 @@ func (m *ProviderConfigManager) Register(ctx context.Context) error {
 	// Update status — retry briefly after create to allow cache to sync
 	var statusErr error
 	for i := 0; i < 5; i++ {
-		statusErr = m.UpdateStatus(ctx, true)
+		probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		statusErr = m.UpdateStatusFromProbe(probeCtx)
+		cancel()
 		if statusErr == nil {
 			break
 		}
@@ -163,25 +167,74 @@ func (m *ProviderConfigManager) Register(ctx context.Context) error {
 	return statusErr
 }
 
-// UpdateStatus updates the status of the InferenceProviderConfig
-func (m *ProviderConfigManager) UpdateStatus(ctx context.Context, ready bool) error {
+// UpdateStatusFromProbe runs probeUpstreamController and writes the result into
+// InferenceProviderConfig.status.
+func (m *ProviderConfigManager) UpdateStatusFromProbe(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+
+	probe := probeUpstreamController(ctx, m.directClient)
+	if probe.Reason == ReasonProbeFailed {
+		logger.Info("upstream probe failed", "reason", probe.Reason, "message", probe.Message)
+	}
+
 	config := &airunwayv1alpha1.InferenceProviderConfig{}
 	if err := m.client.Get(ctx, types.NamespacedName{Name: ProviderConfigName}, config); err != nil {
 		return fmt.Errorf("failed to get InferenceProviderConfig: %w", err)
 	}
 
 	now := metav1.Now()
-	config.Status = airunwayv1alpha1.InferenceProviderConfigStatus{
-		Ready:              ready,
-		Version:            ProviderVersion,
-		LastHeartbeat:      &now,
-		UpstreamCRDVersion: "kaito.sh/v1beta1",
+	config.Status.Ready = probe.Healthy
+	config.Status.Version = ProviderVersion
+	config.Status.LastHeartbeat = &now
+	config.Status.UpstreamCRDVersion = "kaito.sh/v1beta1"
+
+	upsertCondition(&config.Status.Conditions, metav1.Condition{
+		Type:               "UpstreamReady",
+		Status:             boolToConditionStatus(probe.Healthy),
+		Reason:             probe.Reason,
+		Message:            probe.Message,
+		LastTransitionTime: now,
+	})
+
+	if probe.ManagedBy == managedByEno {
+		upsertCondition(&config.Status.Conditions, metav1.Condition{
+			Type:               "UpstreamManagedBy",
+			Status:             metav1.ConditionTrue,
+			Reason:             managedByEno,
+			Message:            "Upstream KAITO resources are managed by the AKS AI toolchain operator (Eno).",
+			LastTransitionTime: now,
+		})
+	} else {
+		removeCondition(&config.Status.Conditions, "UpstreamManagedBy")
 	}
 
 	if err := m.client.Status().Update(ctx, config); err != nil {
 		return fmt.Errorf("failed to update InferenceProviderConfig status: %w", err)
 	}
+	return nil
+}
 
+// MarkUnregistered sets status.ready=false unconditionally. Used by shim shutdown.
+func (m *ProviderConfigManager) MarkUnregistered(ctx context.Context) error {
+	config := &airunwayv1alpha1.InferenceProviderConfig{}
+	if err := m.client.Get(ctx, types.NamespacedName{Name: ProviderConfigName}, config); err != nil {
+		return fmt.Errorf("failed to get InferenceProviderConfig: %w", err)
+	}
+
+	now := metav1.Now()
+	config.Status.Ready = false
+	config.Status.LastHeartbeat = &now
+	upsertCondition(&config.Status.Conditions, metav1.Condition{
+		Type:               "UpstreamReady",
+		Status:             metav1.ConditionFalse,
+		Reason:             ReasonUnregistered,
+		Message:            "Shim is shutting down.",
+		LastTransitionTime: now,
+	})
+
+	if err := m.client.Status().Update(ctx, config); err != nil {
+		return fmt.Errorf("failed to update InferenceProviderConfig status: %w", err)
+	}
 	return nil
 }
 
@@ -199,9 +252,11 @@ func (m *ProviderConfigManager) StartHeartbeat(ctx context.Context) {
 				logger.Info("Stopping heartbeat goroutine")
 				return
 			case <-ticker.C:
-				if err := m.UpdateStatus(ctx, true); err != nil {
+				tickCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+				if err := m.UpdateStatusFromProbe(tickCtx); err != nil {
 					logger.Error(err, "Failed to update heartbeat")
 				}
+				cancel()
 			}
 		}
 	}()
@@ -209,5 +264,32 @@ func (m *ProviderConfigManager) StartHeartbeat(ctx context.Context) {
 
 // Unregister marks the provider as not ready
 func (m *ProviderConfigManager) Unregister(ctx context.Context) error {
-	return m.UpdateStatus(ctx, false)
+	return m.MarkUnregistered(ctx)
+}
+
+func upsertCondition(conditions *[]metav1.Condition, c metav1.Condition) {
+	for i := range *conditions {
+		if (*conditions)[i].Type == c.Type {
+			(*conditions)[i] = c
+			return
+		}
+	}
+	*conditions = append(*conditions, c)
+}
+
+func removeCondition(conditions *[]metav1.Condition, t string) {
+	out := (*conditions)[:0]
+	for _, c := range *conditions {
+		if c.Type != t {
+			out = append(out, c)
+		}
+	}
+	*conditions = out
+}
+
+func boolToConditionStatus(b bool) metav1.ConditionStatus {
+	if b {
+		return metav1.ConditionTrue
+	}
+	return metav1.ConditionFalse
 }

--- a/providers/kaito/config/rbac/role.yaml
+++ b/providers/kaito/config/rbac/role.yaml
@@ -83,3 +83,16 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get

--- a/providers/kaito/config_test.go
+++ b/providers/kaito/config_test.go
@@ -4,10 +4,16 @@ import (
 	"context"
 	"testing"
 
-	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
 )
 
 func TestGetProviderConfigSpec(t *testing.T) {
@@ -54,7 +60,7 @@ func TestGetProviderConfigSpec(t *testing.T) {
 }
 
 func TestNewProviderConfigManager(t *testing.T) {
-	mgr := NewProviderConfigManager(nil)
+	mgr := NewProviderConfigManager(nil, nil)
 	if mgr == nil {
 		t.Fatal("expected non-nil manager")
 	}
@@ -72,9 +78,10 @@ func TestProviderConstants(t *testing.T) {
 func TestRegisterNew(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = airunwayv1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&airunwayv1alpha1.InferenceProviderConfig{}).Build()
-	mgr := NewProviderConfigManager(c)
+	c := newFakeClientWithWorkspace(scheme)
+	mgr := NewProviderConfigManager(c, c)
 
 	err := mgr.Register(context.Background())
 	if err != nil {
@@ -85,32 +92,16 @@ func TestRegisterNew(t *testing.T) {
 func TestRegisterExisting(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = airunwayv1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
 
 	existing := &airunwayv1alpha1.InferenceProviderConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: ProviderConfigName},
 	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).WithStatusSubresource(existing).Build()
-	mgr := NewProviderConfigManager(c)
+	c := newFakeClientWithWorkspace(scheme, existing)
+	mgr := NewProviderConfigManager(c, c)
 
 	err := mgr.Register(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestUpdateStatus(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = airunwayv1alpha1.AddToScheme(scheme)
-
-	existing := &airunwayv1alpha1.InferenceProviderConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: ProviderConfigName},
-	}
-
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).WithStatusSubresource(existing).Build()
-	mgr := NewProviderConfigManager(c)
-
-	err := mgr.UpdateStatus(context.Background(), true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,7 +116,7 @@ func TestUnregister(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).WithStatusSubresource(existing).Build()
-	mgr := NewProviderConfigManager(c)
+	mgr := NewProviderConfigManager(c, c)
 
 	err := mgr.Unregister(context.Background())
 	if err != nil {
@@ -142,7 +133,7 @@ func TestStartHeartbeat(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).WithStatusSubresource(existing).Build()
-	mgr := NewProviderConfigManager(c)
+	mgr := NewProviderConfigManager(c, c)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mgr.StartHeartbeat(ctx)
@@ -150,15 +141,97 @@ func TestStartHeartbeat(t *testing.T) {
 	cancel()
 }
 
-func TestUpdateStatusNotFound(t *testing.T) {
+func TestUpdateStatusFromProbe_HealthyPath(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = airunwayv1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
 
-	c := fake.NewClientBuilder().WithScheme(scheme).Build()
-	mgr := NewProviderConfigManager(c)
-
-	err := mgr.UpdateStatus(context.Background(), true)
-	if err == nil {
-		t.Fatal("expected error when config not found")
+	config := &airunwayv1alpha1.InferenceProviderConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: ProviderConfigName},
 	}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kaito-workspace",
+			Namespace: "kaito-workspace",
+			Labels:    map[string]string{"app.kubernetes.io/name": "workspace"},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
+
+	c := newFakeClientWithWorkspace(scheme, config, deploy)
+	mgr := NewProviderConfigManager(c, c)
+	if err := mgr.UpdateStatusFromProbe(context.Background()); err != nil {
+		t.Fatalf("UpdateStatusFromProbe: %v", err)
+	}
+
+	got := &airunwayv1alpha1.InferenceProviderConfig{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: ProviderConfigName}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.Status.Ready {
+		t.Error("expected Ready=true")
+	}
+	cond := findCondition(got.Status.Conditions, "UpstreamReady")
+	if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != ReasonUpstreamHealthy {
+		t.Errorf("unexpected UpstreamReady condition: %+v", cond)
+	}
+}
+
+func TestMarkUnregistered(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = airunwayv1alpha1.AddToScheme(scheme)
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	config := &airunwayv1alpha1.InferenceProviderConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: ProviderConfigName},
+		Status:     airunwayv1alpha1.InferenceProviderConfigStatus{Ready: true},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(config).
+		WithStatusSubresource(config).
+		Build()
+
+	mgr := NewProviderConfigManager(c, c)
+	if err := mgr.MarkUnregistered(context.Background()); err != nil {
+		t.Fatalf("MarkUnregistered: %v", err)
+	}
+
+	got := &airunwayv1alpha1.InferenceProviderConfig{}
+	_ = c.Get(context.Background(), types.NamespacedName{Name: ProviderConfigName}, got)
+	if got.Status.Ready {
+		t.Error("expected Ready=false")
+	}
+	cond := findCondition(got.Status.Conditions, "UpstreamReady")
+	if cond == nil || cond.Reason != ReasonUnregistered {
+		t.Errorf("unexpected UpstreamReady condition: %+v", cond)
+	}
+}
+
+func findCondition(conds []metav1.Condition, t string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == t {
+			return &conds[i]
+		}
+	}
+	return nil
+}
+
+// newFakeClientWithWorkspace builds a fake client with the Workspace GVK registered
+// so simpleMapper (from upstream_health_test.go) recognises it during probe calls.
+func newFakeClientWithWorkspace(scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	// Register workspace GVK so the simpleMapper finds it
+	gvk := schema.GroupVersionKind{Group: "kaito.sh", Version: "v1beta1", Kind: "Workspace"}
+	scheme.AddKnownTypeWithName(gvk, &metav1.PartialObjectMetadata{})
+	gvkList := schema.GroupVersionKind{Group: "kaito.sh", Version: "v1beta1", Kind: "WorkspaceList"}
+	scheme.AddKnownTypeWithName(gvkList, &metav1.PartialObjectMetadataList{})
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "kaito.sh", Version: "v1beta1"})
+
+	mapper := &simpleMapper{scheme: scheme}
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(mapper).
+		WithObjects(objs...).
+		WithStatusSubresource(&airunwayv1alpha1.InferenceProviderConfig{}).
+		Build()
 }

--- a/providers/kaito/controller.go
+++ b/providers/kaito/controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -62,15 +64,19 @@ type KaitoProviderReconciler struct {
 	Scheme           *runtime.Scheme
 	Transformer      *Transformer
 	StatusTranslator *StatusTranslator
+	DirectClient     client.Client
+	Recorder         record.EventRecorder
 }
 
 // NewKaitoProviderReconciler creates a new KAITO provider reconciler
-func NewKaitoProviderReconciler(client client.Client, scheme *runtime.Scheme) *KaitoProviderReconciler {
+func NewKaitoProviderReconciler(c client.Client, scheme *runtime.Scheme, direct client.Client, recorder record.EventRecorder) *KaitoProviderReconciler {
 	return &KaitoProviderReconciler{
-		Client:           client,
+		Client:           c,
 		Scheme:           scheme,
 		Transformer:      NewTransformer(),
 		StatusTranslator: NewStatusTranslator(),
+		DirectClient:     direct,
+		Recorder:         recorder,
 	}
 }
 
@@ -127,6 +133,20 @@ func (r *KaitoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
 	}
 	r.setCondition(&md, airunwayv1alpha1.ConditionTypeProviderCompatible, metav1.ConditionTrue, "CompatibilityVerified", "Configuration compatible with KAITO")
+
+	// Upstream health probe — refuse-fast before transform if the real KAITO
+	// workspace controller is not running.
+	probeCtx, cancelProbe := context.WithTimeout(ctx, 10*time.Second)
+	health := probeUpstreamController(probeCtx, r.DirectClient)
+	cancelProbe()
+	if !health.Healthy {
+		r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, health.Reason, health.Message)
+		r.Recorder.Event(&md, corev1.EventTypeWarning, health.Reason, health.Message)
+		if err := r.Status().Update(ctx, &md); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+	}
 
 	// Transform ModelDeployment to KAITO Workspace
 	resources, err := r.Transformer.Transform(ctx, &md)

--- a/providers/kaito/controller_test.go
+++ b/providers/kaito/controller_test.go
@@ -2,14 +2,20 @@ package kaito
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -18,7 +24,33 @@ import (
 func newScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = airunwayv1alpha1.AddToScheme(s)
+	_ = clientgoscheme.AddToScheme(s)
 	return s
+}
+
+// newSchemeWithWorkspace returns a scheme that additionally has the kaito.sh/Workspace
+// GVK registered so the probe's REST-mapper check passes in fake-client tests.
+func newSchemeWithWorkspace() *runtime.Scheme {
+	s := newScheme()
+	gvk := schema.GroupVersionKind{Group: "kaito.sh", Version: "v1beta1", Kind: "Workspace"}
+	s.AddKnownTypeWithName(gvk, &metav1.PartialObjectMetadata{})
+	gvkList := schema.GroupVersionKind{Group: "kaito.sh", Version: "v1beta1", Kind: "WorkspaceList"}
+	s.AddKnownTypeWithName(gvkList, &metav1.PartialObjectMetadataList{})
+	metav1.AddToGroupVersion(s, schema.GroupVersion{Group: "kaito.sh", Version: "v1beta1"})
+	return s
+}
+
+// newReadyKaitoDeployment returns an appsv1.Deployment that satisfies the upstream
+// health probe (label app.kubernetes.io/name=workspace, ReadyReplicas=1).
+func newReadyKaitoDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kaito-workspace",
+			Namespace: "kaito-workspace",
+			Labels:    map[string]string{kaitoDeploymentSelectorKey: kaitoDeploymentSelectorValue},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+	}
 }
 
 func newMDForController(name, ns string) *airunwayv1alpha1.ModelDeployment {
@@ -175,7 +207,7 @@ func TestSetCondition(t *testing.T) {
 }
 
 func TestNewKaitoProviderReconciler(t *testing.T) {
-	r := NewKaitoProviderReconciler(nil, nil)
+	r := NewKaitoProviderReconciler(nil, nil, nil, record.NewFakeRecorder(10))
 	if r == nil {
 		t.Fatal("expected non-nil reconciler")
 	}
@@ -199,7 +231,7 @@ func TestControllerConstants(t *testing.T) {
 func TestReconcileNotFound(t *testing.T) {
 	scheme := newScheme()
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "missing", Namespace: "default"},
@@ -218,7 +250,7 @@ func TestReconcileWrongProvider(t *testing.T) {
 	md.Status.Provider.Name = "other-provider"
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -237,7 +269,7 @@ func TestReconcilePaused(t *testing.T) {
 	md.Annotations = map[string]string{"airunway.ai/reconcile-paused": "true"}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -255,7 +287,7 @@ func TestReconcileAddsFinalizer(t *testing.T) {
 	md := newMDForController("test", "default")
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -284,7 +316,7 @@ func TestReconcileIncompatibleEngine(t *testing.T) {
 	controllerutil.AddFinalizer(md, FinalizerName)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -308,7 +340,9 @@ func TestReconcileTransformFailure(t *testing.T) {
 	controllerutil.AddFinalizer(md, FinalizerName)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	deploy := newReadyKaitoDeployment()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(deploy).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -330,7 +364,7 @@ func TestReconcileNilProvider(t *testing.T) {
 	md.Status.Provider = nil
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -349,7 +383,9 @@ func TestReconcileSuccessfulCreate(t *testing.T) {
 	controllerutil.AddFinalizer(md, FinalizerName)
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	deploy := newReadyKaitoDeployment()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(deploy).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -407,8 +443,10 @@ func TestReconcileAlreadyRunning(t *testing.T) {
 		},
 	}
 
+	deploy := newReadyKaitoDeployment()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(deploy).Build()
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, ws).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -436,7 +474,7 @@ func TestReconcileHandleDeletion(t *testing.T) {
 	md.DeletionTimestamp = &now
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -465,7 +503,7 @@ func TestReconcileDeletionNoFinalizer(t *testing.T) {
 	md.Finalizers = []string{"other-finalizer"}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -496,7 +534,7 @@ func TestReconcileDeletionWithUpstreamResource(t *testing.T) {
 	})
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, ws).WithStatusSubresource(md).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
@@ -513,7 +551,7 @@ func TestReconcileDeletionWithUpstreamResource(t *testing.T) {
 func TestCreateOrUpdateResourceNew(t *testing.T) {
 	scheme := newScheme()
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	md := &airunwayv1alpha1.ModelDeployment{}
 	md.Name = "test"
@@ -553,7 +591,7 @@ func TestCreateOrUpdateResourceUpdate(t *testing.T) {
 	existing.Object["resource"] = map[string]interface{}{"count": int64(1)}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	md := &airunwayv1alpha1.ModelDeployment{}
 	md.Name = "test"
@@ -587,7 +625,7 @@ func TestCreateOrUpdateResourceNoChange(t *testing.T) {
 	existing.Object["inference"] = map[string]interface{}{"preset": map[string]interface{}{"name": "test"}}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	md := &airunwayv1alpha1.ModelDeployment{}
 	md.Name = "test"
@@ -611,7 +649,7 @@ func TestCreateOrUpdateResourceNoChange(t *testing.T) {
 func TestSyncStatusNotFound(t *testing.T) {
 	scheme := newScheme()
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	md := &airunwayv1alpha1.ModelDeployment{}
 	desired := &unstructured.Unstructured{}
@@ -642,7 +680,7 @@ func TestSyncStatusRunning(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	md := &airunwayv1alpha1.ModelDeployment{}
 	desired := &unstructured.Unstructured{}
@@ -677,7 +715,7 @@ func TestSyncStatusFailed(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	md := &airunwayv1alpha1.ModelDeployment{}
 	desired := &unstructured.Unstructured{}
@@ -711,7 +749,7 @@ func TestSyncStatusDeploying(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws).Build()
-	r := NewKaitoProviderReconciler(c, scheme)
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
 
 	md := &airunwayv1alpha1.ModelDeployment{}
 	desired := &unstructured.Unstructured{}
@@ -725,6 +763,109 @@ func TestSyncStatusDeploying(t *testing.T) {
 	}
 	if md.Status.Phase != airunwayv1alpha1.DeploymentPhaseDeploying {
 		t.Errorf("expected Deploying phase, got %s", md.Status.Phase)
+	}
+}
+
+func TestReconcile_InvalidSpecReportsCompatibilityBeforeProbe(t *testing.T) {
+	md := &airunwayv1alpha1.ModelDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "default", Finalizers: []string{FinalizerName}},
+		Spec: airunwayv1alpha1.ModelDeploymentSpec{
+			Model:   airunwayv1alpha1.ModelSpec{ID: "m", Source: airunwayv1alpha1.ModelSourceHuggingFace},
+			Engine:  airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM},
+			Serving: &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated},
+		},
+		Status: airunwayv1alpha1.ModelDeploymentStatus{
+			Provider: &airunwayv1alpha1.ProviderStatus{Name: ProviderName},
+		},
+	}
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(md).WithStatusSubresource(md).Build()
+	rec := record.NewFakeRecorder(10)
+	r := &KaitoProviderReconciler{
+		Client:           c,
+		Scheme:           s,
+		Transformer:      NewTransformer(),
+		StatusTranslator: NewStatusTranslator(),
+		DirectClient:     c,
+		Recorder:         rec,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "bad", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	got := &airunwayv1alpha1.ModelDeployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Name: "bad", Namespace: "default"}, got)
+
+	// Must see IncompatibleConfiguration, NOT an upstream-health reason.
+	if got.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("expected Phase=Failed, got %q", got.Status.Phase)
+	}
+	if !strings.Contains(got.Status.Message, "disaggregated") {
+		t.Errorf("expected message about disaggregated, got %q", got.Status.Message)
+	}
+}
+
+func TestReconcile_UnhealthyProbeRefusesFast(t *testing.T) {
+	md := &airunwayv1alpha1.ModelDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "mymd", Namespace: "default", Finalizers: []string{FinalizerName}},
+		Spec: airunwayv1alpha1.ModelDeploymentSpec{
+			Model:  airunwayv1alpha1.ModelSpec{ID: "m", Source: airunwayv1alpha1.ModelSourceHuggingFace},
+			Engine: airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM},
+			Resources: &airunwayv1alpha1.ResourceSpec{
+				GPU: &airunwayv1alpha1.GPUSpec{Count: 1},
+			},
+		},
+		Status: airunwayv1alpha1.ModelDeploymentStatus{
+			Provider: &airunwayv1alpha1.ProviderStatus{Name: ProviderName},
+		},
+	}
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kaito-local-nvme-disk",
+			Labels: map[string]string{"app.kubernetes.io/managed-by": "Eno"},
+		},
+		Provisioner: "test",
+	}
+	s := newScheme()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(md).WithStatusSubresource(md).Build()
+	// directC: has Workspace CRD + Eno StorageClass, but NO ready deployment → EnoPartialInstall
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(sc).Build()
+	rec := record.NewFakeRecorder(10)
+	r := &KaitoProviderReconciler{
+		Client:           c,
+		Scheme:           s,
+		Transformer:      NewTransformer(),
+		StatusTranslator: NewStatusTranslator(),
+		DirectClient:     directC,
+		Recorder:         rec,
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "mymd", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter != RequeueInterval {
+		t.Errorf("expected RequeueAfter=%v, got %v", RequeueInterval, res.RequeueAfter)
+	}
+
+	got := &airunwayv1alpha1.ModelDeployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Name: "mymd", Namespace: "default"}, got)
+
+	// Phase must NOT be set to Failed (transient state).
+	if got.Status.Phase == airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("expected Phase to be left untouched, got Failed")
+	}
+
+	// Event must have been recorded.
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, ReasonEnoPartialInstall) && !strings.Contains(ev, ReasonUpstreamControllerMissing) {
+			t.Errorf("expected event with upstream reason, got %q", ev)
+		}
+	default:
+		t.Error("expected a Warning event, none recorded")
 	}
 }
 

--- a/providers/kaito/upstream_health.go
+++ b/providers/kaito/upstream_health.go
@@ -19,8 +19,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -135,8 +133,3 @@ func listWorkspaceController(ctx context.Context, direct client.Client) (*appsv1
 	}
 	return &list.Items[0], true, nil
 }
-
-// Ensure unstructured/schema types are referenced so goimports is stable even
-// before later tasks add their uses.
-var _ = unstructured.Unstructured{}
-var _ schema.GroupVersionKind

--- a/providers/kaito/upstream_health.go
+++ b/providers/kaito/upstream_health.go
@@ -19,6 +19,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -74,7 +75,32 @@ const (
 //  4. Any unexpected API error returns Reason=ProbeFailed
 func probeUpstreamController(ctx context.Context, direct client.Client) UpstreamHealth {
 	_ = log.FromContext(ctx)
-	// Stub — replaced incrementally in Tasks 2–5.
+	// Step 1: Detect CRD presence by querying the REST mapper for the Workspace kind.
+	workspaceGVK := schema.GroupVersionKind{
+		Group:   "kaito.sh",
+		Version: "v1beta1",
+		Kind:    "Workspace",
+	}
+
+	// Try to get the REST mapping for Workspace. If the CRD is not installed,
+	// the REST mapper will not have a mapping and will return a NoKindMatchError.
+	_, err := direct.RESTMapper().RESTMapping(workspaceGVK.GroupKind())
+	if isNoKindMatch(err) {
+		return UpstreamHealth{
+			Healthy: false,
+			Reason:  ReasonCRDMissing,
+			Message: crdMissingUserMessage,
+		}
+	}
+	if err != nil {
+		return UpstreamHealth{
+			Healthy: false,
+			Reason:  ReasonProbeFailed,
+			Message: fmt.Sprintf("check workspace crd: %v", err),
+		}
+	}
+
+	// Steps 2-3 implemented in later tasks.
 	return UpstreamHealth{
 		Healthy: false,
 		Reason:  ReasonProbeFailed,

--- a/providers/kaito/upstream_health.go
+++ b/providers/kaito/upstream_health.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // UpstreamHealth summarises the state of the real KAITO workspace controller.
@@ -74,16 +73,12 @@ const (
 //  3. Find the controller Deployment by label
 //  4. Any unexpected API error returns Reason=ProbeFailed
 func probeUpstreamController(ctx context.Context, direct client.Client) UpstreamHealth {
-	_ = log.FromContext(ctx)
-	// Step 1: Detect CRD presence by querying the REST mapper for the Workspace kind.
+	// Step 1: Detect CRD presence by checking the REST mapper.
 	workspaceGVK := schema.GroupVersionKind{
 		Group:   "kaito.sh",
 		Version: "v1beta1",
 		Kind:    "Workspace",
 	}
-
-	// Try to get the REST mapping for Workspace. If the CRD is not installed,
-	// the REST mapper will not have a mapping and will return a NoKindMatchError.
 	_, err := direct.RESTMapper().RESTMapping(workspaceGVK.GroupKind())
 	if isNoKindMatch(err) {
 		return UpstreamHealth{
@@ -100,11 +95,57 @@ func probeUpstreamController(ctx context.Context, direct client.Client) Upstream
 		}
 	}
 
-	// Steps 2-3 implemented in later tasks.
+	// Step 2: Detect Eno signal from the well-known StorageClass.
+	managedBy, err := getStorageClassManagedBy(ctx, direct)
+	if err != nil {
+		return UpstreamHealth{
+			Healthy: false,
+			Reason:  ReasonProbeFailed,
+			Message: err.Error(),
+		}
+	}
+
+	// Step 3: Find the controller Deployment by label.
+	deploy, found, err := listWorkspaceController(ctx, direct)
+	if err != nil {
+		return UpstreamHealth{
+			Healthy:   false,
+			Reason:    ReasonProbeFailed,
+			Message:   err.Error(),
+			ManagedBy: managedBy,
+		}
+	}
+	if !found {
+		if managedBy == managedByEno {
+			return UpstreamHealth{
+				Healthy:   false,
+				Reason:    ReasonEnoPartialInstall,
+				Message:   enoPartialInstallUserMessage,
+				ManagedBy: managedByEno,
+			}
+		}
+		return UpstreamHealth{
+			Healthy:   false,
+			Reason:    ReasonUpstreamControllerMissing,
+			Message:   controllerMissingUserMessage,
+			ManagedBy: managedBy,
+		}
+	}
+
+	// Step 4: Deployment found — healthy if ReadyReplicas > 0, otherwise NotReady.
+	if deploy.Status.ReadyReplicas > 0 {
+		return UpstreamHealth{
+			Healthy:   true,
+			Reason:    ReasonUpstreamHealthy,
+			Message:   fmt.Sprintf("KAITO workspace controller %s/%s is ready", deploy.Namespace, deploy.Name),
+			ManagedBy: managedBy,
+		}
+	}
 	return UpstreamHealth{
-		Healthy: false,
-		Reason:  ReasonProbeFailed,
-		Message: "probe not implemented",
+		Healthy:   false,
+		Reason:    ReasonUpstreamControllerNotReady,
+		Message:   fmt.Sprintf(controllerNotReadyUserMessage, deploy.Namespace, deploy.Name),
+		ManagedBy: managedBy,
 	}
 }
 

--- a/providers/kaito/upstream_health.go
+++ b/providers/kaito/upstream_health.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kaito
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// UpstreamHealth summarises the state of the real KAITO workspace controller.
+// The probe is called from both the heartbeat loop (writing InferenceProviderConfig.status)
+// and the ModelDeployment reconcile loop (refuse-fast when upstream is broken).
+type UpstreamHealth struct {
+	Healthy   bool
+	Reason    string // one of the Reason* constants
+	Message   string // user-facing, safe to surface in CR status
+	ManagedBy string // "Helm", "Eno", or "" (unknown / no candidate resource)
+}
+
+// Reason codes stamped into InferenceProviderConfig.status.conditions[UpstreamReady]
+// and into ModelDeployment.status.conditions[Ready] on the refuse-fast path.
+const (
+	ReasonUpstreamHealthy            = "UpstreamHealthy"
+	ReasonCRDMissing                 = "CRDMissing"
+	ReasonUpstreamControllerMissing  = "UpstreamControllerMissing"
+	ReasonUpstreamControllerNotReady = "UpstreamControllerNotReady"
+	ReasonEnoPartialInstall          = "EnoPartialInstall"
+	ReasonProbeFailed                = "ProbeFailed"
+	ReasonUnregistered               = "Unregistered" // stamped by MarkUnregistered on shim shutdown
+)
+
+// Well-known resource names the probe looks up.
+const (
+	kaitoStorageClassName         = "kaito-local-nvme-disk"
+	kaitoDeploymentSelectorKey    = "app.kubernetes.io/name"
+	kaitoDeploymentSelectorValue  = "workspace"
+	managedByLabel                = "app.kubernetes.io/managed-by"
+	managedByEno                  = "Eno"
+	managedByHelm                 = "Helm"
+	enoPartialInstallUserMessage  = "This cluster was set up with `--enable-ai-toolchain-operator`, which installs KAITO partially (CRDs and StorageClass only). The KAITO workspace controller is not running. Options: (1) disable the AKS extension with `az aks update --disable-ai-toolchain-operator ...` and then click Install KAITO, or (2) install the `kaito-workspace` controller manually."
+	controllerMissingUserMessage  = "The KAITO workspace controller is not running. Install KAITO with `helm install kaito-workspace kaito/workspace`."
+	controllerNotReadyUserMessage = "The KAITO workspace controller Deployment %s/%s exists but has no ready replicas."
+	crdMissingUserMessage         = "KAITO Workspace CRD not found. Install KAITO."
+)
+
+// probeUpstreamController checks whether the upstream kaito-workspace controller
+// is installed and running. The caller is responsible for applying a bounded
+// timeout (e.g. context.WithTimeout(ctx, 10*time.Second)) and for passing an
+// uncached direct client — NOT the manager's cached client. The function
+// performs a handful of direct API calls per invocation and does not rely on
+// informer caches.
+//
+// Probe order:
+//  1. Detect CRD presence (via meta.NoKindMatchError on workspaces list)
+//  2. Detect Eno signal (via the kaito-local-nvme-disk StorageClass label)
+//  3. Find the controller Deployment by label
+//  4. Any unexpected API error returns Reason=ProbeFailed
+func probeUpstreamController(ctx context.Context, direct client.Client) UpstreamHealth {
+	_ = log.FromContext(ctx)
+	// Stub — replaced incrementally in Tasks 2–5.
+	return UpstreamHealth{
+		Healthy: false,
+		Reason:  ReasonProbeFailed,
+		Message: "probe not implemented",
+	}
+}
+
+// isNoKindMatch returns true when err (possibly wrapped) indicates that the
+// REST mapper has no mapping for the queried kind — i.e. the CRD is not
+// installed in the cluster.
+func isNoKindMatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	var nkm *meta.NoKindMatchError
+	return errors.As(err, &nkm)
+}
+
+// getStorageClassManagedBy reads the kaito-local-nvme-disk StorageClass and
+// returns its app.kubernetes.io/managed-by label. Returns "" if the
+// StorageClass does not exist; returns an error for any other failure.
+func getStorageClassManagedBy(ctx context.Context, direct client.Client) (string, error) {
+	sc := &storagev1.StorageClass{}
+	err := direct.Get(ctx, types.NamespacedName{Name: kaitoStorageClassName}, sc)
+	if apierrors.IsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get storageclass %q: %w", kaitoStorageClassName, err)
+	}
+	if sc.Labels == nil {
+		return "", nil
+	}
+	return sc.Labels[managedByLabel], nil
+}
+
+// listWorkspaceController returns the first Deployment matching the KAITO
+// workspace controller label selector. It also returns a second return value
+// indicating whether any Deployment with the selector was found (so callers
+// can distinguish "missing" from "not ready").
+func listWorkspaceController(ctx context.Context, direct client.Client) (*appsv1.Deployment, bool, error) {
+	list := &appsv1.DeploymentList{}
+	if err := direct.List(ctx, list, client.MatchingLabels{kaitoDeploymentSelectorKey: kaitoDeploymentSelectorValue}); err != nil {
+		return nil, false, fmt.Errorf("list deployments: %w", err)
+	}
+	if len(list.Items) == 0 {
+		return nil, false, nil
+	}
+	// Prefer a ready one; otherwise return the first item so the caller can
+	// reference the namespace/name in the message.
+	for i := range list.Items {
+		d := &list.Items[i]
+		if d.Status.ReadyReplicas > 0 {
+			return d, true, nil
+		}
+	}
+	return &list.Items[0], true, nil
+}
+
+// Ensure unstructured/schema types are referenced so goimports is stable even
+// before later tasks add their uses.
+var _ = unstructured.Unstructured{}
+var _ schema.GroupVersionKind

--- a/providers/kaito/upstream_health_test.go
+++ b/providers/kaito/upstream_health_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026.
+*/
+
+package kaito
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
+)
+
+// simpleMapper is a minimal REST mapper that checks the scheme for registered types.
+type simpleMapper struct {
+	scheme *runtime.Scheme
+}
+
+func (m *simpleMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	// Check if the kind is registered in the scheme
+	knownTypes := m.scheme.AllKnownTypes()
+	for registeredGVK := range knownTypes {
+		if registeredGVK.Group == gk.Group && registeredGVK.Kind == gk.Kind {
+			// Kind found in scheme
+			return &meta.RESTMapping{}, nil
+		}
+	}
+	// Kind not found in scheme; return NoKindMatchError
+	return nil, &meta.NoKindMatchError{GroupKind: gk}
+}
+
+func (m *simpleMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	mapping, err := m.RESTMapping(gk, versions...)
+	if err != nil {
+		return nil, err
+	}
+	return []*meta.RESTMapping{mapping}, nil
+}
+
+func (m *simpleMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	return resource, nil
+}
+
+func (m *simpleMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return []schema.GroupVersionResource{input}, nil
+}
+
+func (m *simpleMapper) KindsFor(input schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return []schema.GroupVersionKind{
+		{
+			Group:   input.Group,
+			Version: input.Version,
+			Kind:    "Unknown",
+		},
+	}, nil
+}
+
+func (m *simpleMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return input, nil
+}
+
+func (m *simpleMapper) KindFor(input schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{
+		Group:   input.Group,
+		Version: input.Version,
+		Kind:    "Unknown",
+	}, nil
+}
+
+// probeTestScheme returns a scheme with the core k8s types + airunway v1alpha1.
+// It intentionally does NOT register kaito.sh/Workspace — tests that need the
+// CRD present should use probeTestSchemeWithWorkspace instead.
+func probeTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme.AddToScheme: %v", err)
+	}
+	if err := airunwayv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("airunway AddToScheme: %v", err)
+	}
+	return s
+}
+
+// probeTestSchemeWithWorkspace adds the kaito.sh/Workspace GVK as an unstructured
+// registration so the fake client's REST mapper will match it.
+func probeTestSchemeWithWorkspace(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := probeTestScheme(t)
+	gvk := schema.GroupVersionKind{Group: "kaito.sh", Version: "v1beta1", Kind: "Workspace"}
+	s.AddKnownTypeWithName(gvk, &metav1.PartialObjectMetadata{})
+	gvkList := schema.GroupVersionKind{Group: "kaito.sh", Version: "v1beta1", Kind: "WorkspaceList"}
+	s.AddKnownTypeWithName(gvkList, &metav1.PartialObjectMetadataList{})
+	metav1.AddToGroupVersion(s, schema.GroupVersion{Group: "kaito.sh", Version: "v1beta1"})
+	return s
+}
+
+func TestProbe_CRDMissing(t *testing.T) {
+	// Scheme without kaito.sh registered — List will fail with NoKindMatchError.
+	// We need to create a simple REST mapper that only knows about registered types.
+	scheme := probeTestScheme(t)
+	mapper := &simpleMapper{scheme: scheme}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRESTMapper(mapper).Build()
+
+	got := probeUpstreamController(context.Background(), c)
+
+	if got.Healthy {
+		t.Errorf("expected Healthy=false, got true")
+	}
+	if got.Reason != ReasonCRDMissing {
+		t.Errorf("expected Reason=%s, got %s", ReasonCRDMissing, got.Reason)
+	}
+	if got.Message != crdMissingUserMessage {
+		t.Errorf("unexpected Message: %s", got.Message)
+	}
+	// Sanity: helper stays exercised
+	_ = meta.NoKindMatchError{}
+	_ = client.InNamespace("")
+	_ = appsv1.Deployment{}
+	_ = storagev1.StorageClass{}
+}

--- a/providers/kaito/upstream_health_test.go
+++ b/providers/kaito/upstream_health_test.go
@@ -105,6 +105,140 @@ func probeTestSchemeWithWorkspace(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+// probeClientBuilderWithWorkspace returns a fake.ClientBuilder pre-configured
+// with the Workspace scheme and a simpleMapper that recognises it. Use this
+// helper for all probe tests that expect the Workspace CRD to be present.
+func probeClientBuilderWithWorkspace(t *testing.T) *fake.ClientBuilder {
+	t.Helper()
+	s := probeTestSchemeWithWorkspace(t)
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithRESTMapper(&simpleMapper{scheme: s})
+}
+
+func newStorageClass(name, managedBy string) *storagev1.StorageClass {
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Provisioner: "test",
+	}
+	if managedBy != "" {
+		sc.Labels = map[string]string{managedByLabel: managedBy}
+	}
+	return sc
+}
+
+func newKaitoDeployment(namespace, name string, readyReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{kaitoDeploymentSelectorKey: kaitoDeploymentSelectorValue},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: readyReplicas},
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProbe_EnoStorageClass_NoController(t *testing.T) {
+	sc := newStorageClass(kaitoStorageClassName, managedByEno)
+	c := probeClientBuilderWithWorkspace(t).
+		WithObjects(sc).
+		Build()
+
+	got := probeUpstreamController(context.Background(), c)
+
+	if got.Healthy {
+		t.Error("expected Healthy=false")
+	}
+	if got.Reason != ReasonEnoPartialInstall {
+		t.Errorf("expected Reason=%s, got %s", ReasonEnoPartialInstall, got.Reason)
+	}
+	if got.ManagedBy != managedByEno {
+		t.Errorf("expected ManagedBy=%s, got %s", managedByEno, got.ManagedBy)
+	}
+	if got.Message != enoPartialInstallUserMessage {
+		t.Errorf("unexpected Message: %s", got.Message)
+	}
+}
+
+func TestProbe_HelmStorageClass_NoController(t *testing.T) {
+	sc := newStorageClass(kaitoStorageClassName, managedByHelm)
+	c := probeClientBuilderWithWorkspace(t).
+		WithObjects(sc).
+		Build()
+
+	got := probeUpstreamController(context.Background(), c)
+
+	if got.Reason != ReasonUpstreamControllerMissing {
+		t.Errorf("expected Reason=%s, got %s", ReasonUpstreamControllerMissing, got.Reason)
+	}
+	if got.ManagedBy != managedByHelm {
+		t.Errorf("expected ManagedBy=%s, got %s", managedByHelm, got.ManagedBy)
+	}
+}
+
+func TestProbe_NoStorageClass_NoController(t *testing.T) {
+	c := probeClientBuilderWithWorkspace(t).
+		Build()
+
+	got := probeUpstreamController(context.Background(), c)
+
+	if got.Reason != ReasonUpstreamControllerMissing {
+		t.Errorf("expected Reason=%s, got %s", ReasonUpstreamControllerMissing, got.Reason)
+	}
+	if got.ManagedBy != "" {
+		t.Errorf("expected ManagedBy='', got %q", got.ManagedBy)
+	}
+}
+
+func TestProbe_ControllerReady(t *testing.T) {
+	d := newKaitoDeployment("kaito-workspace", "kaito-workspace", 1)
+	c := probeClientBuilderWithWorkspace(t).
+		WithObjects(d).
+		Build()
+
+	got := probeUpstreamController(context.Background(), c)
+
+	if !got.Healthy {
+		t.Errorf("expected Healthy=true, got %+v", got)
+	}
+	if got.Reason != ReasonUpstreamHealthy {
+		t.Errorf("expected Reason=%s, got %s", ReasonUpstreamHealthy, got.Reason)
+	}
+}
+
+func TestProbe_ControllerNotReady(t *testing.T) {
+	d := newKaitoDeployment("kaito-workspace", "kaito-workspace", 0)
+	c := probeClientBuilderWithWorkspace(t).
+		WithObjects(d).
+		Build()
+
+	got := probeUpstreamController(context.Background(), c)
+
+	if got.Healthy {
+		t.Error("expected Healthy=false")
+	}
+	if got.Reason != ReasonUpstreamControllerNotReady {
+		t.Errorf("expected Reason=%s, got %s", ReasonUpstreamControllerNotReady, got.Reason)
+	}
+	want := "kaito-workspace/kaito-workspace"
+	if !stringContains(got.Message, want) {
+		t.Errorf("expected Message to contain %q, got %q", want, got.Message)
+	}
+}
+
 func TestProbe_CRDMissing(t *testing.T) {
 	// Scheme without kaito.sh registered — List will fail with NoKindMatchError.
 	// We need to create a simple REST mapper that only knows about registered types.

--- a/providers/kaito/upstream_health_test.go
+++ b/providers/kaito/upstream_health_test.go
@@ -263,3 +263,22 @@ func TestProbe_CRDMissing(t *testing.T) {
 	_ = appsv1.Deployment{}
 	_ = storagev1.StorageClass{}
 }
+
+func TestProbe_ContextCancelled(t *testing.T) {
+	c := probeClientBuilderWithWorkspace(t).
+		Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	got := probeUpstreamController(ctx, c)
+
+	// The key invariant: probe doesn't report healthy on a cancelled context.
+	if got.Healthy {
+		t.Error("expected Healthy=false on cancelled context")
+	}
+	// The exact reason depends on which step the fake client fails at.
+	// Since the fake client doesn't actually check context cancellation,
+	// it will proceed through the normal probe steps and fail at whichever
+	// resource is missing first. The important thing is that Healthy=false.
+}

--- a/shared/types/settings.ts
+++ b/shared/types/settings.ts
@@ -81,6 +81,7 @@ export interface RuntimeStatus {
   healthy: boolean;     // Operator pods running
   version?: string;     // Detected version
   message?: string;     // Status message
+  managedBy?: string;   // Detected managing operator (e.g. 'Eno', 'Helm')
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Go shim**: new `probeUpstreamController` checks the real KAITO workspace controller Deployment (label-based, uncached direct client, 10s timeout) and the `kaito-local-nvme-disk` StorageClass for Eno ownership. `InferenceProviderConfig.status.ready` is now set from the probe result instead of unconditionally `true`. The reconciler refuses to create a Workspace CR when upstream is unhealthy, stamping `Ready=False` with a targeted reason + emitting a Kubernetes event — without touching `Status.Phase` (transient state, self-recovering).
- **Backend**: new `providerHealth.ts` service wraps CR status with staleness override, KAITO-specific Eno StorageClass fallback, and an `EnoPartialInstallSuspected` override for old-shim clusters. Both `getRuntimesStatus` and `GET /providers/:id/status` now route through it. The helm install endpoint returns `409` with a structured `InstallConflict` body when Eno owns the target StorageClass.
- **RBAC**: shim gains cluster-wide `get,list` on `apps/deployments` and `get` on `storage.k8s.io/storageclasses` (no `watch`).

Fixes #179

## Test plan

- [ ] Go race-detector tests pass (`go test -race ./...` in `providers/kaito/`)
- [ ] 15 new TS tests (11 providerHealth, 4 installation routes) — `bun run test` 621/621 pass
- [ ] Manual: AKS cluster with `--enable-ai-toolchain-operator` → Settings → Runtimes shows unhealthy with Eno message within one heartbeat tick → ModelDeployment gets `Ready=False` with `EnoPartialInstall` within seconds → "Install KAITO" returns 409 with actionable error

