### PR TITLE
fix(dynamo): prevent panic on nodeSelector deep copy

### DIFF
--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -778,7 +778,11 @@ func (t *Transformer) addSchedulingConfig(service map[string]interface{}, md *ai
 	}
 
 	if len(md.Spec.NodeSelector) > 0 {
-		extraPodSpec["nodeSelector"] = md.Spec.NodeSelector
+		ns := make(map[string]interface{}, len(md.Spec.NodeSelector))
+		for k, v := range md.Spec.NodeSelector {
+			ns[k] = v
+		}
+		extraPodSpec["nodeSelector"] = ns
 	}
 
 	if len(md.Spec.Tolerations) > 0 {

--- a/providers/dynamo/transformer_test.go
+++ b/providers/dynamo/transformer_test.go
@@ -587,9 +587,15 @@ func TestAddSchedulingConfig(t *testing.T) {
 	}
 	tr.addSchedulingConfig(service, md)
 	eps, _ := service["extraPodSpec"].(map[string]interface{})
-	ns, _ := eps["nodeSelector"].(map[string]string)
+	ns, _ := eps["nodeSelector"].(map[string]interface{})
 	if ns["gpu"] != "a100" {
 		t.Errorf("expected nodeSelector gpu=a100")
+	}
+
+	// Verify nodeSelector is a copy (safe for unstructured deep copy)
+	md.Spec.NodeSelector["gpu"] = "changed"
+	if ns["gpu"] != "a100" {
+		t.Errorf("nodeSelector should be a copy, not a reference to the original map")
 	}
 
 	// With tolerations


### PR DESCRIPTION
## Problem

When creating a ModelDeployment with `nodeSelector` to target a dedicated GPU node pool (e.g. scheduling vLLM workers onto specific GKE nodes with NVIDIA L4 GPUs), the dynamo provider shim panics:

```
panic: cannot deep copy map[string]string
```

Without `nodeSelector`, there is no way to pin workloads to a specific GPU node pool when a cluster has multiple pools with different GPU types or driver configurations.

## Root Cause

`addSchedulingConfig` in `transformer.go` assigns `md.Spec.NodeSelector` (`map[string]string`) directly into the unstructured service map. When `createOrUpdateResource` calls `equality.Semantic.DeepEqual` on the unstructured object, it panics because only `map[string]interface{}` is supported inside unstructured maps.

## Fix

Convert nodeSelector entries to `map[string]interface{}` before assignment, matching the pattern already used for tolerations in the same function.

## Test

Updated `TestAddSchedulingConfig` to assert `map[string]interface{}` type and added a mutation guard verifying the stored map is a copy, not a reference.