### PR TITLE
feat(dynamo): add `setup-dynamo` and `cleanup-dynamo` Makefile targets

### DIFF
--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -5,7 +5,7 @@ PUSH ?= false
 PUSH_ENABLED := $(filter true TRUE 1 yes YES on ON,$(PUSH))
 IMAGE_OUTPUT_FLAG := $(if $(PUSH_ENABLED),--push,--load)
 
-.PHONY: build docker-build deploy generate-deploy-manifests test-e2e
+.PHONY: build docker-build deploy generate-deploy-manifests setup-dynamo cleanup-dynamo test-e2e
 
 ## Build the provider binary
 build:
@@ -31,6 +31,34 @@ generate-deploy-manifests:
 	$(KUSTOMIZE) build config/default > deploy/dynamo.yaml
 	@git checkout config/manager/kustomization.yaml 2>/dev/null || true
 	@echo "✅ Generated deploy/dynamo.yaml"
+
+## Install Dynamo platform on the cluster (run before test-e2e)
+DYNAMO_NAMESPACE ?= dynamo-system
+DYNAMO_VERSION ?= 1.0.2
+DYNAMO_CHART_URL := https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-$(DYNAMO_VERSION).tgz
+DYNAMO_PRE_DEPLOY_URL := https://raw.githubusercontent.com/ai-dynamo/dynamo/main/deploy/pre-deployment/pre-deployment-check.sh
+
+setup-dynamo:
+	@echo "Running Dynamo pre-deployment checks..."
+	@TMPSCRIPT=$$(mktemp --suffix=.sh) && \
+		curl -fsSL "$(DYNAMO_PRE_DEPLOY_URL)" -o "$$TMPSCRIPT" && \
+		chmod +x "$$TMPSCRIPT" && \
+		bash "$$TMPSCRIPT" && \
+		rm -f "$$TMPSCRIPT"
+	@echo "Installing Dynamo platform v$(DYNAMO_VERSION)..."
+	@CHART_TGZ="dynamo-platform-$(DYNAMO_VERSION).tgz" && \
+		helm fetch "$(DYNAMO_CHART_URL)" && \
+		helm upgrade -i dynamo-platform "$$CHART_TGZ" \
+			--namespace $(DYNAMO_NAMESPACE) \
+			--create-namespace \
+			--set "dynamo-operator.controllerManager.manager.image.tag=$(DYNAMO_VERSION)" && \
+		rm -f "$$CHART_TGZ"
+	@echo "✅ Dynamo platform v$(DYNAMO_VERSION) installed in namespace $(DYNAMO_NAMESPACE)"
+
+## Uninstall Dynamo platform from the cluster
+cleanup-dynamo:
+	helm uninstall dynamo-platform --namespace $(DYNAMO_NAMESPACE)
+	@echo "✅ Dynamo platform uninstalled from namespace $(DYNAMO_NAMESPACE)"
 
 ## Run e2e tests (requires DYNAMO_INSTALLED=true and a cluster with dynamo provider deployed)
 test-e2e:

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -36,28 +36,25 @@ generate-deploy-manifests:
 DYNAMO_NAMESPACE ?= dynamo-system
 DYNAMO_VERSION ?= 1.0.2
 DYNAMO_CHART_URL := https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-$(DYNAMO_VERSION).tgz
-DYNAMO_PRE_DEPLOY_URL := https://raw.githubusercontent.com/ai-dynamo/dynamo/main/deploy/pre-deployment/pre-deployment-check.sh
+DYNAMO_PRE_DEPLOY_URL := https://raw.githubusercontent.com/ai-dynamo/dynamo/v$(DYNAMO_VERSION)/deploy/pre-deployment/pre-deployment-check.sh
 
 setup-dynamo:
 	@echo "Running Dynamo pre-deployment checks..."
-	@TMPSCRIPT=$$(mktemp --suffix=.sh) && \
+	@TMPSCRIPT=$$(mktemp) && \
+		trap 'rm -f "$$TMPSCRIPT"' EXIT && \
 		curl -fsSL "$(DYNAMO_PRE_DEPLOY_URL)" -o "$$TMPSCRIPT" && \
 		chmod +x "$$TMPSCRIPT" && \
-		bash "$$TMPSCRIPT" && \
-		rm -f "$$TMPSCRIPT"
+		bash "$$TMPSCRIPT"
 	@echo "Installing Dynamo platform v$(DYNAMO_VERSION)..."
-	@CHART_TGZ="dynamo-platform-$(DYNAMO_VERSION).tgz" && \
-		helm fetch "$(DYNAMO_CHART_URL)" && \
-		helm upgrade -i dynamo-platform "$$CHART_TGZ" \
+	@helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
 			--namespace $(DYNAMO_NAMESPACE) \
 			--create-namespace \
-			--set "dynamo-operator.controllerManager.manager.image.tag=$(DYNAMO_VERSION)" && \
-		rm -f "$$CHART_TGZ"
+			--set "dynamo-operator.controllerManager.manager.image.tag=$(DYNAMO_VERSION)"
 	@echo "✅ Dynamo platform v$(DYNAMO_VERSION) installed in namespace $(DYNAMO_NAMESPACE)"
 
 ## Uninstall Dynamo platform from the cluster
 cleanup-dynamo:
-	helm uninstall dynamo-platform --namespace $(DYNAMO_NAMESPACE)
+	helm uninstall dynamo-platform --namespace $(DYNAMO_NAMESPACE) --ignore-not-found
 	@echo "✅ Dynamo platform uninstalled from namespace $(DYNAMO_NAMESPACE)"
 
 ## Run e2e tests (requires DYNAMO_INSTALLED=true and a cluster with dynamo provider deployed)


### PR DESCRIPTION
## Description

Add Makefile targets to automate Dynamo platform installation and teardown, so users can easily set up the cluster for e2e testing without manual helm commands.


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Related Issues

N/A

## Changes Made

- Add `setup-dynamo` target to `providers/dynamo/Makefile` that:
  - Fetches and runs the upstream [pre-deployment check script](https://github.com/ai-dynamo/dynamo/blob/main/deploy/pre-deployment/pre-deployment-check.sh) (validates kubectl connectivity, default StorageClass, GPU nodes, GPU operator)
  - Installs the Dynamo platform helm chart (pinned to v`1.0.2`) from NVIDIA NGC into the `dynamo-system` namespace
- Add `cleanup-dynamo` target to uninstall the Dynamo platform via `helm uninstall`
- Both `DYNAMO_VERSION` and `DYNAMO_NAMESPACE` are overridable (e.g., `make setup-dynamo DYNAMO_VERSION=1.1.0`)

## Testing

- [ ] Unit tests pass (`bun run test`)
- [ ] Manual testing performed
- [x] Tested with a Kubernetes cluster

### Test plan

```bash
cd providers/dynamo
make setup-dynamo        # installs Dynamo platform
make test-e2e            # runs e2e tests
make cleanup-dynamo      # tears down Dynamo platform
```

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

N/A

## Additional Notes

The Dynamo chart version is pinned to `1.0.2` to ensure reproducible test environments. Override with `DYNAMO_VERSION=<version>` when a newer release is needed.