### PR TITLE
Add CODEOWNERS for airunway maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for the repository
+* @kaito-project/airunway-maintainers


### PR DESCRIPTION
## Summary
- add a repository CODEOWNERS file
- assign the repository to @kaito-project/airunway-maintainers

## Testing
- git diff --check -- .github/CODEOWNERS