### PR TITLE
feat(ui): add gateway routing toggle to deployment form

### DIFF
--- a/backend/src/routes/deployments.test.ts
+++ b/backend/src/routes/deployments.test.ts
@@ -208,6 +208,54 @@ describe('Deployment Routes', () => {
       expect(data.resources[0].manifest.spec.resources).toBeUndefined();
       expect(data.resources[0].manifest.spec.engine.type).toBe('llamacpp');
     });
+
+    test('omits spec.gateway when gatewayEnabled is not set', async () => {
+      restores.push(
+        mockServiceMethod(configService, 'getDefaultNamespace', async () => 'default'),
+      );
+
+      const res = await app.request('/api/deployments/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validDeploymentBody),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.resources[0].manifest.spec.gateway).toBeUndefined();
+    });
+
+    test('emits spec.gateway.enabled=true when gatewayEnabled is true', async () => {
+      restores.push(
+        mockServiceMethod(configService, 'getDefaultNamespace', async () => 'default'),
+      );
+
+      const res = await app.request('/api/deployments/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validDeploymentBody, gatewayEnabled: true }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.resources[0].manifest.spec.gateway).toEqual({ enabled: true });
+    });
+
+    test('emits spec.gateway.enabled=false when gatewayEnabled is false', async () => {
+      restores.push(
+        mockServiceMethod(configService, 'getDefaultNamespace', async () => 'default'),
+      );
+
+      const res = await app.request('/api/deployments/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...validDeploymentBody, gatewayEnabled: false }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.resources[0].manifest.spec.gateway).toEqual({ enabled: false });
+    });
   });
 
   describe('POST /api/deployments - storage validation', () => {

--- a/backend/src/routes/deployments.ts
+++ b/backend/src/routes/deployments.ts
@@ -100,6 +100,7 @@ const createDeploymentSchema = z.object({
   imageRef: z.string().optional(),
   computeType: z.enum(['cpu', 'gpu']).optional(),
   maxModelLen: z.number().int().positive().optional(),
+  gatewayEnabled: z.boolean().optional(),
   storage: storageSchema,
 }).superRefine((data, ctx) => {
   const volumes = data.storage?.volumes;

--- a/frontend/src/components/deployments/DeploymentForm.test.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.test.tsx
@@ -27,6 +27,12 @@ vi.mock('@/hooks/useAikit', () => ({
   usePremadeModels: () => ({ data: [] }),
 }))
 
+const gatewayMock = vi.hoisted(() => ({ data: { available: false } as { available: boolean } }))
+
+vi.mock('@/hooks/useGateway', () => ({
+  useGatewayStatus: () => gatewayMock,
+}))
+
 vi.mock('@/hooks/useToast', () => ({
   useToast: () => ({ toast }),
 }))
@@ -100,6 +106,7 @@ describe('DeploymentForm', () => {
   beforeEach(() => {
     mutateAsync.mockReset()
     toast.mockReset()
+    gatewayMock.data = { available: false }
   })
 
   it('keeps manual topology edits instead of snapping back to the recommendation', async () => {
@@ -132,5 +139,46 @@ describe('DeploymentForm', () => {
     expect(
       screen.queryByText(/Multi-Node \(2 nodes × 8 GPUs = 16 total\)/i)
     ).not.toBeInTheDocument()
+  })
+
+  it('does not render the gateway routing toggle when no gateway is available', () => {
+    gatewayMock.data = { available: false }
+    render(
+      <MemoryRouter>
+        <DeploymentForm
+          model={createModel()}
+          detailedCapacity={createCapacity()}
+          runtimes={[createRuntime()]}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByLabelText(/Gateway routing/i)).not.toBeInTheDocument()
+  })
+
+  it('renders the gateway routing toggle (on by default) when a gateway is available', async () => {
+    gatewayMock.data = { available: true }
+    render(
+      <MemoryRouter>
+        <DeploymentForm
+          model={createModel()}
+          detailedCapacity={createCapacity()}
+          runtimes={[createRuntime()]}
+        />
+      </MemoryRouter>
+    )
+
+    // Expand the Advanced Settings <details> to make the toggle visible
+    const summary = await screen.findByText(/Advanced Settings/i)
+    fireEvent.click(summary)
+
+    const toggle = await screen.findByRole('switch', { name: /Gateway routing/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+
+    fireEvent.click(toggle)
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-checked', 'false')
+    })
   })
 })

--- a/frontend/src/components/deployments/DeploymentForm.test.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/hooks/useAikit', () => ({
 }))
 
 const gatewayMock = vi.hoisted(() => ({ data: { available: false } as { available: boolean } }))
+const manifestViewerMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/hooks/useGateway', () => ({
   useGatewayStatus: () => gatewayMock,
@@ -53,7 +54,10 @@ vi.mock('./AIConfiguratorPanel', () => ({
 }))
 
 vi.mock('./ManifestViewer', () => ({
-  ManifestViewer: () => null,
+  ManifestViewer: (props: unknown) => {
+    manifestViewerMock(props)
+    return null
+  },
 }))
 
 vi.mock('./CostEstimate', () => ({
@@ -106,6 +110,7 @@ describe('DeploymentForm', () => {
   beforeEach(() => {
     mutateAsync.mockReset()
     toast.mockReset()
+    manifestViewerMock.mockReset()
     gatewayMock.data = { available: false }
   })
 
@@ -156,7 +161,58 @@ describe('DeploymentForm', () => {
     expect(screen.queryByLabelText(/Gateway routing/i)).not.toBeInTheDocument()
   })
 
-  it('renders the gateway routing toggle (on by default) when a gateway is available', async () => {
+  it('clears explicit gateway routing from preview and submit when the gateway becomes unavailable', async () => {
+    gatewayMock.data = { available: true }
+    const { rerender } = render(
+      <MemoryRouter>
+        <DeploymentForm
+          model={createModel()}
+          detailedCapacity={createCapacity()}
+          runtimes={[createRuntime({ id: 'dynamo' })]}
+        />
+      </MemoryRouter>
+    )
+
+    const summary = await screen.findByText(/Advanced Settings/i)
+    fireEvent.click(summary)
+
+    const toggle = await screen.findByRole('switch', { name: /Gateway routing/i })
+    fireEvent.click(toggle)
+    await waitFor(() => {
+      const lastManifestProps = manifestViewerMock.mock.calls[
+        manifestViewerMock.mock.calls.length - 1
+      ]?.[0] as { config?: { gatewayEnabled?: boolean } } | undefined
+      expect(lastManifestProps?.config?.gatewayEnabled).toBe(false)
+    })
+
+    gatewayMock.data = { available: false }
+    rerender(
+      <MemoryRouter>
+        <DeploymentForm
+          model={createModel()}
+          detailedCapacity={createCapacity()}
+          runtimes={[createRuntime({ id: 'dynamo' })]}
+        />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      const lastManifestProps = manifestViewerMock.mock.calls[
+        manifestViewerMock.mock.calls.length - 1
+      ]?.[0] as { config?: { gatewayEnabled?: boolean } } | undefined
+      expect(lastManifestProps?.config?.gatewayEnabled).toBeUndefined()
+    })
+    expect(screen.queryByLabelText(/Gateway routing/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Deploy Model/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(mutateAsync.mock.calls[0][0]).not.toHaveProperty('gatewayEnabled')
+  })
+
+  it('renders the gateway routing toggle as default-on without submitting gateway routing until changed', async () => {
     gatewayMock.data = { available: true }
     render(
       <MemoryRouter>
@@ -176,9 +232,22 @@ describe('DeploymentForm', () => {
     expect(toggle).toBeInTheDocument()
     expect(toggle).toHaveAttribute('aria-checked', 'true')
 
+    const latestManifestConfig = () => (manifestViewerMock.mock.calls[
+      manifestViewerMock.mock.calls.length - 1
+    ]?.[0] as { config?: { gatewayEnabled?: boolean } } | undefined)?.config
+
+    expect(latestManifestConfig()?.gatewayEnabled).toBeUndefined()
+
     fireEvent.click(toggle)
     await waitFor(() => {
       expect(toggle).toHaveAttribute('aria-checked', 'false')
+      expect(latestManifestConfig()?.gatewayEnabled).toBe(false)
+    })
+
+    fireEvent.click(toggle)
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+      expect(latestManifestConfig()?.gatewayEnabled).toBe(true)
     })
   })
 })

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -11,6 +11,7 @@ import { useConfetti } from '@/components/ui/confetti'
 import { useCreateDeployment, type DeploymentConfig } from '@/hooks/useDeployments'
 import { useHuggingFaceStatus, useGgufFiles } from '@/hooks/useHuggingFace'
 import { usePremadeModels } from '@/hooks/useAikit'
+import { useGatewayStatus } from '@/hooks/useGateway'
 import { useToast } from '@/hooks/useToast'
 import { generateDeploymentName, cn } from '@/lib/utils'
 import { type Model, type DetailedClusterCapacity, type AutoscalerDetectionResult, type RuntimeStatus, type PremadeModel, type AIConfiguratorResult, aikitApi, type Engine, type KaitoResourceType } from '@/lib/api'
@@ -197,6 +198,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
   const createDeployment = useCreateDeployment()
   const { data: hfStatus } = useHuggingFaceStatus()
   const { data: premadeModels } = usePremadeModels()
+  const { data: gatewayInfo } = useGatewayStatus()
   const formRef = useRef<HTMLFormElement>(null)
   const { trigger: triggerConfetti, ConfettiComponent } = useConfetti(2500)
 
@@ -349,6 +351,15 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hfStatus?.configured])
+
+  // Default gatewayEnabled to true once we know a gateway is available,
+  // so the manifest preview reflects the on-by-default UI state.
+  useEffect(() => {
+    if (gatewayInfo?.available && config.gatewayEnabled === undefined) {
+      setConfig(prev => ({ ...prev, gatewayEnabled: true }))
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gatewayInfo?.available])
 
   // Set initial GPU value from recommendation when component mounts
   useEffect(() => {
@@ -1045,15 +1056,33 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
             <summary className="text-sm font-medium cursor-pointer text-muted-foreground hover:text-foreground">
               Advanced Settings
             </summary>
-            <div className="mt-3 space-y-2">
-              <Label htmlFor="namespace">Namespace</Label>
-              <Input
-                id="namespace"
-                value={config.namespace}
-                onChange={(e) => updateConfig('namespace', e.target.value)}
-                placeholder={RUNTIME_INFO[selectedRuntime].defaultNamespace}
-                required
-              />
+            <div className="mt-3 space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="namespace">Namespace</Label>
+                <Input
+                  id="namespace"
+                  value={config.namespace}
+                  onChange={(e) => updateConfig('namespace', e.target.value)}
+                  placeholder={RUNTIME_INFO[selectedRuntime].defaultNamespace}
+                  required
+                />
+              </div>
+
+              {gatewayInfo?.available && (
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="gateway-enabled">Gateway routing</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Route requests to this model through the cluster gateway. Defaults to enabled when a gateway is detected.
+                    </p>
+                  </div>
+                  <Switch
+                    id="gateway-enabled"
+                    checked={config.gatewayEnabled ?? true}
+                    onCheckedChange={(checked) => updateConfig('gatewayEnabled', checked)}
+                  />
+                </div>
+              )}
             </div>
           </details>
         </div>

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -129,6 +129,19 @@ const RUNTIME_ENGINES: Record<RuntimeId, TraditionalEngine[]> = {
   llmd: ['vllm'], // llm-d uses vLLM exclusively
 }
 
+function normalizeGatewayAvailability(
+  config: DeploymentConfig,
+  gatewayAvailable: boolean | undefined
+): DeploymentConfig {
+  if (gatewayAvailable !== false || !('gatewayEnabled' in config)) {
+    return config
+  }
+
+  const nextConfig = { ...config }
+  delete nextConfig.gatewayEnabled
+  return nextConfig
+}
+
 // Check if a runtime is compatible with a model based on engine support
 function isRuntimeCompatible(runtimeId: RuntimeId, modelEngines: Engine[]): boolean {
   // KAITO supports llamacpp (GGUF) AND vllm models
@@ -352,13 +365,10 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hfStatus?.configured])
 
-  // Default gatewayEnabled to true once we know a gateway is available,
-  // so the manifest preview reflects the on-by-default UI state.
+  // Clear stale gatewayEnabled when gateway support disappears; keep the default-on UI
+  // state implicit so untouched deployments omit spec.gateway.
   useEffect(() => {
-    if (gatewayInfo?.available && config.gatewayEnabled === undefined) {
-      setConfig(prev => ({ ...prev, gatewayEnabled: true }))
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    setConfig(prev => normalizeGatewayAvailability(prev, gatewayInfo?.available))
   }, [gatewayInfo?.available])
 
   // Set initial GPU value from recommendation when component mounts
@@ -570,7 +580,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
 
     try {
       // Build the deployment config, adding KAITO-specific fields if needed
-      let deployConfig = { ...config }
+      let deployConfig = normalizeGatewayAvailability(config, gatewayInfo?.available)
 
       if (selectedRuntime === 'kaito') {
         // Add kaitoResourceType to all KAITO deployments
@@ -684,7 +694,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
         variant: 'destructive',
       })
     }
-  }, [config, createDeployment, navigate, toast, triggerConfetti, selectedRuntime, kaitoComputeType, kaitoResourceType, selectedPremadeModel, isHuggingFaceGgufModel, isVllmModel, model.id, model.gated, ggufFile, ggufRunMode, maxModelLen])
+  }, [config, createDeployment, navigate, toast, triggerConfetti, selectedRuntime, kaitoComputeType, kaitoResourceType, selectedPremadeModel, isHuggingFaceGgufModel, isVllmModel, model.id, model.gated, ggufFile, ggufRunMode, maxModelLen, gatewayInfo?.available])
 
   const updateConfig = <K extends keyof DeploymentConfig>(
     key: K,
@@ -1793,7 +1803,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
         {/* Manifest Preview - build config with KAITO-specific fields */}
         {(() => {
           // Build preview config with all necessary fields
-          let previewConfig = { ...config };
+          let previewConfig = normalizeGatewayAvailability(config, gatewayInfo?.available);
 
           if (selectedRuntime === 'kaito') {
             // Always include kaitoResourceType for KAITO deployments

--- a/frontend/src/hooks/useGateway.ts
+++ b/frontend/src/hooks/useGateway.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { installationApi, type GatewayCRDStatus, type GatewayCRDInstallResult } from '@/lib/api'
+import { installationApi, gatewayApi, type GatewayCRDStatus, type GatewayCRDInstallResult, type GatewayInfo } from '@/lib/api'
 
 /**
  * Hook to get Gateway API / GAIE CRD installation status
@@ -24,5 +24,16 @@ export function useInstallGatewayCRDs() {
       queryClient.invalidateQueries({ queryKey: ['gateway-crd-status'] })
       queryClient.invalidateQueries({ queryKey: ['gateway-status'] })
     },
+  })
+}
+
+/**
+ * Hook to get current Gateway resource availability and endpoint
+ */
+export function useGatewayStatus() {
+  return useQuery<GatewayInfo>({
+    queryKey: ['gateway-status'],
+    queryFn: () => gatewayApi.getStatus(),
+    refetchInterval: 30000,
   })
 }

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -226,6 +226,13 @@ export const handlers = [
     })
   }),
 
+  // Gateway resource status (used by useGatewayStatus to drive UI gating)
+  http.get(`${API_BASE}/gateway/status`, () => {
+    return HttpResponse.json({
+      available: false,
+    })
+  }),
+
   // HuggingFace OAuth API
   http.get(`${API_BASE}/oauth/huggingface/config`, () => {
     return HttpResponse.json({

--- a/shared/types/deployment.ts
+++ b/shared/types/deployment.ts
@@ -68,6 +68,7 @@ export interface DeploymentConfig {
   kaitoResourceType?: KaitoResourceType;
   providerOverrides?: Record<string, unknown>;
   storage?: StorageSpec;
+  gatewayEnabled?: boolean;
 }
 
 export interface ModelSpec {
@@ -137,6 +138,12 @@ export interface SecretSpec {
   custom?: string[];
 }
 
+export interface GatewaySpec {
+  enabled?: boolean;
+  modelName?: string;
+  httpRouteRef?: string;
+}
+
 export interface ModelDeploymentSpec {
   model: ModelSpec;
   provider?: ProviderSpec;
@@ -148,6 +155,7 @@ export interface ModelDeploymentSpec {
   env?: Record<string, string>;
   podTemplate?: PodTemplateSpec;
   secrets?: SecretSpec;
+  gateway?: GatewaySpec;
 }
 
 export interface ReplicaStatus {
@@ -545,6 +553,12 @@ export function toModelDeploymentSpec(config: DeploymentConfig): ModelDeployment
   if (config.storage?.volumes && config.storage.volumes.length > 0) {
     spec.model.storage = {
       volumes: config.storage.volumes,
+    };
+  }
+
+  if (config.gatewayEnabled !== undefined) {
+    spec.gateway = {
+      enabled: config.gatewayEnabled,
     };
   }
 


### PR DESCRIPTION
## Description

Adds a "Gateway routing" toggle to the deployment form's Advanced Settings so
users can opt a ModelDeployment in or out of Gateway API Inference Extension
routing from the UI. The toggle only appears when the cluster has the Gateway
API + GAIE CRDs installed, and defaults to on (matching the controller's
existing opt-in-when-detected behavior).

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Implement issue #232: add a UI toggle on ModelDeployment create form that
sets spec.gateway.enabled. Hide the toggle when the cluster has no gateway
detected. Round-trip the value through the manifest preview and add tests
at every layer touched.
```

**AI Tool:** GitHub Copilot CLI (Claude Opus)

</details>

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 UI/UX improvement

## Related Issues

Fixes #232

## Changes Made

- Add `GatewaySpec` and `gateway?` to the shared `ModelDeploymentSpec`, and
  `gatewayEnabled?: boolean` to `DeploymentConfig`. Wire it through
  `toModelDeploymentSpec` so the field only emits when the user has expressed
  an opinion.
- New `useGatewayStatus()` hook on the frontend that drives toggle visibility
  off `/api/gateway/status`.
- New "Gateway routing" `Switch` in `DeploymentForm`'s Basic Configuration →
  Advanced Settings, gated on `gatewayInfo.available`. Defaults to on once we
  know a gateway exists.
- Add `gatewayEnabled` to the Zod schema on `/api/deployments` and
  `/api/deployments/preview` — without this the preview was silently stripping
  the field.

## Testing

- [x] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

Test coverage added in this PR:

- **backend** — three new tests on `POST /api/deployments/preview` covering
  `gatewayEnabled` undefined / `true` / `false` and the corresponding
  `spec.gateway` emission. (`backend/src/routes/deployments.test.ts`)
- **frontend** — two new `DeploymentForm` tests: toggle is hidden when no
  gateway is available, and is visible/on-by-default and clickable when one
  is. (`frontend/src/components/deployments/DeploymentForm.test.tsx`)
- **controller** — no controller code changed; existing `TestGateway_*` suite
  still passes (covers enabled→create and disabled→cleanup branches with a
  fake client + real Gateway/InferencePool schemes).

Manual verification on a kind cluster with Gateway API v1.5.1 + GAIE v1.3.1
CRDs installed:

- Backend reports `{ "available": true }` from `/api/gateway/status`.
- Toggle appears in the form, defaults on, hides when CRDs are uninstalled.
- Manifest preview round-trips: untouched → no `spec.gateway`; off →
  `enabled: false`; on → `enabled: true`.
- Applied both variants directly via `kubectl apply` and confirmed the CRD
  preserves the value exactly.
- Deployed the controller into the cluster and confirmed it picks up the
  field on reconcile (logs: `"Gateway API Inference Extension CRDs detected,
  gateway integration enabled"`). Full end-to-end (InferencePool + HTTPRoute
  creation) is gated on the deployment reaching `Phase: Running`, which needs
  a real provider workload — covered by the existing controller unit tests
  rather than locally on kind.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

_To be added before merge — toggle on/off and resulting manifest preview._

## Additional Notes

The toggle is purely additive on the controller side: when `gatewayEnabled` is
undefined the field is omitted from the manifest, preserving today's behavior
for anyone deploying via the API or YAML directly. The default-on UI choice
mirrors what the controller already does when it detects a Gateway resource.
