### PR TITLE
fix(backend): require Gateway resource for gateway availability (#235)

### DIFF
--- a/backend/src/services/kubernetes-gateway.test.ts
+++ b/backend/src/services/kubernetes-gateway.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test';
+import { INFERENCE_GATEWAY_LABEL } from '@airunway/shared';
 import { kubernetesService } from './kubernetes';
 import { mockServiceMethod } from '../test/helpers';
 
@@ -107,7 +108,7 @@ describe('kubernetesService.getGatewayStatus', () => {
     expect(result.available).toBe(false);
   });
 
-  test('multiple Gateways → picks the one labeled airunway.ai/inference-gateway=true', async () => {
+  test('multiple Gateways → picks the one with the inference-gateway label', async () => {
     mockCRDs({ inferencePool: true, gatewayApi: true });
     mockListGateways([
       { metadata: { name: 'gw-a', namespace: 'default' } },
@@ -115,7 +116,7 @@ describe('kubernetesService.getGatewayStatus', () => {
         metadata: {
           name: 'gw-b',
           namespace: 'default',
-          labels: { 'airunway.ai/inference-gateway': 'true' },
+          labels: { [INFERENCE_GATEWAY_LABEL]: 'true' },
         },
         status: { addresses: [{ value: 'gw-b.example.com' }] },
       },

--- a/backend/src/services/kubernetes-gateway.test.ts
+++ b/backend/src/services/kubernetes-gateway.test.ts
@@ -21,7 +21,8 @@ describe('kubernetesService.getGatewayStatus', () => {
 
   function mockListGateways(items: unknown[] | Error) {
     const original = svc.customObjectsApi.listClusterCustomObject;
-    svc.customObjectsApi.listClusterCustomObject = async (group: string, _version: string, plural: string) => {
+    svc.customObjectsApi.listClusterCustomObject = async (...args: unknown[]) => {
+      const [group, , plural] = args;
       if (group === 'gateway.networking.k8s.io' && plural === 'gateways') {
         if (items instanceof Error) throw items;
         return { body: { items } };

--- a/backend/src/services/kubernetes-gateway.test.ts
+++ b/backend/src/services/kubernetes-gateway.test.ts
@@ -8,9 +8,9 @@ import { mockServiceMethod } from '../test/helpers';
  *
  * Regression: previously returned available=true whenever the InferencePool CRD
  * existed, regardless of whether any Gateway resource was actually present.
- * It must now mirror the controller's resolveGatewayConfig selection so the
+ * It must now mirror the controller's auto-detection selection so the
  * Settings page only reports "Available" when the controller would actually
- * be able to attach an HTTPRoute.
+ * be able to attach an HTTPRoute without an explicit gateway override.
  */
 describe('kubernetesService.getGatewayStatus', () => {
   const restores: Array<() => void> = [];
@@ -35,10 +35,15 @@ describe('kubernetesService.getGatewayStatus', () => {
     });
   }
 
-  function mockCRDs({ inferencePool, gatewayApi }: { inferencePool: boolean; gatewayApi: boolean }) {
+  function mockCRDs({
+    inferencePool = true,
+    httpRoute = true,
+    gatewayApi = true,
+  }: Partial<{ inferencePool: boolean; httpRoute: boolean; gatewayApi: boolean }> = {}) {
     restores.push(
       mockServiceMethod(kubernetesService, 'checkCRDExists', async (crdName: string) => {
         if (crdName === 'inferencepools.inference.networking.k8s.io') return inferencePool;
+        if (crdName === 'httproutes.gateway.networking.k8s.io') return httpRoute;
         if (crdName === 'gateways.gateway.networking.k8s.io') return gatewayApi;
         return false;
       }),
@@ -51,15 +56,23 @@ describe('kubernetesService.getGatewayStatus', () => {
   });
 
   test('returns unavailable when InferencePool CRD is missing', async () => {
-    mockCRDs({ inferencePool: false, gatewayApi: true });
+    mockCRDs({ inferencePool: false });
     mockListGateways([{ metadata: { name: 'gw' } }]);
 
     const result = await kubernetesService.getGatewayStatus();
     expect(result).toEqual({ available: false });
   });
 
-  test('returns unavailable when Gateway API CRD is missing', async () => {
-    mockCRDs({ inferencePool: true, gatewayApi: false });
+  test('returns unavailable when HTTPRoute CRD is missing', async () => {
+    mockCRDs({ httpRoute: false });
+    mockListGateways([{ metadata: { name: 'gw' } }]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result).toEqual({ available: false });
+  });
+
+  test('returns unavailable when Gateway CRD is missing', async () => {
+    mockCRDs({ gatewayApi: false });
     mockListGateways([]);
 
     const result = await kubernetesService.getGatewayStatus();
@@ -67,7 +80,7 @@ describe('kubernetesService.getGatewayStatus', () => {
   });
 
   test('returns unavailable when CRDs are installed but no Gateway resource exists (issue #235)', async () => {
-    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockCRDs();
     mockListGateways([]);
 
     const result = await kubernetesService.getGatewayStatus();
@@ -76,7 +89,7 @@ describe('kubernetesService.getGatewayStatus', () => {
   });
 
   test('returns available with no endpoint when a Gateway exists but has no addresses yet', async () => {
-    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockCRDs();
     mockListGateways([{ metadata: { name: 'gw', namespace: 'default' } }]);
 
     const result = await kubernetesService.getGatewayStatus();
@@ -85,7 +98,7 @@ describe('kubernetesService.getGatewayStatus', () => {
   });
 
   test('returns available with endpoint when a Gateway exists with status.addresses', async () => {
-    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockCRDs();
     mockListGateways([
       {
         metadata: { name: 'gw', namespace: 'default' },
@@ -98,7 +111,7 @@ describe('kubernetesService.getGatewayStatus', () => {
   });
 
   test('multiple Gateways without inference-gateway label → unavailable (matches controller)', async () => {
-    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockCRDs();
     mockListGateways([
       { metadata: { name: 'gw-a', namespace: 'default' } },
       { metadata: { name: 'gw-b', namespace: 'default' } },
@@ -109,7 +122,7 @@ describe('kubernetesService.getGatewayStatus', () => {
   });
 
   test('multiple Gateways → picks the one with the inference-gateway label', async () => {
-    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockCRDs();
     mockListGateways([
       { metadata: { name: 'gw-a', namespace: 'default' } },
       {
@@ -127,7 +140,7 @@ describe('kubernetesService.getGatewayStatus', () => {
   });
 
   test('returns unavailable when listing Gateway resources errors', async () => {
-    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockCRDs();
     mockListGateways(new Error('forbidden'));
 
     const result = await kubernetesService.getGatewayStatus();

--- a/backend/src/services/kubernetes-gateway.test.ts
+++ b/backend/src/services/kubernetes-gateway.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { kubernetesService } from './kubernetes';
+import { mockServiceMethod } from '../test/helpers';
+
+/**
+ * Tests for kubernetesService.getGatewayStatus().
+ *
+ * Regression: previously returned available=true whenever the InferencePool CRD
+ * existed, regardless of whether any Gateway resource was actually present.
+ * It must now mirror the controller's resolveGatewayConfig selection so the
+ * Settings page only reports "Available" when the controller would actually
+ * be able to attach an HTTPRoute.
+ */
+describe('kubernetesService.getGatewayStatus', () => {
+  const restores: Array<() => void> = [];
+  // The customObjectsApi is private; reach in just for tests so we can stub
+  // listClusterCustomObject without spinning up a real Kubernetes API server.
+  const svc = kubernetesService as unknown as {
+    customObjectsApi: { listClusterCustomObject: (...args: unknown[]) => Promise<{ body: unknown }> };
+  };
+
+  function mockListGateways(items: unknown[] | Error) {
+    const original = svc.customObjectsApi.listClusterCustomObject;
+    svc.customObjectsApi.listClusterCustomObject = async (group: string, _version: string, plural: string) => {
+      if (group === 'gateway.networking.k8s.io' && plural === 'gateways') {
+        if (items instanceof Error) throw items;
+        return { body: { items } };
+      }
+      return { body: { items: [] } };
+    };
+    restores.push(() => {
+      svc.customObjectsApi.listClusterCustomObject = original;
+    });
+  }
+
+  function mockCRDs({ inferencePool, gatewayApi }: { inferencePool: boolean; gatewayApi: boolean }) {
+    restores.push(
+      mockServiceMethod(kubernetesService, 'checkCRDExists', async (crdName: string) => {
+        if (crdName === 'inferencepools.inference.networking.k8s.io') return inferencePool;
+        if (crdName === 'gateways.gateway.networking.k8s.io') return gatewayApi;
+        return false;
+      }),
+    );
+  }
+
+  afterEach(() => {
+    restores.forEach((r) => r());
+    restores.length = 0;
+  });
+
+  test('returns unavailable when InferencePool CRD is missing', async () => {
+    mockCRDs({ inferencePool: false, gatewayApi: true });
+    mockListGateways([{ metadata: { name: 'gw' } }]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result).toEqual({ available: false });
+  });
+
+  test('returns unavailable when Gateway API CRD is missing', async () => {
+    mockCRDs({ inferencePool: true, gatewayApi: false });
+    mockListGateways([]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result).toEqual({ available: false });
+  });
+
+  test('returns unavailable when CRDs are installed but no Gateway resource exists (issue #235)', async () => {
+    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockListGateways([]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result.available).toBe(false);
+    expect(result.endpoint).toBeUndefined();
+  });
+
+  test('returns available with no endpoint when a Gateway exists but has no addresses yet', async () => {
+    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockListGateways([{ metadata: { name: 'gw', namespace: 'default' } }]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result.available).toBe(true);
+    expect(result.endpoint).toBeUndefined();
+  });
+
+  test('returns available with endpoint when a Gateway exists with status.addresses', async () => {
+    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockListGateways([
+      {
+        metadata: { name: 'gw', namespace: 'default' },
+        status: { addresses: [{ value: '10.0.0.50' }] },
+      },
+    ]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result).toEqual({ available: true, endpoint: '10.0.0.50' });
+  });
+
+  test('multiple Gateways without inference-gateway label → unavailable (matches controller)', async () => {
+    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockListGateways([
+      { metadata: { name: 'gw-a', namespace: 'default' } },
+      { metadata: { name: 'gw-b', namespace: 'default' } },
+    ]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result.available).toBe(false);
+  });
+
+  test('multiple Gateways → picks the one labeled airunway.ai/inference-gateway=true', async () => {
+    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockListGateways([
+      { metadata: { name: 'gw-a', namespace: 'default' } },
+      {
+        metadata: {
+          name: 'gw-b',
+          namespace: 'default',
+          labels: { 'airunway.ai/inference-gateway': 'true' },
+        },
+        status: { addresses: [{ value: 'gw-b.example.com' }] },
+      },
+    ]);
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result).toEqual({ available: true, endpoint: 'gw-b.example.com' });
+  });
+
+  test('returns unavailable when listing Gateway resources errors', async () => {
+    mockCRDs({ inferencePool: true, gatewayApi: true });
+    mockListGateways(new Error('forbidden'));
+
+    const result = await kubernetesService.getGatewayStatus();
+    expect(result).toEqual({ available: false });
+  });
+});

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -1,7 +1,7 @@
 import * as k8s from '@kubernetes/client-node';
 import { configService } from './config';
 import type { DeploymentStatus, PodStatus, ClusterStatus, PodPhase, DeploymentConfig, RuntimeStatus, ModelDeployment, GatewayInfo, GatewayModelInfo, GatewayCRDStatus } from '@airunway/shared';
-import { toModelDeploymentManifest, toDeploymentStatus } from '@airunway/shared';
+import { toModelDeploymentManifest, toDeploymentStatus, INFERENCE_GATEWAY_LABEL } from '@airunway/shared';
 import { withRetry } from '../lib/retry';
 import { loadKubeConfig } from '../lib/kubeconfig';
 import logger from '../lib/logger';
@@ -1522,8 +1522,13 @@ class KubernetesService {
   }
 
   /**
-   * Get gateway status: checks if Gateway API InferencePool CRD exists,
-   * lists InferencePool resources, and finds gateway endpoint from Gateway resources.
+   * Get gateway status by checking the required InferencePool and Gateway CRDs,
+   * listing Gateway resources, and selecting the Gateway the controller would use.
+   *
+   * `available` is true only when the CRDs exist and a Gateway can be selected
+   * (a single Gateway, or a Gateway labeled `INFERENCE_GATEWAY_LABEL=true` when
+   * multiple Gateways exist). `endpoint` is the selected Gateway's first status
+   * address value, when the Gateway has published one.
    */
   async getGatewayStatus(): Promise<GatewayInfo> {
     // Check if InferencePool CRD exists - without it, gateway integration is not supported.
@@ -1538,8 +1543,8 @@ class KubernetesService {
       return { available: false };
     }
 
-    // "Available" means a routable Gateway exists - mirror the controller's
-    // resolveGatewayConfig selection so the UI matches what the controller will
+    // "Available" means the controller can select a Gateway - mirror the
+    // controller's resolveGatewayConfig selection so the UI matches what it will
     // actually pick when reconciling a ModelDeployment with gateway.enabled=true.
     type GatewayItem = {
       metadata?: { name?: string; namespace?: string; labels?: Record<string, string> };
@@ -1565,7 +1570,6 @@ class KubernetesService {
       return { available: false };
     }
 
-    const INFERENCE_GATEWAY_LABEL = 'airunway.ai/inference-gateway';
     let selected: GatewayItem | undefined;
     if (items.length === 1) {
       selected = items[0];

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -1526,38 +1526,59 @@ class KubernetesService {
    * lists InferencePool resources, and finds gateway endpoint from Gateway resources.
    */
   async getGatewayStatus(): Promise<GatewayInfo> {
-    // Check if InferencePool CRD exists
+    // Check if InferencePool CRD exists - without it, gateway integration is not supported.
     const inferencePoolCrdExists = await this.checkCRDExists('inferencepools.inference.networking.k8s.io');
     if (!inferencePoolCrdExists) {
       return { available: false };
     }
 
-    // Try to find a Gateway endpoint
-    let endpoint: string | undefined;
+    // The Gateway API CRD must exist before we can list Gateway resources.
     const gatewayCrdExists = await this.checkCRDExists('gateways.gateway.networking.k8s.io');
-    if (gatewayCrdExists) {
-      try {
-        const response = await withRetry(
-          () => this.customObjectsApi.listClusterCustomObject(
-            'gateway.networking.k8s.io',
-            'v1',
-            'gateways'
-          ),
-          { operationName: 'listGateways', maxRetries: 1 }
-        );
-        const items = (response.body as { items?: Array<{ status?: { addresses?: Array<{ value?: string }> } }> }).items || [];
-        for (const gw of items) {
-          const addr = gw.status?.addresses?.[0]?.value;
-          if (addr) {
-            endpoint = addr;
-            break;
-          }
-        }
-      } catch (error: any) {
-        logger.debug({ error: error?.message }, 'Could not list Gateway resources');
-      }
+    if (!gatewayCrdExists) {
+      return { available: false };
     }
 
+    // "Available" means a routable Gateway exists - mirror the controller's
+    // resolveGatewayConfig selection so the UI matches what the controller will
+    // actually pick when reconciling a ModelDeployment with gateway.enabled=true.
+    type GatewayItem = {
+      metadata?: { name?: string; namespace?: string; labels?: Record<string, string> };
+      status?: { addresses?: Array<{ value?: string }> };
+    };
+    let items: GatewayItem[] = [];
+    try {
+      const response = await withRetry(
+        () => this.customObjectsApi.listClusterCustomObject(
+          'gateway.networking.k8s.io',
+          'v1',
+          'gateways'
+        ),
+        { operationName: 'listGateways', maxRetries: 1 }
+      );
+      items = (response.body as { items?: GatewayItem[] }).items || [];
+    } catch (error: any) {
+      logger.debug({ error: error?.message }, 'Could not list Gateway resources');
+      return { available: false };
+    }
+
+    if (items.length === 0) {
+      return { available: false };
+    }
+
+    const INFERENCE_GATEWAY_LABEL = 'airunway.ai/inference-gateway';
+    let selected: GatewayItem | undefined;
+    if (items.length === 1) {
+      selected = items[0];
+    } else {
+      // Multiple Gateways: require the controller's inference-gateway label to disambiguate.
+      const labeled = items.filter((gw) => gw.metadata?.labels?.[INFERENCE_GATEWAY_LABEL] === 'true');
+      if (labeled.length === 0) {
+        return { available: false };
+      }
+      selected = labeled[0];
+    }
+
+    const endpoint = selected?.status?.addresses?.[0]?.value;
     return { available: true, endpoint };
   }
 

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -1522,8 +1522,9 @@ class KubernetesService {
   }
 
   /**
-   * Get gateway status by checking the required InferencePool and Gateway CRDs,
-   * listing Gateway resources, and selecting the Gateway the controller would use.
+   * Get gateway status by checking the required InferencePool, HTTPRoute, and
+   * Gateway CRDs, listing Gateway resources, and selecting the Gateway the
+   * controller auto-detection would select.
    *
    * `available` is true only when the CRDs exist and a Gateway can be selected
    * (a single Gateway, or a Gateway labeled `INFERENCE_GATEWAY_LABEL=true` when
@@ -1537,15 +1538,22 @@ class KubernetesService {
       return { available: false };
     }
 
-    // The Gateway API CRD must exist before we can list Gateway resources.
+    // The controller creates HTTPRoutes, so the HTTPRoute CRD must be present.
+    const httpRouteCrdExists = await this.checkCRDExists('httproutes.gateway.networking.k8s.io');
+    if (!httpRouteCrdExists) {
+      return { available: false };
+    }
+
+    // The Gateway CRD must exist before the backend can list Gateway resources.
     const gatewayCrdExists = await this.checkCRDExists('gateways.gateway.networking.k8s.io');
     if (!gatewayCrdExists) {
       return { available: false };
     }
 
-    // "Available" means the controller can select a Gateway - mirror the
-    // controller's resolveGatewayConfig selection so the UI matches what it will
-    // actually pick when reconciling a ModelDeployment with gateway.enabled=true.
+    // "Available" means the controller auto-detection can select a Gateway -
+    // mirror that path so the UI matches what it will actually pick when
+    // reconciling a ModelDeployment with gateway.enabled=true and no explicit
+    // gateway override.
     type GatewayItem = {
       metadata?: { name?: string; namespace?: string; labels?: Record<string, string> };
       status?: { addresses?: Array<{ value?: string }> };

--- a/backend/src/test/helpers.test.ts
+++ b/backend/src/test/helpers.test.ts
@@ -60,6 +60,41 @@ describe('mockFetchByUrl', () => {
     expect(globalThis.fetch).toBe(originalFetch);
   });
 
+  test('preserves fetch.preconnect on the mock and restores the original fetch', () => {
+    const actualFetch = globalThis.fetch;
+    const preconnectCalls: Array<unknown[]> = [];
+    const tempFetch = (async () => new Response('{}')) as typeof fetch & {
+      preconnect: (...args: unknown[]) => void;
+    };
+    tempFetch.preconnect = (...args: unknown[]) => {
+      preconnectCalls.push(args);
+    };
+
+    let localRestore: (() => void) | undefined;
+    globalThis.fetch = tempFetch;
+    try {
+      localRestore = mockFetchByUrl({
+        '/test': { body: { mocked: true } },
+      });
+
+      const mockedFetch = globalThis.fetch as typeof fetch & {
+        preconnect?: (...args: unknown[]) => unknown;
+      };
+      expect(mockedFetch).not.toBe(tempFetch);
+      expect(typeof mockedFetch.preconnect).toBe('function');
+
+      mockedFetch.preconnect?.('https://example.com');
+      expect(preconnectCalls).toEqual([['https://example.com']]);
+
+      localRestore();
+      localRestore = undefined;
+      expect(globalThis.fetch).toBe(tempFetch);
+    } finally {
+      localRestore?.();
+      globalThis.fetch = actualFetch;
+    }
+  });
+
   test('first matching pattern wins for overlapping URL substrings', async () => {
     // '/api/whoami-v2' should match before '/api/whoami' when listed first
     restore = mockFetchByUrl({

--- a/backend/src/test/helpers.ts
+++ b/backend/src/test/helpers.ts
@@ -44,7 +44,7 @@ export function mockFetchByUrl(
   routes: Record<string, { body: unknown; ok?: boolean; status?: number }>
 ): () => void {
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+  const mockFetch = (async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
     let url: string;
     if (input instanceof Request) {
       url = input.url;
@@ -68,7 +68,16 @@ export function mockFetchByUrl(
       statusText: 'Not Found',
       headers: { 'Content-Type': 'application/json' },
     });
+  }) as typeof fetch;
+
+  const fetchWithPreconnect = originalFetch as typeof fetch & {
+    preconnect?: (...args: unknown[]) => unknown;
   };
+  if (typeof fetchWithPreconnect.preconnect === 'function') {
+    Object.assign(mockFetch, { preconnect: fetchWithPreconnect.preconnect.bind(originalFetch) });
+  }
+
+  globalThis.fetch = mockFetch;
   return () => {
     globalThis.fetch = originalFetch;
   };

--- a/shared/types/installation.ts
+++ b/shared/types/installation.ts
@@ -12,6 +12,12 @@ export const PINNED_GAIE_VERSION = 'v1.3.1';
 export const GAIE_CRD_URL = `https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${PINNED_GAIE_VERSION}/manifests.yaml`;
 export const GATEWAY_API_CRD_URL = 'https://github.com/kubernetes-sigs/gateway-api/releases/latest/download/standard-install.yaml';
 
+/**
+ * Label that marks a Gateway resource as the AIRunway inference gateway.
+ * Must match the controller's LabelInferenceGateway in controller/internal/gateway/detection.go.
+ */
+export const INFERENCE_GATEWAY_LABEL = 'airunway.ai/inference-gateway';
+
 export interface HelmStatus {
   available: boolean;
   version?: string;


### PR DESCRIPTION
## Description

The Settings page reported "Gateway: Available" whenever the Inference Extension CRDs were installed, even when no actual Gateway resource existed in the cluster. This was misleading and caused the gateway routing toggle (added in #232) to default-on for deployments that the controller would then reject with `GatewayReady=False/NoGateway`.

This PR tightens `getGatewayStatus()` in the backend so that "available" means *the controller can actually attach an HTTPRoute right now* — mirroring the controller's `resolveGatewayConfig` selection logic.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Settings page incorrectly reports Gateway as "Available" when CRDs are
installed but no Gateway resource exists. Align backend getGatewayStatus()
with the controller's resolveGatewayConfig selection so the UI matches
what the controller will actually do at reconcile time.
```

**AI Tool:** GitHub Copilot CLI (Claude Opus 4.7)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test update

## Related Issues

Fixes #235

## Changes Made

- `backend/src/services/kubernetes.ts` — `getGatewayStatus()` now requires both the `gateways.gateway.networking.k8s.io` and `inferencepools.inference.networking.k8s.io` CRDs **and** at least one usable Gateway resource. Multi-Gateway disambiguation matches the controller (`airunway.ai/inference-gateway=true` label). Listing errors return `available: false` instead of being silently swallowed.
- `backend/src/services/kubernetes-gateway.test.ts` — new test file with 8 cases covering: missing CRD combos, the bug repro (CRDs present + no Gateway → unavailable), Gateway without addresses, Gateway with addresses, multi-Gateway with/without label, and list-API errors.
- `checkGatewayCRDStatus()` already had the correct "No active gateway detected" message branch — it just never fired before. Now it does.

Knock-on effect: the gateway routing toggle in `DeploymentForm` (shipped in #232) correctly hides itself when no Gateway exists, so users can't opt into routing the controller would immediately fail.

## Testing

- [x] Unit tests pass (`bun run test`) — 614 backend + 102 frontend
- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

Live verified on a kind cluster matching the bug repro state:

| State | `/api/gateway/status` | `/api/installation/gateway/status` message |
|---|---|---|
| GAIE CRDs installed, no Gateway resource | `{available: false}` | "Gateway API and Inference Extension CRDs are installed. No active gateway detected." |
| Gateway resource applied | `{available: true}` | "Gateway API and Inference Extension CRDs are installed. Gateway is available." |

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `bun run lint`
- [x] I have added tests that prove my fix works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed (no user-facing docs change — message strings already covered the new state)
- [x] My changes generate no new warnings

## Additional Notes

The controller has its own gateway availability check (`controller/internal/gateway/detection.go::IsAvailable`) which only validates CRDs — that's intentional, since the controller separately runs `resolveGatewayConfig` at reconcile time and produces a clear `GatewayReady=False/NoGateway` condition. This PR brings the **backend's** notion of "available" in line with the controller's *runtime* notion, which is what the Settings page and routing toggle actually care about.
