### PR TITLE
Fix installed Inference Extension version display

### DIFF
--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -227,6 +227,8 @@ describe('Gateway Installation Routes', () => {
         mockServiceMethod(kubernetesService, 'checkGatewayCRDStatus', async () => ({
           gatewayApiInstalled: true,
           inferenceExtInstalled: true,
+          gatewayApiVersion: 'v1.2.1',
+          inferenceExtVersion: 'v1.5.0',
           pinnedVersion: 'v1.3.1',
           gatewayAvailable: true,
           gatewayEndpoint: '10.0.0.50',
@@ -244,6 +246,8 @@ describe('Gateway Installation Routes', () => {
       const data = await res.json();
       expect(data.gatewayApiInstalled).toBe(true);
       expect(data.inferenceExtInstalled).toBe(true);
+      expect(data.gatewayApiVersion).toBe('v1.2.1');
+      expect(data.inferenceExtVersion).toBe('v1.5.0');
       expect(data.pinnedVersion).toBe('v1.3.1');
       expect(data.gatewayAvailable).toBe(true);
       expect(data.gatewayEndpoint).toBe('10.0.0.50');

--- a/backend/src/services/kubernetes.test.ts
+++ b/backend/src/services/kubernetes.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { extractCRDVersionFromAnnotations, toPodStatus, type ClusterGpuCapacity, type NodeGpuInfo, type GPUAvailability, type GPUOperatorStatus } from './kubernetes';
+import { extractCRDVersionFromAnnotations, kubernetesService, toPodStatus, type ClusterGpuCapacity, type NodeGpuInfo, type GPUAvailability, type GPUOperatorStatus } from './kubernetes';
 import { toDeploymentStatus, type ClusterStatus, type PodStatus, type DeploymentStatus, type PodPhase, type ModelDeployment } from '@airunway/shared';
 
 
@@ -49,6 +49,65 @@ describe('KubernetesService - CRD Version Annotation Extraction', () => {
       'inference.networking.k8s.io/bundle-version',
       'app.kubernetes.io/version',
     ])).toBeUndefined();
+  });
+
+
+  test('checks Gateway CRD status with a single read per CRD', async () => {
+    const service = kubernetesService as any;
+    const originalApiExtensionsApi = service.apiExtensionsApi;
+    const originalGetGatewayStatus = service.getGatewayStatus;
+    const readCalls: string[] = [];
+
+    service.apiExtensionsApi = {
+      readCustomResourceDefinition: async (crdName: string) => {
+        readCalls.push(crdName);
+
+        if (crdName === 'gateways.gateway.networking.k8s.io') {
+          return {
+            body: {
+              metadata: {
+                annotations: {
+                  'gateway.networking.k8s.io/bundle-version': 'v1.2.1',
+                },
+              },
+            },
+          };
+        }
+
+        if (crdName === 'inferencepools.inference.networking.k8s.io') {
+          return {
+            body: {
+              metadata: {
+                annotations: {
+                  'inference.networking.k8s.io/bundle-version': 'v1.5.0',
+                },
+              },
+            },
+          };
+        }
+
+        throw { statusCode: 404 };
+      },
+    };
+    service.getGatewayStatus = async () => ({ available: true, endpoint: 'gateway.example.com' });
+
+    try {
+      const status = await kubernetesService.checkGatewayCRDStatus();
+
+      expect(readCalls).toEqual([
+        'gateways.gateway.networking.k8s.io',
+        'inferencepools.inference.networking.k8s.io',
+      ]);
+      expect(status.gatewayApiInstalled).toBe(true);
+      expect(status.inferenceExtInstalled).toBe(true);
+      expect(status.gatewayApiVersion).toBe('v1.2.1');
+      expect(status.inferenceExtVersion).toBe('v1.5.0');
+      expect(status.gatewayAvailable).toBe(true);
+      expect(status.gatewayEndpoint).toBe('gateway.example.com');
+    } finally {
+      service.apiExtensionsApi = originalApiExtensionsApi;
+      service.getGatewayStatus = originalGetGatewayStatus;
+    }
   });
 });
 

--- a/backend/src/services/kubernetes.test.ts
+++ b/backend/src/services/kubernetes.test.ts
@@ -1,6 +1,57 @@
 import { describe, test, expect } from 'bun:test';
-import { toPodStatus, type ClusterGpuCapacity, type NodeGpuInfo, type GPUAvailability, type GPUOperatorStatus } from './kubernetes';
+import { extractCRDVersionFromAnnotations, toPodStatus, type ClusterGpuCapacity, type NodeGpuInfo, type GPUAvailability, type GPUOperatorStatus } from './kubernetes';
 import { toDeploymentStatus, type ClusterStatus, type PodStatus, type DeploymentStatus, type PodPhase, type ModelDeployment } from '@airunway/shared';
+
+
+describe('KubernetesService - CRD Version Annotation Extraction', () => {
+  test('extracts and trims the Inference Extension bundle version from a raw CRD object', () => {
+    const crd = {
+      metadata: {
+        annotations: {
+          'inference.networking.k8s.io/bundle-version': ' v1.5.0 ',
+        },
+      },
+    };
+
+    expect(extractCRDVersionFromAnnotations(crd, [
+      'inference.networking.k8s.io/bundle-version',
+      'app.kubernetes.io/version',
+    ])).toBe('v1.5.0');
+  });
+
+  test('extracts the Gateway API version from a Kubernetes response wrapper', () => {
+    const response = {
+      body: {
+        metadata: {
+          annotations: {
+            'gateway.networking.k8s.io/bundle-version': 'v1.2.1',
+          },
+        },
+      },
+    };
+
+    expect(extractCRDVersionFromAnnotations(response, [
+      'gateway.networking.k8s.io/bundle-version',
+      'app.kubernetes.io/version',
+    ])).toBe('v1.2.1');
+  });
+
+  test('returns undefined when version annotations are missing', () => {
+    const crd = {
+      metadata: {
+        annotations: {
+          'example.com/other': 'v0.1.0',
+        },
+      },
+    };
+
+    expect(extractCRDVersionFromAnnotations(crd, [
+      'inference.networking.k8s.io/bundle-version',
+      'app.kubernetes.io/version',
+    ])).toBeUndefined();
+  });
+});
+
 
 describe('KubernetesService - Type Definitions', () => {
   describe('ClusterGpuCapacity', () => {

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -659,9 +659,9 @@ class KubernetesService {
         version: extractCRDVersionFromAnnotations(response, annotationKeys),
       };
     } catch (error: any) {
-      const statusCode = error?.statusCode || error?.response?.statusCode;
+      const statusCode = getK8sStatusCode(error);
       if (statusCode !== 404) {
-        logger.debug({ error: error?.message || error, crdName }, 'Could not read CRD status');
+        logger.debug({ error: getK8sErrorMessage(error), crdName }, 'Could not read CRD status');
       }
     }
 

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -573,24 +573,30 @@ class KubernetesService {
   }
 
   /**
-   * Read a version annotation from a CRD, if present.
+   * Read a CRD once and derive both existence and version from the same response.
    */
-  async getCRDVersionFromAnnotations(crdName: string, annotationKeys: string[]): Promise<string | undefined> {
+  private async getCRDStatusFromAnnotations(
+    crdName: string,
+    annotationKeys: string[]
+  ): Promise<{ installed: boolean; version?: string }> {
     try {
       const response = await withRetry(
         () => this.apiExtensionsApi.readCustomResourceDefinition(crdName),
-        { operationName: `getCRDVersionFromAnnotations:${crdName}`, maxRetries: 1 }
+        { operationName: `getCRDStatusFromAnnotations:${crdName}`, maxRetries: 1 }
       );
 
-      return extractCRDVersionFromAnnotations(response, annotationKeys);
+      return {
+        installed: true,
+        version: extractCRDVersionFromAnnotations(response, annotationKeys),
+      };
     } catch (error: any) {
       const statusCode = error?.statusCode || error?.response?.statusCode;
       if (statusCode !== 404) {
-        logger.debug({ error: error?.message || error, crdName }, 'Could not read CRD version annotation');
+        logger.debug({ error: error?.message || error, crdName }, 'Could not read CRD status');
       }
     }
 
-    return undefined;
+    return { installed: false };
   }
 
   /**
@@ -1660,17 +1666,15 @@ class KubernetesService {
   async checkGatewayCRDStatus(): Promise<GatewayCRDStatus> {
     const { PINNED_GAIE_VERSION, GAIE_CRD_URL, GATEWAY_API_CRD_URL } = await import('@airunway/shared');
 
-    const [
-      gatewayApiInstalled,
-      inferenceExtInstalled,
-      gatewayApiVersion,
-      inferenceExtVersion,
-    ] = await Promise.all([
-      this.checkCRDExists(GATEWAY_API_CRD_NAME),
-      this.checkCRDExists(INFERENCE_POOL_CRD_NAME),
-      this.getCRDVersionFromAnnotations(GATEWAY_API_CRD_NAME, GATEWAY_API_VERSION_ANNOTATIONS),
-      this.getCRDVersionFromAnnotations(INFERENCE_POOL_CRD_NAME, INFERENCE_EXTENSION_VERSION_ANNOTATIONS),
+    const [gatewayApiStatus, inferenceExtStatus] = await Promise.all([
+      this.getCRDStatusFromAnnotations(GATEWAY_API_CRD_NAME, GATEWAY_API_VERSION_ANNOTATIONS),
+      this.getCRDStatusFromAnnotations(INFERENCE_POOL_CRD_NAME, INFERENCE_EXTENSION_VERSION_ANNOTATIONS),
     ]);
+
+    const gatewayApiInstalled = gatewayApiStatus.installed;
+    const inferenceExtInstalled = inferenceExtStatus.installed;
+    const gatewayApiVersion = gatewayApiStatus.version;
+    const inferenceExtVersion = inferenceExtStatus.version;
 
     // Get live gateway status
     let gatewayAvailable = false;

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -14,6 +14,19 @@ const MODEL_DEPLOYMENT_CRD = {
   kind: 'ModelDeployment',
 };
 
+const GATEWAY_API_CRD_NAME = 'gateways.gateway.networking.k8s.io';
+const INFERENCE_POOL_CRD_NAME = 'inferencepools.inference.networking.k8s.io';
+
+const GATEWAY_API_VERSION_ANNOTATIONS = [
+  'gateway.networking.k8s.io/bundle-version',
+  'app.kubernetes.io/version',
+];
+
+const INFERENCE_EXTENSION_VERSION_ANNOTATIONS = [
+  'inference.networking.k8s.io/bundle-version',
+  'app.kubernetes.io/version',
+];
+
 /**
  * GPU availability information from cluster nodes
  */
@@ -58,6 +71,25 @@ export interface ClusterGpuCapacity {
   gpuNodeCount: number;           // Total number of nodes with GPUs
   totalMemoryGb?: number;         // Total GPU memory per GPU (e.g., 80 for A100 80GB)
   nodes: NodeGpuInfo[];           // Per-node breakdown
+}
+
+/**
+ * Extract the first non-empty version annotation from a Kubernetes CRD object or
+ * Kubernetes client response wrapper. The generated Kubernetes client has used
+ * both shapes across versions (`response.body` and the resource object itself).
+ */
+export function extractCRDVersionFromAnnotations(crdOrResponse: unknown, annotationKeys: string[]): string | undefined {
+  const crd = (crdOrResponse as any)?.body || crdOrResponse;
+  const annotations = (crd as any)?.metadata?.annotations || {};
+
+  for (const key of annotationKeys) {
+    const version = annotations[key];
+    if (typeof version === 'string' && version.trim().length > 0) {
+      return version.trim();
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -538,6 +570,27 @@ class KubernetesService {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Read a version annotation from a CRD, if present.
+   */
+  async getCRDVersionFromAnnotations(crdName: string, annotationKeys: string[]): Promise<string | undefined> {
+    try {
+      const response = await withRetry(
+        () => this.apiExtensionsApi.readCustomResourceDefinition(crdName),
+        { operationName: `getCRDVersionFromAnnotations:${crdName}`, maxRetries: 1 }
+      );
+
+      return extractCRDVersionFromAnnotations(response, annotationKeys);
+    } catch (error: any) {
+      const statusCode = error?.statusCode || error?.response?.statusCode;
+      if (statusCode !== 404) {
+        logger.debug({ error: error?.message || error, crdName }, 'Could not read CRD version annotation');
+      }
+    }
+
+    return undefined;
   }
 
   /**
@@ -1607,9 +1660,16 @@ class KubernetesService {
   async checkGatewayCRDStatus(): Promise<GatewayCRDStatus> {
     const { PINNED_GAIE_VERSION, GAIE_CRD_URL, GATEWAY_API_CRD_URL } = await import('@airunway/shared');
 
-    const [gatewayApiInstalled, inferenceExtInstalled] = await Promise.all([
-      this.checkCRDExists('gateways.gateway.networking.k8s.io'),
-      this.checkCRDExists('inferencepools.inference.networking.k8s.io'),
+    const [
+      gatewayApiInstalled,
+      inferenceExtInstalled,
+      gatewayApiVersion,
+      inferenceExtVersion,
+    ] = await Promise.all([
+      this.checkCRDExists(GATEWAY_API_CRD_NAME),
+      this.checkCRDExists(INFERENCE_POOL_CRD_NAME),
+      this.getCRDVersionFromAnnotations(GATEWAY_API_CRD_NAME, GATEWAY_API_VERSION_ANNOTATIONS),
+      this.getCRDVersionFromAnnotations(INFERENCE_POOL_CRD_NAME, INFERENCE_EXTENSION_VERSION_ANNOTATIONS),
     ]);
 
     // Get live gateway status
@@ -1642,6 +1702,8 @@ class KubernetesService {
     return {
       gatewayApiInstalled,
       inferenceExtInstalled,
+      gatewayApiVersion,
+      inferenceExtVersion,
       pinnedVersion: PINNED_GAIE_VERSION,
       gatewayAvailable,
       gatewayEndpoint,

--- a/frontend/src/hooks/useGateway.test.tsx
+++ b/frontend/src/hooks/useGateway.test.tsx
@@ -16,6 +16,8 @@ describe('useGatewayCRDStatus', () => {
     expect(result.current.data).toBeDefined()
     expect(result.current.data?.gatewayApiInstalled).toBe(true)
     expect(result.current.data?.inferenceExtInstalled).toBe(true)
+    expect(result.current.data?.gatewayApiVersion).toBe('v1.2.1')
+    expect(result.current.data?.inferenceExtVersion).toBe('v1.5.0')
     expect(result.current.data?.pinnedVersion).toBe('v1.3.1')
     expect(result.current.data?.installCommands).toHaveLength(2)
   })

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -27,6 +27,17 @@ let mockHfStatus: {
   configured: false,
 }
 
+let mockGatewayStatus = {
+  gatewayApiInstalled: false,
+  inferenceExtInstalled: false,
+  gatewayAvailable: false,
+  installCommands: [] as string[],
+  message: '',
+  pinnedVersion: 'v1.3.1',
+  gatewayApiVersion: undefined as string | undefined,
+  inferenceExtVersion: undefined as string | undefined,
+}
+
 vi.mock('@/hooks/useSettings', () => ({
   useSettings: () => ({ isLoading: false }),
 }))
@@ -112,13 +123,7 @@ vi.mock('@/hooks/useGpuOperator', () => ({
 
 vi.mock('@/hooks/useGateway', () => ({
   useGatewayCRDStatus: () => ({
-    data: {
-      gatewayApiInstalled: false,
-      inferenceExtInstalled: false,
-      gatewayAvailable: false,
-      installCommands: [],
-      message: '',
-    },
+    data: mockGatewayStatus,
     isLoading: false,
     refetch,
   }),
@@ -170,6 +175,16 @@ describe('SettingsPage', () => {
     mockHfStatus = {
       configured: false,
     }
+    mockGatewayStatus = {
+      gatewayApiInstalled: false,
+      inferenceExtInstalled: false,
+      gatewayAvailable: false,
+      installCommands: [],
+      message: '',
+      pinnedVersion: 'v1.3.1',
+      gatewayApiVersion: undefined,
+      inferenceExtVersion: undefined,
+    }
   })
 
   it('renders runtime cards without inline accent border styles', () => {
@@ -212,6 +227,29 @@ describe('SettingsPage', () => {
 
     expect(screen.getByText('GPUs Enabled')).toHaveClass('bg-green-500/15', 'text-green-600', 'dark:text-green-400')
     expect(screen.getByText('Connected')).toHaveClass('bg-green-500/15', 'text-green-600', 'dark:text-green-400')
+  })
+
+  it('shows the installed Inference Extension version instead of the pinned install version', () => {
+    mockGatewayStatus = {
+      gatewayApiInstalled: true,
+      inferenceExtInstalled: true,
+      gatewayAvailable: false,
+      installCommands: [],
+      message: 'Gateway API and Inference Extension CRDs are installed. No active gateway detected.',
+      pinnedVersion: 'v1.3.1',
+      gatewayApiVersion: undefined,
+      inferenceExtVersion: 'v1.5.0',
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=integrations']}>
+        <SettingsPage />
+      </MemoryRouter>
+    )
+
+    const inferenceExtensionLabel = screen.getByText('Inference Extension').closest('div')
+    expect(inferenceExtensionLabel).toHaveTextContent('(v1.5.0)')
+    expect(inferenceExtensionLabel).not.toHaveTextContent('v1.3.1')
   })
 
   it('uses the Hugging Face emoji on the connect button', () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -849,8 +849,8 @@ export function SettingsPage() {
                     <div className="flex items-center justify-between rounded-lg bg-muted p-3">
                       <div className="flex items-center gap-1">
                         <span>Inference Extension</span>
-                        {gatewayCRDStatus?.pinnedVersion && (
-                          <span className="text-xs text-muted-foreground">({gatewayCRDStatus.pinnedVersion})</span>
+                        {gatewayCRDStatus?.inferenceExtInstalled && gatewayCRDStatus?.inferenceExtVersion && (
+                          <span className="text-xs text-muted-foreground">({gatewayCRDStatus.inferenceExtVersion})</span>
                         )}
                       </div>
                       {gatewayCRDStatus?.inferenceExtInstalled ? (

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -205,6 +205,8 @@ export const handlers = [
     return HttpResponse.json({
       gatewayApiInstalled: true,
       inferenceExtInstalled: true,
+      gatewayApiVersion: 'v1.2.1',
+      inferenceExtVersion: 'v1.5.0',
       pinnedVersion: 'v1.3.1',
       gatewayAvailable: false,
       message: 'Gateway API and Inference Extension CRDs are installed. No active gateway detected.',


### PR DESCRIPTION
## Summary
- read Gateway API and Inference Extension installed versions from CRD annotations
- return the installed CRD versions in gateway CRD status responses
- show the installed Inference Extension version in Settings instead of the pinned install version
- update backend/frontend mocks and tests for installed version fields

## Validation
- [x] `bun test backend/src/routes/installation.test.ts backend/src/services/kubernetes.test.ts`
- [x] `bun run --filter '@airunway/frontend' test -- src/pages/SettingsPage.test.tsx src/hooks/useGateway.test.tsx`
- [x] `bun run --filter '@airunway/frontend' test`
- [x] `bun run --filter '@airunway/backend' test`

## Note
- `bun run build` completed shared/frontend build, but backend `tsc` hit a Node heap out-of-memory error under the default heap limit; a larger-heap retry was stopped after running several minutes without output.
