### PR TITLE
fix: resolve deployment metrics via frontend service

### DIFF
--- a/backend/src/routes/deployments.test.ts
+++ b/backend/src/routes/deployments.test.ts
@@ -2,7 +2,9 @@ import { describe, test, expect, afterEach } from 'bun:test';
 import app from '../hono-app';
 import { kubernetesService } from '../services/kubernetes';
 import { configService } from '../services/config';
+import { metricsService } from '../services/metrics';
 import { mockServiceMethod } from '../test/helpers';
+import type { MetricsResponse } from '@airunway/shared';
 import {
   mockDeployment,
   mockDeploymentWithPendingPod,
@@ -610,6 +612,46 @@ describe('Deployment Routes', () => {
 
       const res = await app.request('/api/deployments/test-deploy/manifest');
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/deployments/:name/metrics', () => {
+    test('passes frontend service endpoint details to the metrics service', async () => {
+      let capturedArgs: Parameters<typeof metricsService.getDeploymentMetrics> | undefined;
+
+      restores.push(
+        mockServiceMethod(configService, 'getDefaultNamespace', async () => 'default'),
+      );
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDeployment', async () => ({
+          ...mockDeployment,
+          provider: 'dynamo',
+          frontendService: 'test-deploy-frontend:8080',
+        })),
+      );
+      restores.push(
+        mockServiceMethod(metricsService, 'getDeploymentMetrics', async (...args) => {
+          capturedArgs = args;
+          return {
+            available: true,
+            timestamp: '2026-05-01T00:00:00.000Z',
+            metrics: [],
+          } satisfies MetricsResponse;
+        }),
+      );
+
+      const res = await app.request('/api/deployments/test-deploy/metrics');
+      expect(res.status).toBe(200);
+
+      expect(capturedArgs).toEqual([
+        'test-deploy',
+        'default',
+        {
+          providerId: 'dynamo',
+          serviceName: 'test-deploy-frontend',
+          port: 8080,
+        },
+      ]);
     });
   });
 

--- a/backend/src/routes/deployments.ts
+++ b/backend/src/routes/deployments.ts
@@ -10,9 +10,13 @@ import { aikitService, GGUF_RUNNER_IMAGE } from '../services/aikit';
 import { handleK8sError } from '../lib/k8s-errors';
 import models from '../data/models.json';
 import logger from '../lib/logger';
-import type { DeploymentStatus, DeploymentConfig } from '@airunway/shared';
 import type { AppEnv } from '../types/hono';
-import { toModelDeploymentManifest } from '@airunway/shared';
+import {
+  parseFrontendService,
+  toModelDeploymentManifest,
+  type DeploymentStatus,
+  type DeploymentConfig,
+} from '@airunway/shared';
 import {
   namespaceSchema,
   resourceNameSchema,
@@ -600,7 +604,12 @@ const deployments = new Hono<AppEnv>()
         throw new HTTPException(404, { message: 'Deployment not found' });
       }
 
-      const metricsResponse = await metricsService.getDeploymentMetrics(name, resolvedNamespace);
+      const frontendService = parseFrontendService(deployment.frontendService);
+      const metricsResponse = await metricsService.getDeploymentMetrics(name, resolvedNamespace, {
+        providerId: deployment.provider,
+        serviceName: frontendService?.serviceName,
+        port: frontendService?.servicePort,
+      });
       return c.json(metricsResponse);
     }
 )

--- a/backend/src/services/metrics.test.ts
+++ b/backend/src/services/metrics.test.ts
@@ -149,6 +149,119 @@ describe('MetricsService - Caching', () => {
   });
 });
 
+describe('MetricsService - Endpoint Resolution', () => {
+  test('uses frontend service override for in-cluster scraping', async () => {
+    const urls: string[] = [];
+    const fetchRawMetrics = mock(async (url: string) => {
+      urls.push(url);
+      return 'vllm:num_requests_running 5\n';
+    });
+
+    const service = new MetricsService({
+      fetchRawMetrics,
+      checkInCluster: () => true,
+      now: () => 1700000000000,
+      successCacheTtlMs: 0,
+      errorCacheTtlMs: 0,
+    });
+
+    const response = await service.getDeploymentMetrics('demo', 'default', {
+      providerId: 'dynamo',
+      serviceName: 'demo-frontend',
+      port: 8000,
+    });
+
+    expect(response.available).toBe(true);
+    expect(urls).toEqual(['http://demo-frontend.default.svc.cluster.local:8000/metrics']);
+  });
+
+  test('uses resolved service and port for off-cluster proxy scraping', async () => {
+    const calls: Array<[string, string, number, string]> = [];
+    const proxyServiceGet = mock(async (serviceName: string, namespace: string, port: number, path: string) => {
+      calls.push([serviceName, namespace, port, path]);
+      return 'vllm:num_requests_running 5\n';
+    });
+
+    const service = new MetricsService({
+      proxyServiceGet,
+      checkInCluster: () => false,
+      now: () => 1700000000000,
+      successCacheTtlMs: 0,
+      errorCacheTtlMs: 0,
+    });
+
+    const response = await service.getDeploymentMetrics('demo', 'models', {
+      serviceName: 'custom-svc',
+      port: 9000,
+    });
+
+    expect(response.available).toBe(true);
+    expect(calls).toEqual([['custom-svc', 'models', 9000, 'metrics']]);
+  });
+
+  test('keeps default deployment-name service behavior when no endpoint override is supplied', async () => {
+    const urls: string[] = [];
+    const fetchRawMetrics = mock(async (url: string) => {
+      urls.push(url);
+      return 'vllm:num_requests_running 5\n';
+    });
+
+    const service = new MetricsService({
+      fetchRawMetrics,
+      checkInCluster: () => true,
+      now: () => 1700000000000,
+      successCacheTtlMs: 0,
+      errorCacheTtlMs: 0,
+    });
+
+    const response = await service.getDeploymentMetrics('demo', 'default');
+
+    expect(response.available).toBe(true);
+    expect(urls).toEqual(['http://demo.default.svc.cluster.local:8000/metrics']);
+  });
+
+  test('cache keys differ when service or port differs for the same deployment', async () => {
+    let now = 1700000000000;
+    const fetchRawMetrics = mock(async () => 'vllm:num_requests_running 5\n');
+    const service = new MetricsService({
+      fetchRawMetrics,
+      checkInCluster: () => true,
+      now: () => now,
+      successCacheTtlMs: 15000,
+      errorCacheTtlMs: 5000,
+    });
+
+    await service.getDeploymentMetrics('demo', 'default', { serviceName: 'demo-a', port: 8000 });
+    now += 1000;
+    await service.getDeploymentMetrics('demo', 'default', { serviceName: 'demo-b', port: 8000 });
+    now += 1000;
+    await service.getDeploymentMetrics('demo', 'default', { serviceName: 'demo-a', port: 8000 });
+
+    expect(fetchRawMetrics).toHaveBeenCalledTimes(2);
+  });
+
+  test('uses Dynamo frontend service fallback when provider is dynamo and no endpoint override is supplied', async () => {
+    const urls: string[] = [];
+    const fetchRawMetrics = mock(async (url: string) => {
+      urls.push(url);
+      return 'vllm:num_requests_running 5\n';
+    });
+
+    const service = new MetricsService({
+      fetchRawMetrics,
+      checkInCluster: () => true,
+      now: () => 1700000000000,
+      successCacheTtlMs: 0,
+      errorCacheTtlMs: 0,
+    });
+
+    const response = await service.getDeploymentMetrics('demo', 'default', 'dynamo');
+
+    expect(response.available).toBe(true);
+    expect(urls).toEqual(['http://demo-frontend.default.svc.cluster.local:8000/metrics']);
+  });
+});
+
 describe('MetricsService - MetricsResponse structure', () => {
   test('creates unavailable response for off-cluster', () => {
     const response: MetricsResponse = {

--- a/backend/src/services/metrics.ts
+++ b/backend/src/services/metrics.ts
@@ -132,6 +132,25 @@ interface MetricsServiceOptions {
   errorCacheTtlMs?: number;
 }
 
+export interface DeploymentMetricsEndpointOptions {
+  providerId?: string;
+  serviceName?: string;
+  port?: number;
+  endpointPath?: string;
+}
+
+interface ResolvedMetricsTarget {
+  providerId?: string;
+  serviceName: string;
+  port: number;
+  endpointPath: string;
+}
+
+function normalizeEndpointPath(endpointPath?: string): string {
+  const path = endpointPath?.trim() || DEFAULT_METRICS_CONFIG.endpointPath;
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
 /**
  * MetricsService class for fetching deployment metrics
  */
@@ -167,8 +186,46 @@ export class MetricsService {
     this.inFlightRequests.clear();
   }
 
-  private buildCacheKey(deploymentName: string, namespace: string, providerId?: string): string {
-    return `${namespace}/${deploymentName}/${providerId ?? 'default'}`;
+  private resolveMetricsTarget(
+    deploymentName: string,
+    options: DeploymentMetricsEndpointOptions = {}
+  ): ResolvedMetricsTarget {
+    const providerId = options.providerId?.trim();
+    const normalizedProviderId = providerId?.toLowerCase();
+    const explicitServiceName = options.serviceName?.trim();
+    const explicitPort =
+      options.port && Number.isFinite(options.port) && options.port > 0
+        ? options.port
+        : undefined;
+
+    let serviceName = explicitServiceName;
+    const port = explicitPort ?? DEFAULT_METRICS_CONFIG.port;
+
+    if (!serviceName) {
+      if (normalizedProviderId === 'dynamo') {
+        serviceName = `${deploymentName}-frontend`;
+      } else {
+        serviceName = DEFAULT_METRICS_CONFIG.serviceNamePattern.replace('{name}', deploymentName);
+      }
+    }
+
+    return {
+      providerId,
+      serviceName,
+      port,
+      endpointPath: normalizeEndpointPath(options.endpointPath),
+    };
+  }
+
+  private buildCacheKey(deploymentName: string, namespace: string, target: ResolvedMetricsTarget): string {
+    return [
+      namespace,
+      deploymentName,
+      target.providerId ?? 'default',
+      target.serviceName,
+      target.port,
+      target.endpointPath,
+    ].join('/');
   }
 
   private getCachedResponse(cacheKey: string): MetricsResponse | null {
@@ -202,11 +259,20 @@ export class MetricsService {
    *
    * @param deploymentName - Name of the deployment
    * @param namespace - Kubernetes namespace
-   * @param providerId - Optional provider ID (for future use)
+   * @param providerIdOrOptions - Optional provider ID or endpoint options
    * @returns MetricsResponse with available metrics or error
    */
-  async getDeploymentMetrics(deploymentName: string, namespace: string, providerId?: string): Promise<MetricsResponse> {
-    const cacheKey = this.buildCacheKey(deploymentName, namespace, providerId);
+  async getDeploymentMetrics(
+    deploymentName: string,
+    namespace: string,
+    providerIdOrOptions?: string | DeploymentMetricsEndpointOptions
+  ): Promise<MetricsResponse> {
+    const options: DeploymentMetricsEndpointOptions =
+      typeof providerIdOrOptions === 'string'
+        ? { providerId: providerIdOrOptions }
+        : (providerIdOrOptions ?? {});
+    const target = this.resolveMetricsTarget(deploymentName, options);
+    const cacheKey = this.buildCacheKey(deploymentName, namespace, target);
     const cachedResponse = this.getCachedResponse(cacheKey);
     if (cachedResponse) {
       logger.debug({ deploymentName, namespace }, 'Serving cached deployment metrics');
@@ -219,7 +285,7 @@ export class MetricsService {
       return inFlightRequest;
     }
 
-    const request = this.fetchDeploymentMetrics(deploymentName, namespace, cacheKey).finally(() => {
+    const request = this.fetchDeploymentMetrics(deploymentName, namespace, target, cacheKey).finally(() => {
       this.inFlightRequests.delete(cacheKey);
     });
 
@@ -230,16 +296,13 @@ export class MetricsService {
   private async fetchDeploymentMetrics(
     deploymentName: string,
     namespace: string,
+    target: ResolvedMetricsTarget,
     cacheKey: string
   ): Promise<MetricsResponse> {
     const timestamp = new Date(this.nowFn()).toISOString();
     const inCluster = this.checkInClusterFn();
 
     try {
-      // Use default metrics configuration
-      const metricsConfig = DEFAULT_METRICS_CONFIG;
-      const serviceName = metricsConfig.serviceNamePattern.replace('{name}', deploymentName);
-
       let rawText: string;
 
       if (inCluster) {
@@ -247,18 +310,39 @@ export class MetricsService {
         const url = buildMetricsUrl(
           deploymentName,
           namespace,
-          metricsConfig.serviceNamePattern,
-          metricsConfig.port,
-          metricsConfig.endpointPath
+          target.serviceName,
+          target.port,
+          target.endpointPath
         );
 
-        logger.debug({ url, deploymentName, namespace }, 'Fetching metrics from deployment (in-cluster)');
+        logger.debug(
+          {
+            url,
+            deploymentName,
+            namespace,
+            providerId: target.providerId,
+            serviceName: target.serviceName,
+            port: target.port,
+            path: target.endpointPath,
+          },
+          'Fetching metrics from deployment (in-cluster)'
+        );
         rawText = await this.fetchRawMetricsFn(url);
       } else {
         // Off-cluster: proxy through the K8s API server via kubeconfig
-        const path = metricsConfig.endpointPath.replace(/^\//, ''); // strip leading slash
-        logger.debug({ deploymentName, namespace, port: metricsConfig.port, path }, 'Fetching metrics via K8s API proxy (off-cluster)');
-        rawText = await this.proxyServiceGetFn(serviceName, namespace, metricsConfig.port, path);
+        const path = target.endpointPath.replace(/^\//, ''); // strip leading slash
+        logger.debug(
+          {
+            deploymentName,
+            namespace,
+            providerId: target.providerId,
+            serviceName: target.serviceName,
+            port: target.port,
+            path,
+          },
+          'Fetching metrics via K8s API proxy (off-cluster)'
+        );
+        rawText = await this.proxyServiceGetFn(target.serviceName, namespace, target.port, path);
       }
 
       // Parse Prometheus format
@@ -282,7 +366,15 @@ export class MetricsService {
       const userMessage = mapMetricsErrorMessage(errorMessage);
 
       logger.warn(
-        { deploymentName, namespace, error: errorMessage },
+        {
+          deploymentName,
+          namespace,
+          providerId: target.providerId,
+          serviceName: target.serviceName,
+          port: target.port,
+          path: target.endpointPath,
+          error: errorMessage,
+        },
         'Failed to fetch deployment metrics'
       );
 


### PR DESCRIPTION
## Summary
- route deployment metrics requests through parsed frontend service details
- resolve metrics scrape targets using explicit overrides, Dynamo frontend fallback, or legacy deployment service names
- isolate metrics cache entries by resolved target and add endpoint resolution test coverage

Fixes #251

## Tests
- bun test backend/src/services/metrics.test.ts backend/src/routes/deployments.test.ts
- bun run --filter '@airunway/backend' build