### PR TITLE
fix(kaito): finalize ModelDeployment when upstream CRD is missing

### DIFF
--- a/providers/kaito/controller.go
+++ b/providers/kaito/controller.go
@@ -360,33 +360,56 @@ func (r *KaitoProviderReconciler) handleDeletion(ctx context.Context, md *airunw
 
 		// Resource exists and is owned by us, delete it
 		logger.Info("Deleting Workspace", "name", md.Name)
-		if err := r.Delete(ctx, ws); err != nil && !errors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete Workspace")
+		if err := r.Delete(ctx, ws); err != nil {
+			if upstreamResourceUnavailable(err) {
+				logger.Info("Workspace unavailable during deletion, removing finalizer", "name", md.Name)
+			} else {
+				logger.Error(err, "Failed to delete Workspace")
 
-			// Check if we should force-remove the finalizer
-			deletionTime := md.DeletionTimestamp.Time
-			if time.Since(deletionTime) > FinalizerTimeout {
-				logger.Info("Finalizer timeout reached, removing finalizer without cleanup")
-				controllerutil.RemoveFinalizer(md, FinalizerName)
-				return ctrl.Result{}, r.Update(ctx, md)
+				// Check if we should force-remove the finalizer
+				deletionTime := md.DeletionTimestamp.Time
+				if time.Since(deletionTime) > FinalizerTimeout {
+					logger.Info("Finalizer timeout reached, removing finalizer without cleanup")
+					controllerutil.RemoveFinalizer(md, FinalizerName)
+					return ctrl.Result{}, r.Update(ctx, md)
+				}
+
+				// Requeue to retry deletion
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
-
-			// Requeue to retry deletion
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		} else {
+			// Requeue to wait for deletion
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
-
-		// Requeue to wait for deletion
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	if !errors.IsNotFound(err) {
-		return ctrl.Result{}, fmt.Errorf("failed to get upstream resource: %w", err)
+	if !upstreamResourceUnavailable(err) {
+		// Unexpected error fetching the upstream resource (e.g. transient API
+		// server failure). Honor the finalizer timeout so the ModelDeployment
+		// can still be removed if the error persists, instead of requeueing
+		// forever.
+		deletionTime := md.DeletionTimestamp.Time
+		if time.Since(deletionTime) > FinalizerTimeout {
+			logger.Info("Finalizer timeout reached, removing finalizer without cleanup")
+			controllerutil.RemoveFinalizer(md, FinalizerName)
+			return ctrl.Result{}, r.Update(ctx, md)
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	// Resource is gone, remove finalizer
-	logger.Info("Upstream resource deleted, removing finalizer", "name", md.Name)
+	// The upstream resource is already gone or its CRD is no longer installed,
+	// so cleanup can finish by removing the finalizer.
+	logger.Info("Upstream resource unavailable or deleted, removing finalizer", "name", md.Name)
 	controllerutil.RemoveFinalizer(md, FinalizerName)
 	return ctrl.Result{}, r.Update(ctx, md)
+}
+
+// upstreamResourceUnavailable returns true when the error indicates the
+// upstream resource is missing or its CRD is not installed in the cluster.
+// This mirrors the helper used by the dynamo and kuberay providers so that
+// finalizer cleanup completes even when KAITO has been uninstalled.
+func upstreamResourceUnavailable(err error) bool {
+	return errors.IsNotFound(err) || meta.IsNoMatchError(err)
 }
 
 // setCondition updates a condition on the ModelDeployment

--- a/providers/kaito/controller.go
+++ b/providers/kaito/controller.go
@@ -360,27 +360,29 @@ func (r *KaitoProviderReconciler) handleDeletion(ctx context.Context, md *airunw
 
 		// Resource exists and is owned by us, delete it
 		logger.Info("Deleting Workspace", "name", md.Name)
-		if err := r.Delete(ctx, ws); err != nil {
-			if upstreamResourceUnavailable(err) {
+		if deleteErr := r.Delete(ctx, ws); deleteErr != nil {
+			if upstreamResourceUnavailable(deleteErr) {
 				logger.Info("Workspace unavailable during deletion, removing finalizer", "name", md.Name)
-			} else {
-				logger.Error(err, "Failed to delete Workspace")
-
-				// Check if we should force-remove the finalizer
-				deletionTime := md.DeletionTimestamp.Time
-				if time.Since(deletionTime) > FinalizerTimeout {
-					logger.Info("Finalizer timeout reached, removing finalizer without cleanup")
-					controllerutil.RemoveFinalizer(md, FinalizerName)
-					return ctrl.Result{}, r.Update(ctx, md)
-				}
-
-				// Requeue to retry deletion
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+				controllerutil.RemoveFinalizer(md, FinalizerName)
+				return ctrl.Result{}, r.Update(ctx, md)
 			}
-		} else {
-			// Requeue to wait for deletion
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+
+			logger.Error(deleteErr, "Failed to delete Workspace")
+
+			// Check if we should force-remove the finalizer
+			deletionTime := md.DeletionTimestamp.Time
+			if time.Since(deletionTime) > FinalizerTimeout {
+				logger.Info("Finalizer timeout reached, removing finalizer without cleanup")
+				controllerutil.RemoveFinalizer(md, FinalizerName)
+				return ctrl.Result{}, r.Update(ctx, md)
+			}
+
+			// Requeue to retry deletion
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
+
+		// Requeue to wait for deletion
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	if !upstreamResourceUnavailable(err) {

--- a/providers/kaito/controller_test.go
+++ b/providers/kaito/controller_test.go
@@ -2,16 +2,22 @@ package kaito
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -452,6 +458,140 @@ func TestReconcileHandleDeletion(t *testing.T) {
 		t.Error("expected finalizer to be removed after deletion with no upstream resource")
 	}
 	_ = result
+}
+
+// TestReconcileDeletionWithMissingUpstreamCRDRemovesFinalizer reproduces
+// https://github.com/kaito-project/airunway/issues/239 — when the KAITO
+// upstream CRDs are not installed, fetching the Workspace returns
+// meta.NoKindMatchError (not IsNotFound). The reconciler must still complete
+// finalizer removal so the ModelDeployment can be deleted.
+func TestReconcileDeletionWithMissingUpstreamCRDRemovesFinalizer(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	now := metav1.Now()
+	md.DeletionTimestamp = &now
+
+	interceptorFuncs := interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == WorkspaceKind {
+				return &apimeta.NoKindMatchError{
+					GroupKind:        schema.GroupKind{Group: KaitoAPIGroup, Kind: WorkspaceKind},
+					SearchedVersions: []string{KaitoAPIVersion},
+				}
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(md).
+		WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptorFuncs).
+		Build()
+	r := NewKaitoProviderReconciler(c, scheme)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("expected deletion to finish without requeue, got %#v", result)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected ModelDeployment to be deleted after finalizer removal, got %v", err)
+	}
+}
+
+// TestReconcileDeletionTransientGetErrorBeforeTimeout confirms that an
+// unexpected (non-NoMatch / non-NotFound) error fetching the upstream
+// resource requeues instead of returning a hard error, so subsequent
+// reconciles can still observe the timeout fallback.
+func TestReconcileDeletionTransientGetErrorBeforeTimeout(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	now := metav1.Now()
+	md.DeletionTimestamp = &now
+
+	interceptorFuncs := interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == WorkspaceKind {
+				return errors.New("transient API server failure")
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(md).
+		WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptorFuncs).
+		Build()
+	r := NewKaitoProviderReconciler(c, scheme)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Fatalf("expected requeue while waiting for timeout, got %#v", result)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("expected ModelDeployment to still exist before timeout, got %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(&updated, FinalizerName) {
+		t.Error("expected finalizer to still be present before timeout")
+	}
+}
+
+// TestReconcileDeletionTransientGetErrorAfterTimeout confirms the documented
+// 5-minute force-remove fallback eventually fires when the upstream Get
+// continues to fail with an unexpected error.
+func TestReconcileDeletionTransientGetErrorAfterTimeout(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	old := metav1.NewTime(time.Now().Add(-(FinalizerTimeout + time.Minute)))
+	md.DeletionTimestamp = &old
+
+	interceptorFuncs := interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == WorkspaceKind {
+				return errors.New("persistent API server failure")
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(md).
+		WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptorFuncs).
+		Build()
+	r := NewKaitoProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected ModelDeployment to be deleted after finalizer timeout, got %v", err)
+	}
 }
 
 func TestReconcileDeletionNoFinalizer(t *testing.T) {

--- a/providers/kaito/controller_test.go
+++ b/providers/kaito/controller_test.go
@@ -433,7 +433,6 @@ func TestReconcileAlreadyRunning(t *testing.T) {
 	}
 }
 
-
 func TestReconcileHandleDeletion(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
@@ -505,6 +504,79 @@ func TestReconcileDeletionWithMissingUpstreamCRDRemovesFinalizer(t *testing.T) {
 	var updated airunwayv1alpha1.ModelDeployment
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); !apierrors.IsNotFound(err) {
 		t.Fatalf("expected ModelDeployment to be deleted after finalizer removal, got %v", err)
+	}
+}
+
+func TestReconcileDeletionWithUpstreamUnavailableDeleteRemovesFinalizer(t *testing.T) {
+	tests := []struct {
+		name      string
+		deleteErr error
+	}{
+		{
+			name: "workspace deleted between get and delete",
+			deleteErr: apierrors.NewNotFound(
+				schema.GroupResource{Group: KaitoAPIGroup, Resource: "workspaces"},
+				"test",
+			),
+		},
+		{
+			name: "workspace CRD removed between get and delete",
+			deleteErr: &apimeta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: KaitoAPIGroup, Kind: WorkspaceKind},
+				SearchedVersions: []string{KaitoAPIVersion},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme()
+			md := newMDForController("test", "default")
+			md.UID = "test-uid"
+			controllerutil.AddFinalizer(md, FinalizerName)
+			now := metav1.Now()
+			md.DeletionTimestamp = &now
+
+			ws := &unstructured.Unstructured{}
+			setWorkspaceGVK(ws)
+			ws.SetName("test")
+			ws.SetNamespace("default")
+			ws.SetOwnerReferences([]metav1.OwnerReference{
+				{UID: "test-uid", APIVersion: "airunway.ai/v1alpha1", Kind: "ModelDeployment", Name: "test"},
+			})
+
+			interceptorFuncs := interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if u, ok := obj.(*unstructured.Unstructured); ok && u.GetKind() == WorkspaceKind {
+						return tt.deleteErr
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(md, ws).
+				WithStatusSubresource(md).
+				WithInterceptorFuncs(interceptorFuncs).
+				Build()
+			r := NewKaitoProviderReconciler(c, scheme)
+
+			result, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Requeue || result.RequeueAfter != 0 {
+				t.Fatalf("expected deletion to finish without requeue, got %#v", result)
+			}
+
+			var updated airunwayv1alpha1.ModelDeployment
+			if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); !apierrors.IsNotFound(err) {
+				t.Fatalf("expected ModelDeployment to be deleted after finalizer removal, got %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

When the KAITO upstream CRDs are not installed in the cluster, deleting a `ModelDeployment` that targeted the `kaito` provider would leave the object stuck in `Terminating` forever with the `airunway.ai/kaito-provider` finalizer attached. The reconciler logged `no matches for kind "Workspace" in version "kaito.sh/v1beta1"` on every requeue and the documented 5-minute force-removal fallback never fired.

Root cause: the deletion path only checked `errors.IsNotFound`, but a missing CRD surfaces as `meta.NoKindMatchError`. That error fell through to a `return ctrl.Result{}, fmt.Errorf(...)` branch, so controller-runtime requeued with backoff indefinitely and never reached the timeout escape hatch (which lived only in the *resource-exists / delete-failed* branch).

The dynamo and kuberay providers already handle this with an `upstreamResourceUnavailable()` helper. This PR brings the kaito provider in line with that pattern.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Reproduce issue #239 on a kind cluster and implement the fix.
Audit the other provider shims for the same pattern and mirror what
dynamo/kuberay already do. Add regression tests covering the
missing-CRD path, the transient-error-before-timeout path, and the
transient-error-after-timeout path. Verify end-to-end on the cluster.
```

**AI Tool:** GitHub Copilot CLI (Claude Opus 4.7)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #239

## Changes Made

- Add `upstreamResourceUnavailable(err)` helper in `providers/kaito/controller.go` that treats both `errors.IsNotFound` and `meta.IsNoMatchError` as "upstream is gone" (mirrors the existing helper in dynamo/kuberay for cross-shim consistency).
- In `handleDeletion`:
  - When `Get` on the upstream `Workspace` returns a missing-CRD or NotFound error, remove the finalizer cleanly instead of returning a wrapped error.
  - When `Get` returns an unexpected error (e.g. transient API server failure), still requeue — but check `FinalizerTimeout` so the documented 5-minute fallback actually fires once exceeded, instead of looping forever.
  - When deleting an existing Workspace fails because it has since become unavailable, fall through to finalizer removal rather than retrying.
- Add three regression tests in `providers/kaito/controller_test.go`:
  - `TestReconcileDeletionWithMissingUpstreamCRDRemovesFinalizer` — direct repro of #239 via `client/interceptor` injecting `NoKindMatchError`.
  - `TestReconcileDeletionTransientGetErrorBeforeTimeout` — confirms a generic Get failure within the timeout window still requeues (MD survives).
  - `TestReconcileDeletionTransientGetErrorAfterTimeout` — confirms the now-actually-reachable timeout fallback removes the finalizer.

## Testing

- [x] Unit tests pass (`cd providers/kaito && go test ./...`) — including the 3 new tests.
- [x] Manual testing performed.
- [x] Tested with a Kubernetes cluster.

End-to-end repro on a local kind cluster (no KAITO CRDs installed):

1. Built the kaito provider image from this branch and loaded it into kind.
2. Deployed the kaito provider shim with the new image.
3. Applied a `ModelDeployment` with `provider.name: kaito` — finalizer attaches, MD goes to `Failed` (expected, no upstream).
4. `kubectl delete modeldeployment <name>` — completes in **<5 seconds**.
5. Provider logs show a single new info line: `Upstream resource unavailable or deleted, removing finalizer`.

Before the fix, step 4 hung indefinitely with repeated `no matches for kind "Workspace"` reconcile errors and required a manual finalizer patch to recover.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed — N/A, no user-visible behavior change beyond unsticking the deletion path
- [x] My changes generate no new warnings (`go vet ./...` clean)

## Additional Notes

- **Cross-shim audit:** `dynamo` and `kuberay` already use the same helper. `llmd`'s upstream is the built-in `apps/v1 Deployment`, so its CRD is always present and the bug is latent there. Not addressed in this PR to keep the change focused, but worth a follow-up if llmd ever switches to a custom CRD.
- The renamed log message (`Upstream resource deleted` → `Upstream resource unavailable or deleted`) is intentional so logs accurately reflect both the "Workspace gone" and "CRD missing" paths.
