### PR TITLE
Harden llm-d override handling to block pod-spec privilege escalation

### DIFF
--- a/providers/llmd/transformer.go
+++ b/providers/llmd/transformer.go
@@ -581,8 +581,37 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		}
 	}
 
+	if hasNestedMapPath(overrides, "spec", "template", "spec") {
+		return fmt.Errorf("overriding %q is not allowed", "spec.template.spec")
+	}
+
 	obj.Object = deepMerge(obj.Object, overrides)
 	return nil
+}
+
+// hasNestedMapPath reports whether a nested map path exists in m.
+func hasNestedMapPath(m map[string]interface{}, path ...string) bool {
+	if len(path) == 0 {
+		return false
+	}
+
+	current := m
+	for i, key := range path {
+		value, exists := current[key]
+		if !exists {
+			return false
+		}
+		if i == len(path)-1 {
+			return true
+		}
+		next, ok := value.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		current = next
+	}
+
+	return false
 }
 
 // deepMerge recursively merges src into dst.

--- a/providers/llmd/transformer_test.go
+++ b/providers/llmd/transformer_test.go
@@ -651,6 +651,68 @@ func TestTransformOverrideBlocksMetadata(t *testing.T) {
 	}
 }
 
+func TestTransformOverrideBlocksPodSpec(t *testing.T) {
+	tr := NewTransformer()
+	md := newTestMD("test-model", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Overrides: &runtime.RawExtension{
+			Raw: []byte(`{"spec": {"template": {"spec": {"hostNetwork": true}}}}`),
+		},
+	}
+
+	_, err := tr.Transform(context.Background(), md)
+	if err == nil {
+		t.Fatal("expected error when overriding spec.template.spec")
+	}
+}
+
+func TestHasNestedMapPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		path     []string
+		expected bool
+	}{
+		{
+			name: "path exists",
+			input: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			path:     []string{"spec", "template", "spec"},
+			expected: true,
+		},
+		{
+			name: "path missing",
+			input: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			},
+			path:     []string{"spec", "template", "spec"},
+			expected: false,
+		},
+		{
+			name: "path blocked by non-map",
+			input: map[string]interface{}{
+				"spec": "not-a-map",
+			},
+			path:     []string{"spec", "template", "spec"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasNestedMapPath(tt.input, tt.path...)
+			if result != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestBuildResourceLimits(t *testing.T) {
 	tr := NewTransformer()
 

--- a/providers/llmd/transformer_test.go
+++ b/providers/llmd/transformer_test.go
@@ -2,6 +2,7 @@ package llmd
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
@@ -664,6 +665,9 @@ func TestTransformOverrideBlocksPodSpec(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when overriding spec.template.spec")
 	}
+	if !strings.Contains(err.Error(), "spec.template.spec") {
+		t.Fatalf("expected error to mention spec.template.spec, got %v", err)
+	}
 }
 
 func TestHasNestedMapPath(t *testing.T) {
@@ -833,9 +837,9 @@ func TestTransformUserLabelsCannotClobberSelectors(t *testing.T) {
 	md.Spec.PodTemplate = &airunwayv1alpha1.PodTemplateSpec{
 		Metadata: &airunwayv1alpha1.PodTemplateMetadata{
 			Labels: map[string]string{
-				"app":                        "my-custom-app",
+				"app":                    "my-custom-app",
 				"airunway.ai/deployment": "my-custom-deployment",
-				"my-label":                   "my-value",
+				"my-label":               "my-value",
 			},
 		},
 	}


### PR DESCRIPTION
### Motivation

- The llm-d provider previously deep-merged `spec.provider.overrides` into generated `apps/v1` Deployments and only blocked top-level keys, which allowed attackers to set dangerous `spec.template.spec` pod fields (privileged containers, hostNetwork/hostPID, hostPath volumes, serviceAccountName) via ModelDeployment overrides.

### Description

- Added a targeted guard in `applyOverrides` to reject nested overrides that include the `spec.template.spec` path so provider overrides cannot change pod-level fields (`providers/llmd/transformer.go`).
- Implemented a small helper `hasNestedMapPath` to detect whether a nested map path exists in the overrides without changing existing merge behavior for other fields (`providers/llmd/transformer.go`).
- Kept the existing top-level blocked keys (`apiVersion`, `kind`, `metadata`, `status`) intact so benign top-level overrides continue to be rejected (`providers/llmd/transformer.go`).
- Added unit tests `TestTransformOverrideBlocksPodSpec` and `TestHasNestedMapPath` to verify pod-spec override rejection and nested-path detection behavior (`providers/llmd/transformer_test.go`).

### Testing

- Added unit tests in `providers/llmd/transformer_test.go` that assert `spec.template.spec` overrides are rejected and that `hasNestedMapPath` behaves as expected; these tests were committed alongside the fix.
- Attempted `go test ./providers/llmd/...` from the repo root but the provider is a separate Go module and the command failed to run in this environment, so full package test execution could not be completed here. 
- Attempted targeted `go test` runs inside `providers/llmd`, but environment/module-resolution and execution time constraints prevented obtaining conclusive pass/fail output for the new tests in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96a697100832a966f9adb4dcb4d30)