### PR TITLE
fix(ui): prevent manifest copy from submitting deploy form

### DIFF
--- a/frontend/src/components/deployments/ManifestViewer.tsx
+++ b/frontend/src/components/deployments/ManifestViewer.tsx
@@ -285,6 +285,7 @@ const deployedQuery = useDeploymentManifest(
                   {resources.map((resource, index) => (
                     <Button
                       key={`${resource.kind}-${resource.name}`}
+                      type="button"
                       variant={selectedResourceIndex === index ? 'default' : 'outline'}
                       size="sm"
                       className="h-8"
@@ -308,12 +309,12 @@ const deployedQuery = useDeploymentManifest(
                 </span>
                 <div className="flex gap-2">
                   {resources.length > 1 && (
-                    <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); handleCopyAll(); }}>
+                    <Button type="button" variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); handleCopyAll(); }}>
                       <Copy className="h-4 w-4 mr-1" />
                       Copy All
                     </Button>
                   )}
-                  <Button variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); handleCopy(); }}>
+                  <Button type="button" variant="outline" size="sm" onClick={(e) => { e.stopPropagation(); handleCopy(); }}>
                     <Copy className="h-4 w-4 mr-1" />
                     Copy
                   </Button>


### PR DESCRIPTION
## Description

Adds the missing `type="button"` attribute to the three buttons inside the Manifest Preview component. Without it, browsers default `<button>` elements inside a `<form>` to `type="submit"`, which meant clicking **Copy**, **Copy All**, or a resource-kind tab was silently submitting the parent deployment form and deploying the model — even when the runtime appeared uninstalled.

`e.stopPropagation()` in the existing click handlers only stops click bubbling; it does not prevent the implicit form-submit behavior. Adding `type="button"` opts those buttons out of submission entirely.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Reproduce kaito-project/airunway#274 (Dashboard manifest preview copy button deploys the model) in a worktree on main, identify the root cause, and propose a minimal fix.
```

**AI Tool:** Claude (via GitHub Copilot CLI)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #274

## Changes Made

- `frontend/src/components/deployments/ManifestViewer.tsx`: added `type="button"` to the resource-kind selector buttons, **Copy All**, and **Copy** buttons so they no longer submit the parent `<form>` from `DeploymentForm.tsx`.

## Testing

- [x] Unit tests pass (`bun run test`) — 117 frontend tests pass
- [x] Manual testing performed — reproduced the bug on a local dev server, verified the Copy / Copy All buttons now only copy to clipboard and no `POST /api/deployments` is fired
- [ ] Tested with a Kubernetes cluster — not needed; the bug is purely client-side form behavior

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint` — ESLint config is missing on `main` (pre-existing, unrelated)
- [ ] I have added tests that prove my fix/feature works — not added; the fix is a one-attribute HTML correctness fix and the existing test suite still passes
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed — no doc impact
- [x] My changes generate no new warnings

## Screenshots

_N/A — no visual change. Behavioral fix only._

## Additional Notes

The same pattern (missing `type="button"` on a `<Button>` inside a `<form>`) is **not** present in `DeploymentForm.tsx` itself or in the sibling form components (`AIConfiguratorPanel`, `CapacityWarning`, `CostEstimate`, `StorageVolumesSection`) — audited those during the fix.
