### PR TITLE
chore(dynamo): bump Dynamo to `1.1.1` and install GAIE `v1.5.0`

### DIFF
--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -34,9 +34,11 @@ generate-deploy-manifests:
 
 ## Install Dynamo platform on the cluster (run before test-e2e)
 DYNAMO_NAMESPACE ?= dynamo-system
-DYNAMO_VERSION ?= 1.0.2
+DYNAMO_VERSION ?= 1.1.1
 DYNAMO_CHART_URL := https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-$(DYNAMO_VERSION).tgz
 DYNAMO_PRE_DEPLOY_URL := https://raw.githubusercontent.com/ai-dynamo/dynamo/v$(DYNAMO_VERSION)/deploy/pre-deployment/pre-deployment-check.sh
+GAIE_VERSION := v1.5.0
+GAIE_MANIFEST_URL := https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$(GAIE_VERSION)/manifests.yaml
 
 setup-dynamo:
 	@echo "Running Dynamo pre-deployment checks..."
@@ -46,6 +48,7 @@ setup-dynamo:
 		chmod +x "$$TMPSCRIPT" && \
 		bash "$$TMPSCRIPT"
 	@echo "Installing Dynamo platform v$(DYNAMO_VERSION)..."
+	@kubectl apply -f $(GAIE_MANIFEST_URL)
 	@helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
 			--namespace $(DYNAMO_NAMESPACE) \
 			--create-namespace \
@@ -55,6 +58,7 @@ setup-dynamo:
 ## Uninstall Dynamo platform from the cluster
 cleanup-dynamo:
 	helm uninstall dynamo-platform --namespace $(DYNAMO_NAMESPACE) --ignore-not-found
+	@kubectl delete -f $(GAIE_MANIFEST_URL) --ignore-not-found
 	@echo "✅ Dynamo platform uninstalled from namespace $(DYNAMO_NAMESPACE)"
 
 ## Run e2e tests (requires DYNAMO_INSTALLED=true and a cluster with dynamo provider deployed)


### PR DESCRIPTION
## Description

Bumps the Dynamo installed by `providers/dynamo/Makefile` from `1.0.2` to `1.1.1`, and installs the Gateway API Inference Extension (GAIE) `v1.5.0` manifests as part of the Dynamo setup so its CRDs are available before the Dynamo Helm chart is applied. The GAIE manifests are also removed on cleanup.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration


## Changes Made

- Upgrade `DYNAMO_VERSION` from `1.0.2` to `1.1.1` in `providers/dynamo/Makefile`.
- Add `GAIE_VERSION` (`v1.5.0`) and `GAIE_MANIFEST_URL` variables pointing to the upstream `gateway-api-inference-extension` release manifests.
- In `setup-dynamo`, apply the GAIE manifests via `kubectl apply -f $(GAIE_MANIFEST_URL)` before running `helm upgrade -i dynamo-platform`.
- In `cleanup-dynamo`, remove the GAIE manifests via `kubectl delete -f $(GAIE_MANIFEST_URL) --ignore-not-found` alongside the Helm uninstall.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [ ] My changes generate no new warnings

## Additional Notes

Dynamo `1.1.1` depends on the Gateway API Inference Extension CRDs; pre-installing the GAIE `v1.5.0` manifests ensures the Dynamo Helm chart can reconcile cleanly on a fresh cluster.