### PR TITLE
fix(release): regressions in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ ARG GIT_COMMIT=unknown
 
 WORKDIR /app
 
+# make is required by the verify-versions prebuild hook in package.json
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends make \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy package files for dependency installation
 COPY package.json bun.lock* ./
 COPY backend/package.json backend/

--- a/images/model-downloader/Dockerfile
+++ b/images/model-downloader/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.14-slim
 
-RUN pip install --no-cache-dir huggingface_hub==1.6.0 && \
+RUN pip install --no-cache-dir huggingface_hub==1.6.0 click && \
     hf version
 
 ENTRYPOINT ["hf"]


### PR DESCRIPTION
## Description

Fixes two release-blocker regressions discovered while building the v0.6.0 release images locally from `main`. Both fail the GitHub Actions `release.yml` workflow when a `v*` tag is pushed.

1. **Root `Dockerfile` (dashboard image) — `make: command not found`**
   PR #281 (centralize upstream versions) added `prebuild` / `prebuild:frontend` / `prebuild:backend` / `pretest` hooks to `package.json` that shell out to `make verify-versions`. The root `Dockerfile` uses `oven/bun:1` (Debian slim) which does not include `make`, so `RUN bun run build:frontend` now fails with exit code 127:
   ```
   #20 [builder 10/12] RUN bun run build:frontend
   #20 0.597 $ bun run verify-versions
   #20 0.601 $ make verify-versions
   #20 0.604 /usr/bin/bash: line 1: make: command not found
   #20 0.604 error: script "verify-versions" exited with code 127
   ```
   Fix: install `make` in the builder stage (~5s build penalty for the apt layer, keeps the version-drift guard intact).

2. **`images/model-downloader/Dockerfile` — `ModuleNotFoundError: click`**
   Upstream `huggingface_hub==1.6.0` demoted `click` from a required dependency to an extra. The Dockerfile pins `huggingface_hub==1.6.0` and immediately runs `hf version` as a build-time smoke, which now imports `click` and fails:
   ```
   ModuleNotFoundError: No module named 'click'
   ```
   Fix: add `click` to the `pip install` line.

### Why CI didn't catch this

The dashboard / model-downloader build jobs in `release.yml` only run on `v*` tag pushes. The last `v*` tag was `v0.5.0` (2026-04-06). PR #281 merged 2026-05-24. No release tag has been cut between those dates, so the regression slipped CI. The two Dockerfiles tested manually as part of PR #281 (`controller/Dockerfile`, `providers/dynamo/Dockerfile`) both use `golang` base images that happen to include `make`.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Pulled upstream main, built all four v0.6.0-rc1 images locally (mirroring release.yml), discovered the root Dockerfile and model-downloader Dockerfile both fail to build. Traced the dashboard regression to PR #281's package.json prebuild hooks. Patched both Dockerfiles minimally so the v0.6.0 release tag can ship cleanly.
```

**AI Tool:** GitHub Copilot CLI (Claude Opus 4.7)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Related Issues

Relates to v0.6.0 release prep. Indirectly relates to #281 (which introduced the prebuild hooks without testing the bun-based Dockerfile).

## Changes Made

- `Dockerfile`: install `make` via `apt-get` in the `oven/bun:1` builder stage, with comment explaining why.
- `images/model-downloader/Dockerfile`: add `click` to the `huggingface_hub==1.6.0` pip install.

## Testing

- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

**Reproduced both failures** against `upstream/main @ 9c051d5` with the exact `release.yml` command (`--push` swapped for `--load`):

```bash
git checkout upstream/main -- Dockerfile images/model-downloader/Dockerfile
docker buildx build --platform linux/amd64 --load \
  -f Dockerfile -t airunway/dashboard:repro \
  --build-arg VERSION=v0.6.0-rc1 \
  --build-arg GIT_COMMIT=$(git rev-parse HEAD) .
# Fails at "RUN bun run build:frontend" with exit 127

docker buildx build --platform linux/amd64 --load \
  -f images/model-downloader/Dockerfile \
  -t airunway/model-downloader:repro \
  images/model-downloader
# Fails at "hf version" with ModuleNotFoundError: click
```

**Verified both fixes** by rebuilding with the patch applied — both images build cleanly. Then deployed the patched dashboard image to a real AKS cluster (A100 80GB) and ran the full v0.6.0 smoke test suite:

- Admission webhook rejects bogus provider names (PR #214)
- Auto-selection picks `kaito` + `vllm` from `InferenceProviderConfig` capabilities
- KAITO `ModelDeployment` reconciles to `Running` with all 6 conditions True
- `/v1/chat/completions` returns valid JSON via direct port-forward
- Dashboard `/api/deployments/.../chat` SSE-streams chat completions through to vLLM
- All 8 `airunway_*` Prometheus metric families export (`up{job="airunway-controller-manager-metrics-service"}=1`)
- Grafana "AI Runway - Platform Overview" dashboard loads and panels populate
- Delete cleanup removes the KAITO Workspace and downstream Service/Pod via owner-ref GC (zero orphans)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint` (N/A — only Dockerfile changes)
- [ ] I have added tests that prove my fix/feature works (N/A — Dockerfile build regression; the fix is verified by `docker build` itself succeeding)
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed (no docs reference these Dockerfiles)
- [x] My changes generate no new warnings

## Screenshots

N/A — build/CI fix.

## Additional Notes

**Suggested follow-up (not in this PR):** Add a `make build-images` (or similar) target that runs `docker buildx build` against each Dockerfile on every PR, so this class of regression is caught before tag-time rather than at release. The current release-only Dockerfile builds left a ~5-week window where this bug was undetectable.
