### PR TITLE
feat(gateway): add provider-agnostic `setup-gateway` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install dev dev-frontend dev-backend build compile lint test clean help providers-test verify-versions test-verify-versions
 .PHONY: controller-build controller-docker-build controller-install controller-deploy controller-generate generate-deploy-manifests
-.PHONY: model-downloader-docker-build
+.PHONY: model-downloader-docker-build setup-gateway cleanup-gateway
 
 # Controller image
 CONTROLLER_IMG ?= ghcr.io/kaito-project/airunway/controller:latest
@@ -58,6 +58,10 @@ help:
 	@echo ""
 	@echo "Provider Targets:"
 	@echo "  providers-test         Run all provider tests"
+	@echo ""
+	@echo "Cluster Setup Targets:"
+	@echo "  setup-gateway          Install Gateway API CRDs, Istio, BBR, and the inference Gateway"
+	@echo "  cleanup-gateway        Remove the inference Gateway and BBR (CRDs/Istio left intact)"
 	@echo ""
 	@echo "Image Build Variables:"
 	@echo "  PLATFORM=<platform>    Target platform for image builds (default: linux/amd64)"
@@ -199,6 +203,50 @@ generate-deploy-manifests:
 model-downloader-docker-build:
 	docker buildx build --platform $(PLATFORM) $(IMAGE_OUTPUT_FLAG) -f images/model-downloader/Dockerfile -t $(MODEL_DOWNLOADER_IMG) images/model-downloader
 	@echo "✅ Model downloader image built: $(MODEL_DOWNLOADER_IMG) ($(PLATFORM), $(if $(PUSH_ENABLED),pushed,loaded locally))"
+
+# ==================== Cluster Setup Targets ====================
+
+# Provider-agnostic inference-gateway bootstrap: installs Gateway API CRDs,
+# Istio (with the Gateway API Inference Extension enabled), the Body-Based
+# Router, and an `inference-gateway` Gateway resource. Required before
+# deploying any provider that routes through the inference gateway. Versions
+# are pinned in versions.env (GATEWAY_API_VERSION, ISTIO_VERSION, GAIE_VERSION).
+GATEWAY_NAMESPACE ?= default
+GATEWAY_NAME ?= inference-gateway
+GATEWAY_API_URL := https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
+GATEWAY_MANIFEST := hack/inference-gateway.yaml
+BBR_CHART := oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing
+
+setup-gateway: verify-versions
+	@command -v istioctl >/dev/null 2>&1 || { echo "❌ istioctl not found on PATH. Install Istio $(ISTIO_VERSION): https://istio.io/latest/docs/setup/getting-started/"; exit 1; }
+	@echo "Installing Gateway API CRDs $(GATEWAY_API_VERSION)..."
+	kubectl apply -f $(GATEWAY_API_URL)
+	@echo "Installing Istio $(ISTIO_VERSION) (inference extension enabled)..."
+	istioctl install --skip-confirmation \
+		--set profile=minimal \
+		--set tag=$(ISTIO_VERSION) \
+		--set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
+	@echo "Installing Body-Based Router (BBR) $(GAIE_VERSION)..."
+	helm upgrade -i body-based-router \
+		--set provider.name=istio \
+		--version "$(GAIE_VERSION)" \
+		$(BBR_CHART)
+	@echo "Creating Gateway resource $(GATEWAY_NAME) in namespace $(GATEWAY_NAMESPACE)..."
+	@command -v envsubst >/dev/null 2>&1 || { echo "❌ envsubst not found on PATH (provided by gettext)."; exit 1; }
+	GATEWAY_NAME=$(GATEWAY_NAME) GATEWAY_NAMESPACE=$(GATEWAY_NAMESPACE) \
+		envsubst < $(GATEWAY_MANIFEST) | kubectl apply -f -
+	@echo "✅ Inference gateway ready (Istio $(ISTIO_VERSION), gateway/$(GATEWAY_NAME))"
+
+# Tear down the inference Gateway and BBR. Gateway API CRDs and Istio are left
+# intact because they may be shared with other workloads.
+cleanup-gateway:
+	@GATEWAY_NAME=$(GATEWAY_NAME) GATEWAY_NAMESPACE=$(GATEWAY_NAMESPACE) \
+		envsubst < $(GATEWAY_MANIFEST) | kubectl delete -f - --ignore-not-found
+	@helm uninstall body-based-router --ignore-not-found
+	@echo "⚠️ Gateway API CRDs and Istio left intact (may be shared). Remove manually if needed:"
+	@echo "    kubectl delete -f \"$(GATEWAY_API_URL)\" --ignore-not-found"
+	@echo "    istioctl uninstall --purge -y"
+	@echo "✅ Inference gateway and BBR removed"
 
 # ==================== Version Drift Guard ====================
 

--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,10 @@ setup-gateway: verify-versions
 # Tear down the inference Gateway and BBR. Gateway API CRDs and Istio are left
 # intact because they may be shared with other workloads.
 cleanup-gateway:
+	@command -v envsubst >/dev/null 2>&1 || { echo "❌ envsubst not found on PATH (provided by gettext)."; exit 1; }
 	@GATEWAY_NAME=$(GATEWAY_NAME) GATEWAY_NAMESPACE=$(GATEWAY_NAMESPACE) \
 		envsubst < $(GATEWAY_MANIFEST) | kubectl delete -f - --ignore-not-found
-	@helm uninstall body-based-router --ignore-not-found
+	@helm uninstall body-based-router --ignore-not-found || helm uninstall body-based-router || true
 	@echo "⚠️ Gateway API CRDs, GAIE CRDs, and Istio left intact (may be shared). Remove manually if needed:"
 	@echo "    kubectl delete -f \"$(GATEWAY_API_URL)\" --ignore-not-found"
 	@echo "    kubectl delete -f \"$(GAIE_MANIFEST_URL)\" --ignore-not-found"

--- a/Makefile
+++ b/Makefile
@@ -229,10 +229,12 @@ setup-gateway: verify-versions
 		--set profile=minimal \
 		--set tag=$(ISTIO_VERSION) \
 		--set values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
-	@echo "Installing Body-Based Router (BBR) $(GAIE_VERSION)..."
+	@echo "Installing Body-Based Router (BBR) $(GAIE_VERSION) into namespace $(GATEWAY_NAMESPACE)..."
 	helm upgrade -i body-based-router \
+		--namespace $(GATEWAY_NAMESPACE) --create-namespace \
 		--set provider.name=istio \
 		--version "$(GAIE_VERSION)" \
+		--wait \
 		$(BBR_CHART)
 	@echo "Creating Gateway resource $(GATEWAY_NAME) in namespace $(GATEWAY_NAMESPACE)..."
 	@command -v envsubst >/dev/null 2>&1 || { echo "❌ envsubst not found on PATH (provided by gettext)."; exit 1; }
@@ -246,7 +248,7 @@ cleanup-gateway:
 	@command -v envsubst >/dev/null 2>&1 || { echo "❌ envsubst not found on PATH (provided by gettext)."; exit 1; }
 	@GATEWAY_NAME=$(GATEWAY_NAME) GATEWAY_NAMESPACE=$(GATEWAY_NAMESPACE) \
 		envsubst < $(GATEWAY_MANIFEST) | kubectl delete -f - --ignore-not-found
-	@helm uninstall body-based-router --ignore-not-found || helm uninstall body-based-router || true
+	@helm uninstall body-based-router --namespace $(GATEWAY_NAMESPACE) --ignore-not-found || helm uninstall body-based-router --namespace $(GATEWAY_NAMESPACE) || true
 	@echo "⚠️ Gateway API CRDs, GAIE CRDs, and Istio left intact (may be shared). Remove manually if needed:"
 	@echo "    kubectl delete -f \"$(GATEWAY_API_URL)\" --ignore-not-found"
 	@echo "    kubectl delete -f \"$(GAIE_MANIFEST_URL)\" --ignore-not-found"

--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,14 @@ GATEWAY_NAME ?= inference-gateway
 GATEWAY_API_URL := https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/standard-install.yaml
 GATEWAY_MANIFEST := hack/inference-gateway.yaml
 BBR_CHART := oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing
+GAIE_MANIFEST_URL := https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$(GAIE_VERSION)/manifests.yaml
 
 setup-gateway: verify-versions
 	@command -v istioctl >/dev/null 2>&1 || { echo "❌ istioctl not found on PATH. Install Istio $(ISTIO_VERSION): https://istio.io/latest/docs/setup/getting-started/"; exit 1; }
 	@echo "Installing Gateway API CRDs $(GATEWAY_API_VERSION)..."
 	kubectl apply -f $(GATEWAY_API_URL)
+	@echo "Installing Gateway API Inference Extension (GAIE) CRDs $(GAIE_VERSION)..."
+	kubectl apply -f $(GAIE_MANIFEST_URL)
 	@echo "Installing Istio $(ISTIO_VERSION) (inference extension enabled)..."
 	istioctl install --skip-confirmation \
 		--set profile=minimal \
@@ -243,8 +246,9 @@ cleanup-gateway:
 	@GATEWAY_NAME=$(GATEWAY_NAME) GATEWAY_NAMESPACE=$(GATEWAY_NAMESPACE) \
 		envsubst < $(GATEWAY_MANIFEST) | kubectl delete -f - --ignore-not-found
 	@helm uninstall body-based-router --ignore-not-found
-	@echo "⚠️ Gateway API CRDs and Istio left intact (may be shared). Remove manually if needed:"
+	@echo "⚠️ Gateway API CRDs, GAIE CRDs, and Istio left intact (may be shared). Remove manually if needed:"
 	@echo "    kubectl delete -f \"$(GATEWAY_API_URL)\" --ignore-not-found"
+	@echo "    kubectl delete -f \"$(GAIE_MANIFEST_URL)\" --ignore-not-found"
 	@echo "    istioctl uninstall --purge -y"
 	@echo "✅ Inference gateway and BBR removed"
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -76,8 +76,9 @@ AI Runway works with any Gateway API implementation that supports the [Inference
 
 > [!TIP]
 > **Istio shortcut:** `make setup-gateway` (from the repo root) runs Steps 1–4 below for the
-> **Istio** path in one shot — it installs the Gateway API CRDs, Istio (with the inference
-> extension enabled), the Body-Based Router, and the `inference-gateway` Gateway resource. The
+> **Istio** path in one shot — it installs the Gateway API CRDs, the Gateway API Inference
+> Extension (GAIE) CRDs, Istio (with the inference extension enabled), the Body-Based Router,
+> and the `inference-gateway` Gateway resource. The
 > `GATEWAY_API_VERSION`, `ISTIO_VERSION`, and `GAIE_VERSION` it uses are pinned in
 > [`/versions.env`](../versions.env), and `istioctl` must be on your PATH. For other gateway
 > implementations, follow the manual steps below.

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -75,10 +75,11 @@ AI Runway works with any Gateway API implementation that supports the [Inference
 ## Setup
 
 > [!TIP]
-> **Istio shortcut:** `make setup-gateway` (from the repo root) runs Steps 1–4 below for the
-> **Istio** path in one shot — it installs the Gateway API CRDs, the Gateway API Inference
-> Extension (GAIE) CRDs, Istio (with the inference extension enabled), the Body-Based Router,
-> and the `inference-gateway` Gateway resource. The
+> **Istio shortcut:** `make setup-gateway` (from the repo root) performs the entire manual
+> **Istio** setup below in one shot — it installs the Gateway API CRDs (Step 1), the Gateway
+> API Inference Extension (GAIE) CRDs (Step 2), Istio with the inference extension enabled
+> (Step 3), the `inference-gateway` Gateway resource (Step 4), and the Body-Based Router (see
+> [Body-Based Routing](#body-based-routing-bbr)). The
 > `GATEWAY_API_VERSION`, `ISTIO_VERSION`, and `GAIE_VERSION` it uses are pinned in
 > [`/versions.env`](../versions.env), and `istioctl` must be on your PATH. For other gateway
 > implementations, follow the manual steps below.

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -74,6 +74,14 @@ AI Runway works with any Gateway API implementation that supports the [Inference
 
 ## Setup
 
+> [!TIP]
+> **Istio shortcut:** `make setup-gateway` (from the repo root) runs Steps 1–4 below for the
+> **Istio** path in one shot — it installs the Gateway API CRDs, Istio (with the inference
+> extension enabled), the Body-Based Router, and the `inference-gateway` Gateway resource. The
+> `GATEWAY_API_VERSION`, `ISTIO_VERSION`, and `GAIE_VERSION` it uses are pinned in
+> [`/versions.env`](../versions.env), and `istioctl` must be on your PATH. For other gateway
+> implementations, follow the manual steps below.
+
 ### Step 1: Install Gateway API CRDs
 
 ```bash

--- a/hack/inference-gateway.yaml
+++ b/hack/inference-gateway.yaml
@@ -1,0 +1,20 @@
+# Provider-agnostic inference gateway used by the root `setup-gateway` target.
+# The name and namespace are filled in by envsubst at apply time
+# (defaults: inference-gateway / default — see GATEWAY_NAME / GATEWAY_NAMESPACE
+# in the root Makefile).
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${GATEWAY_NAME}
+  namespace: ${GATEWAY_NAMESPACE}
+spec:
+  gatewayClassName: istio
+  infrastructure:
+    annotations:
+      # Required on AKS with Istio. Azure otherwise probes GET / on port 80,
+      # but the gateway returns 404 there and the public IP can time out.
+      service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80

--- a/hack/inference-gateway.yaml
+++ b/hack/inference-gateway.yaml
@@ -7,6 +7,12 @@ kind: Gateway
 metadata:
   name: ${GATEWAY_NAME}
   namespace: ${GATEWAY_NAMESPACE}
+  labels:
+    # Identifies this as the airunway inference gateway. The controller's
+    # auto-selection and the backend status check use this label to
+    # disambiguate when more than one Gateway exists in the cluster (see
+    # controller/internal/gateway/detection.go and gateway_reconciler.go).
+    airunway.ai/inference-gateway: "true"
 spec:
   gatewayClassName: istio
   infrastructure:

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -76,7 +76,8 @@ setup-dynamo: verify-versions
 	@helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
 			--namespace $(DYNAMO_NAMESPACE) \
 			--create-namespace \
-			--set "dynamo-operator.controllerManager.manager.image.tag=$(DYNAMO_VERSION)"
+			--set "dynamo-operator.controllerManager.manager.image.tag=$(DYNAMO_VERSION)" \
+			--wait
 	@echo "✅ Dynamo platform v$(DYNAMO_VERSION) installed in namespace $(DYNAMO_NAMESPACE)"
 
 ## Uninstall Dynamo platform from the cluster

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -64,15 +64,15 @@ DYNAMO_PRE_DEPLOY_URL := https://raw.githubusercontent.com/ai-dynamo/dynamo/v$(D
 GAIE_MANIFEST_URL := https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$(GAIE_VERSION)/manifests.yaml
 
 setup-dynamo: verify-versions
-	@echo "Setting up the inference gateway (Gateway API CRDs, GAIE CRDs, Istio, BBR, Gateway)..."
-	@$(MAKE) -C ../.. setup-gateway
 	@echo "Running Dynamo pre-deployment checks..."
 	@TMPSCRIPT=$$(mktemp) && \
 		trap 'rm -f "$$TMPSCRIPT"' EXIT && \
 		curl -fsSL "$(DYNAMO_PRE_DEPLOY_URL)" -o "$$TMPSCRIPT" && \
 		chmod +x "$$TMPSCRIPT" && \
 		bash "$$TMPSCRIPT"
-	@echo "Pre-deployment checks passed. Installing Dynamo platform v$(DYNAMO_VERSION)..."
+	@echo "Pre-deployment checks passed. Setting up the inference gateway (Gateway API CRDs, GAIE CRDs, Istio, BBR, Gateway)..."
+	@$(MAKE) -C ../.. setup-gateway
+	@echo "Installing Dynamo platform v$(DYNAMO_VERSION)..."
 	@helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
 			--namespace $(DYNAMO_NAMESPACE) \
 			--create-namespace \

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -64,6 +64,8 @@ DYNAMO_PRE_DEPLOY_URL := https://raw.githubusercontent.com/ai-dynamo/dynamo/v$(D
 GAIE_MANIFEST_URL := https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$(GAIE_VERSION)/manifests.yaml
 
 setup-dynamo: verify-versions
+	@echo "Setting up the inference gateway (Gateway API CRDs, Istio, BBR, Gateway)..."
+	@$(MAKE) -C ../.. setup-gateway
 	@echo "Running Dynamo pre-deployment checks..."
 	@TMPSCRIPT=$$(mktemp) && \
 		trap 'rm -f "$$TMPSCRIPT"' EXIT && \

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -64,7 +64,7 @@ DYNAMO_PRE_DEPLOY_URL := https://raw.githubusercontent.com/ai-dynamo/dynamo/v$(D
 GAIE_MANIFEST_URL := https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$(GAIE_VERSION)/manifests.yaml
 
 setup-dynamo: verify-versions
-	@echo "Setting up the inference gateway (Gateway API CRDs, Istio, BBR, Gateway)..."
+	@echo "Setting up the inference gateway (Gateway API CRDs, GAIE CRDs, Istio, BBR, Gateway)..."
 	@$(MAKE) -C ../.. setup-gateway
 	@echo "Running Dynamo pre-deployment checks..."
 	@TMPSCRIPT=$$(mktemp) && \
@@ -72,9 +72,7 @@ setup-dynamo: verify-versions
 		curl -fsSL "$(DYNAMO_PRE_DEPLOY_URL)" -o "$$TMPSCRIPT" && \
 		chmod +x "$$TMPSCRIPT" && \
 		bash "$$TMPSCRIPT"
-	@echo "Pre-deployment checks passed. Installing GAIE components..."
-	@kubectl apply -f $(GAIE_MANIFEST_URL)
-	@echo "Installing Dynamo platform v$(DYNAMO_VERSION)..."
+	@echo "Pre-deployment checks passed. Installing Dynamo platform v$(DYNAMO_VERSION)..."
 	@helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
 			--namespace $(DYNAMO_NAMESPACE) \
 			--create-namespace \

--- a/shared/types/versions.generated.ts
+++ b/shared/types/versions.generated.ts
@@ -5,3 +5,5 @@
 export const GAIE_VERSION = "v1.5.0";
 export const DYNAMO_VERSION = "1.1.1";
 export const KAITO_VERSION = "0.10.0";
+export const GATEWAY_API_VERSION = "v1.5.1";
+export const ISTIO_VERSION = "1.30.0";

--- a/versions.env
+++ b/versions.env
@@ -24,3 +24,11 @@ DYNAMO_VERSION=1.1.1
 
 # KAITO workspace operator Helm chart version (kaito/workspace chart).
 KAITO_VERSION=0.10.0
+
+# Gateway API CRDs (a separate project from GAIE). Used by the root
+# `setup-gateway` Makefile target to install standard-install.yaml.
+GATEWAY_API_VERSION=v1.5.1
+
+# Istio control plane installed by the root `setup-gateway` target
+# (gatewayClassName: istio). Requires a matching local istioctl on PATH.
+ISTIO_VERSION=1.30.0


### PR DESCRIPTION
## Description

Folds the four manual inference-gateway bootstrap steps (Gateway API CRDs, Gateway API Inference Extension (GAIE) CRDs, Istio with the inference extension, the Body-Based Router, and the `inference-gateway` Gateway resource) into a single provider-agnostic `make setup-gateway` target at the repo root. Pins the new component versions in `versions.env` and chains `setup-dynamo` onto `setup-gateway` so the Dynamo flow becomes turnkey.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Changes Made

- Add `setup-gateway` and `cleanup-gateway` targets to the root `Makefile`. `setup-gateway` installs the Gateway API CRDs, the GAIE CRDs, Istio (with `ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true`), the Body-Based Router, and an `inference-gateway` Gateway resource; `cleanup-gateway` tears down the Gateway and BBR while leaving shared CRDs/Istio intact.
- Add `hack/inference-gateway.yaml`, an `envsubst`-templated Gateway manifest (`GATEWAY_NAME` / `GATEWAY_NAMESPACE`) carrying the `airunway.ai/inference-gateway: "true"` label so the controller's auto-selection and backend status check can disambiguate when multiple Gateways exist.
- Move the GAIE CRD install out of `providers/dynamo/Makefile` and into the root `setup-gateway` target, since GAIE CRDs are core controller routing infra rather than Dynamo-specific. `setup-dynamo` now delegates to `make -C ../.. setup-gateway` (GAIE is still installed, just no longer Dynamo-scoped).
- Pin `GATEWAY_API_VERSION=v1.5.1` and `ISTIO_VERSION=1.30.0` in `versions.env` and regenerate `shared/types/versions.generated.ts`.
- Document the `make setup-gateway` Istio shortcut in `docs/gateway.md`.
- Harden `cleanup-gateway`: guard it with an `envsubst` availability check (matching `setup-gateway`) and make BBR teardown idempotent across Helm versions via `helm uninstall --ignore-not-found || helm uninstall body-based-router || true`.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

<!-- These changes are Makefile/docs/manifest only; no application code or tests changed. setup/cleanup targets exercised against a dev cluster. -->

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Additional Notes

The `verify-versions` drift guard already covers `GAIE_VERSION` and `DYNAMO_VERSION`; the two new pins (`GATEWAY_API_VERSION`, `ISTIO_VERSION`) are surfaced in `versions.env` and the generated TS but are not yet wired into the drift guard since they have no second source-of-truth to compare against.
