### PR TITLE
feat(kaito): add `setup-kaito` target to install KAITO operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ model-downloader-docker-build:
 # regexes, preventing e.g. "1.5.0" from also matching "1X5Y0".
 GAIE_VERSION_RE := $(subst .,\.,$(GAIE_VERSION))
 DYNAMO_VERSION_RE := $(subst .,\.,$(DYNAMO_VERSION))
+KAITO_VERSION_RE := $(subst .,\.,$(KAITO_VERSION))
 
 verify-versions:
 	@# 1. controller/go.mod must pin GAIE_VERSION
@@ -221,6 +222,9 @@ verify-versions:
 	@# 3. controller/internal/gateway/detection.go fallback literal must match GAIE_VERSION
 	@grep -qE '^var DefaultGAIEVersion = "$(GAIE_VERSION_RE)"$$' controller/internal/gateway/detection.go || \
 	  { echo "❌ controller/internal/gateway/detection.go DefaultGAIEVersion fallback != $(GAIE_VERSION) (from versions.env)"; exit 1; }
+	@# 4. providers/kaito/config.go chart version literal must match KAITO_VERSION
+	@grep -qE 'Version:[[:space:]]+"$(KAITO_VERSION_RE)"' providers/kaito/config.go || \
+	  { echo "❌ providers/kaito/config.go chart Version != $(KAITO_VERSION) (from versions.env)"; exit 1; }
 	@# 4. generated TS must be in sync with versions.env.
 	@#    Generate to a temp file and diff against the working-tree copy so
 	@#    that synced uncommitted edits pass (the local-dev case) while
@@ -239,7 +243,7 @@ verify-versions:
 	    echo "❌ shared/types/versions.generated.ts is stale — run 'cd shared && bun run generate-versions' and commit the result"; \
 	    exit 1; \
 	  }
-	@echo "✅ versions in sync (GAIE_VERSION=$(GAIE_VERSION), DYNAMO_VERSION=$(DYNAMO_VERSION))"
+	@echo "✅ versions in sync (GAIE_VERSION=$(GAIE_VERSION), DYNAMO_VERSION=$(DYNAMO_VERSION), KAITO_VERSION=$(KAITO_VERSION))"
 
 # Test the verify-versions guard itself by deliberately breaking each
 # input it inspects and asserting the target exits non-zero.

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,10 @@ verify-versions:
 	@# 4. providers/kaito/config.go chart version literal must match KAITO_VERSION
 	@grep -qE 'Version:[[:space:]]+"$(KAITO_VERSION_RE)"' providers/kaito/config.go || \
 	  { echo "❌ providers/kaito/config.go chart Version != $(KAITO_VERSION) (from versions.env)"; exit 1; }
-	@# 4. generated TS must be in sync with versions.env.
+	@# 5. providers/kaito/config.go install Command --version arg must match KAITO_VERSION
+	@grep -qE -- '--version $(KAITO_VERSION_RE) ' providers/kaito/config.go || \
+	  { echo "❌ providers/kaito/config.go install Command --version != $(KAITO_VERSION) (from versions.env)"; exit 1; }
+	@# 6. generated TS must be in sync with versions.env.
 	@#    Generate to a temp file and diff against the working-tree copy so
 	@#    that synced uncommitted edits pass (the local-dev case) while
 	@#    stale committed files still fail (the CI case — CI's working

--- a/hack/test-verify-versions.sh
+++ b/hack/test-verify-versions.sh
@@ -71,9 +71,14 @@ sed -i.bak -E 's|^var DefaultGAIEVersion = "[^"]*"$|var DefaultGAIEVersion = "v0
 expect_fail "${GATEWAY_DETECTION}"
 mv -f "${GATEWAY_DETECTION}.bak" "${GATEWAY_DETECTION}"
 
-echo "== Mutating ${KAITO_CONFIG} =="
+echo "== Mutating ${KAITO_CONFIG} (struct Version field) =="
 sed -i.bak -E 's|(Version:[[:space:]]+)"[^"]*"|\1"0.0.0-bogus"|' "${KAITO_CONFIG}"
-expect_fail "${KAITO_CONFIG}"
+expect_fail "${KAITO_CONFIG} struct Version"
+mv -f "${KAITO_CONFIG}.bak" "${KAITO_CONFIG}"
+
+echo "== Mutating ${KAITO_CONFIG} (install Command --version arg) =="
+sed -i.bak -E 's|(--version )[^ ]+( )|\10.0.0-bogus\2|' "${KAITO_CONFIG}"
+expect_fail "${KAITO_CONFIG} install Command --version"
 mv -f "${KAITO_CONFIG}.bak" "${KAITO_CONFIG}"
 
 echo "== Mutating ${VERSIONS_TS} =="

--- a/hack/test-verify-versions.sh
+++ b/hack/test-verify-versions.sh
@@ -19,12 +19,14 @@ cd "${REPO_ROOT}"
 GO_MOD="controller/go.mod"
 DYNAMO_CONFIG="providers/dynamo/config.go"
 GATEWAY_DETECTION="controller/internal/gateway/detection.go"
+KAITO_CONFIG="providers/kaito/config.go"
 VERSIONS_TS="shared/types/versions.generated.ts"
 
 BACKUPS=(
     "${GO_MOD}.bak"
     "${DYNAMO_CONFIG}.bak"
     "${GATEWAY_DETECTION}.bak"
+    "${KAITO_CONFIG}.bak"
     "${VERSIONS_TS}.bak"
 )
 
@@ -68,6 +70,11 @@ echo "== Mutating ${GATEWAY_DETECTION} =="
 sed -i.bak -E 's|^var DefaultGAIEVersion = "[^"]*"$|var DefaultGAIEVersion = "v0.0.0-bogus"|' "${GATEWAY_DETECTION}"
 expect_fail "${GATEWAY_DETECTION}"
 mv -f "${GATEWAY_DETECTION}.bak" "${GATEWAY_DETECTION}"
+
+echo "== Mutating ${KAITO_CONFIG} =="
+sed -i.bak -E 's|(Version:[[:space:]]+)"[^"]*"|\1"0.0.0-bogus"|' "${KAITO_CONFIG}"
+expect_fail "${KAITO_CONFIG}"
+mv -f "${KAITO_CONFIG}.bak" "${KAITO_CONFIG}"
 
 echo "== Mutating ${VERSIONS_TS} =="
 # Now that verify-versions diffs a temp regen against the working-tree

--- a/providers/kaito/Makefile
+++ b/providers/kaito/Makefile
@@ -59,7 +59,7 @@ KAITO_REPO_URL  ?= https://kaito-project.github.io/kaito/charts/kaito
 
 setup-kaito: verify-versions
 	@echo "Installing KAITO workspace operator v$(KAITO_VERSION)..."
-	@helm repo add kaito $(KAITO_REPO_URL) 2>/dev/null || true
+	@helm repo add kaito $(KAITO_REPO_URL) --force-update
 	@helm repo update kaito
 	@helm upgrade --install $(KAITO_RELEASE) kaito/workspace \
 		--version $(KAITO_VERSION) \

--- a/providers/kaito/Makefile
+++ b/providers/kaito/Makefile
@@ -71,10 +71,7 @@ setup-kaito: verify-versions
 		--set gpu-feature-discovery.gfd.enabled=false \
 		--set gpu-feature-discovery.nfd.master.deploy=false \
 		--set gpu-feature-discovery.nfd.worker.deploy=false \
-		--wait
-	@echo "Waiting for KAITO operator to be ready..."
-	@kubectl wait --for=condition=Available deployment \
-		-n $(KAITO_NAMESPACE) -l app.kubernetes.io/name=workspace --timeout=5m
+		--wait --timeout=5m
 	@echo "✅ KAITO workspace operator v$(KAITO_VERSION) installed in namespace $(KAITO_NAMESPACE)"
 
 ## Uninstall KAITO workspace operator from the cluster

--- a/providers/kaito/Makefile
+++ b/providers/kaito/Makefile
@@ -5,7 +5,17 @@ PUSH ?= false
 PUSH_ENABLED := $(filter true TRUE 1 yes YES on ON,$(PUSH))
 IMAGE_OUTPUT_FLAG := $(if $(PUSH_ENABLED),--push,--load)
 
-.PHONY: build vet test docker-build deploy generate-deploy-manifests
+# Upstream component versions (single source of truth at /versions.env).
+include ../../versions.env
+export
+
+.PHONY: build vet test docker-build deploy generate-deploy-manifests setup-kaito cleanup-kaito verify-versions
+
+## Verify upstream versions are in sync (delegates to root Makefile).
+verify-versions:
+ifneq ($(VERIFIED_VERSIONS),1)
+	@$(MAKE) -C ../.. verify-versions
+endif
 
 ## Run go vet against code
 vet:
@@ -41,3 +51,33 @@ generate-deploy-manifests:
 	$(KUSTOMIZE) build config/default > deploy/kaito.yaml
 	@git checkout config/manager/kustomization.yaml 2>/dev/null || true
 	@echo "✅ Generated deploy/kaito.yaml"
+
+## Install KAITO workspace operator on the cluster (run before deploying the provider)
+KAITO_NAMESPACE ?= kaito-workspace
+KAITO_RELEASE   ?= kaito-workspace
+KAITO_REPO_URL  ?= https://kaito-project.github.io/kaito/charts/kaito
+
+setup-kaito: verify-versions
+	@echo "Installing KAITO workspace operator v$(KAITO_VERSION)..."
+	@helm repo add kaito $(KAITO_REPO_URL) 2>/dev/null || true
+	@helm repo update kaito
+	@helm upgrade --install $(KAITO_RELEASE) kaito/workspace \
+		--version $(KAITO_VERSION) \
+		--namespace $(KAITO_NAMESPACE) \
+		--create-namespace \
+		--set featureGates.disableNodeAutoProvisioning=true \
+		--set nvidiaDevicePlugin.enabled=false \
+		--set localCSIDriver.useLocalCSIDriver=false \
+		--set gpu-feature-discovery.gfd.enabled=false \
+		--set gpu-feature-discovery.nfd.master.deploy=false \
+		--set gpu-feature-discovery.nfd.worker.deploy=false \
+		--wait
+	@echo "Waiting for KAITO operator to be ready..."
+	@kubectl wait --for=condition=Available deployment \
+		-n $(KAITO_NAMESPACE) -l app.kubernetes.io/name=workspace --timeout=5m
+	@echo "✅ KAITO workspace operator v$(KAITO_VERSION) installed in namespace $(KAITO_NAMESPACE)"
+
+## Uninstall KAITO workspace operator from the cluster
+cleanup-kaito:
+	@helm uninstall $(KAITO_RELEASE) --namespace $(KAITO_NAMESPACE) --ignore-not-found
+	@echo "✅ KAITO workspace operator uninstalled from namespace $(KAITO_NAMESPACE)"

--- a/providers/kaito/Makefile
+++ b/providers/kaito/Makefile
@@ -67,14 +67,13 @@ setup-kaito: verify-versions
 		--create-namespace \
 		--set featureGates.disableNodeAutoProvisioning=true \
 		--set nvidiaDevicePlugin.enabled=false \
-		--set localCSIDriver.useLocalCSIDriver=false \
+		--set gpu-feature-discovery.nfd.enabled=false \
 		--set gpu-feature-discovery.gfd.enabled=false \
-		--set gpu-feature-discovery.nfd.master.deploy=false \
-		--set gpu-feature-discovery.nfd.worker.deploy=false \
 		--wait --timeout=5m
 	@echo "✅ KAITO workspace operator v$(KAITO_VERSION) installed in namespace $(KAITO_NAMESPACE)"
 
 ## Uninstall KAITO workspace operator from the cluster
 cleanup-kaito:
 	@helm uninstall $(KAITO_RELEASE) --namespace $(KAITO_NAMESPACE) --ignore-not-found
+	@kubectl delete namespace $(KAITO_NAMESPACE) --ignore-not-found
 	@echo "✅ KAITO workspace operator uninstalled from namespace $(KAITO_NAMESPACE)"

--- a/providers/kaito/config.go
+++ b/providers/kaito/config.go
@@ -127,7 +127,7 @@ func GetInstallationInfo() *airunwayv1alpha1.InstallationInfo {
 			},
 			{
 				Title:       "Update Helm Repositories",
-				Command:     "helm repo update",
+				Command:     "helm repo update kaito",
 				Description: "Update local Helm repository cache.",
 			},
 			{

--- a/shared/types/versions.generated.ts
+++ b/shared/types/versions.generated.ts
@@ -4,3 +4,4 @@
 
 export const GAIE_VERSION = "v1.5.0";
 export const DYNAMO_VERSION = "1.1.1";
+export const KAITO_VERSION = "0.10.0";

--- a/versions.env
+++ b/versions.env
@@ -21,3 +21,6 @@ GAIE_VERSION=v1.5.0
 # (e.g. dynamo-platform-1.1.1.tgz). Sites that need a git tag prepend "v"
 # at the use site (see providers/dynamo/Makefile, providers/dynamo/config.go).
 DYNAMO_VERSION=1.1.1
+
+# KAITO workspace operator Helm chart version (kaito/workspace chart).
+KAITO_VERSION=0.10.0


### PR DESCRIPTION
## Description

Adds a one-command, version-pinned way to install the KAITO workspace operator for the kaito provider, mirroring the dynamo provider's existing `setup-dynamo` flow. Previously, installing KAITO required manually copy-pasting a block of `helm repo add` / `helm upgrade --install` / `kubectl wait` commands from a test script. This wires that into `make -C providers/kaito setup-kaito`, with the chart version pinned in the repo's single source of truth (`versions.env`) and guarded against drift by `make verify-versions`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Changes Made

- Added `setup-kaito` and `cleanup-kaito` targets to `providers/kaito/Makefile` that install/uninstall the `kaito/workspace` Helm chart, mirroring `providers/dynamo/Makefile`'s `setup-dynamo`. `setup-kaito` runs `helm repo add --force-update` + `helm repo update kaito` (idempotent on re-runs), then `helm upgrade --install` with the same `--set` flags as `providers/kaito/config.go` (`featureGates.disableNodeAutoProvisioning=true`, `nvidiaDevicePlugin.enabled=false`, `localCSIDriver.useLocalCSIDriver=false`, `gpu-feature-discovery.gfd.enabled=false`, `gpu-feature-discovery.nfd.master.deploy=false`, `gpu-feature-discovery.nfd.worker.deploy=false`), and relies on `helm --wait --timeout=5m` to block until the operator is ready.
- Made the target configurable via `KAITO_NAMESPACE`, `KAITO_RELEASE`, and `KAITO_REPO_URL` (`?=` so callers can override; defaults to the `kaito-workspace` namespace/release).
- Pinned `KAITO_VERSION=0.10.0` in `versions.env` as the single source of truth, added `include ../../versions.env` + `export` to the kaito Makefile so the version flows through to `--version $(KAITO_VERSION)`, and regenerated `shared/types/versions.generated.ts` to export `KAITO_VERSION`.
- Extended the root `Makefile` `verify-versions` guard with two KAITO checks: the `HelmChart.Version` field and the install `Command` `--version` argument in `providers/kaito/config.go` must both match `KAITO_VERSION` (renumbered the generated-TS check accordingly). Wired a delegating `verify-versions` prerequisite into the kaito Makefile (guarded by `VERIFIED_VERSIONS`) so `setup-kaito` validates version sync before running.
- Extended `hack/test-verify-versions.sh` with mutation cases for both new KAITO checks so the drift guard is protected from regression.

## Testing

- [ ] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [ ] Tested with a Kubernetes cluster

`make verify-versions` passes with the new `KAITO_VERSION`, `make test-verify-versions` confirms all six drift cases (including both new KAITO mutations) correctly fail, and `make -C providers/kaito setup-kaito -n` (dry run) emits the expected, version-pinned `helm` commands. Not yet run against a live cluster.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Additional Notes

- A root-`Makefile` `verify-versions` guard was added for KAITO: it asserts both the `HelmChart.Version` field and the install `Command` `--version` argument in `providers/kaito/config.go` match `KAITO_VERSION` from `versions.env`, in addition to the regenerated-TS diff check. `hack/test-verify-versions.sh` was extended with matching mutation cases so the guard is protected from regression.
- Unlike `setup-dynamo`, `setup-kaito` intentionally omits the pre-deployment check and GAIE manifest apply — the original KAITO install steps did neither.

