### PR TITLE
feat(dynamo): add CPU-only mocker mode for GPU-less E2E coverage

### DIFF
--- a/.github/workflows/e2e-dynamo-mocker.yml
+++ b/.github/workflows/e2e-dynamo-mocker.yml
@@ -25,6 +25,13 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: providers/dynamo/go.sum
 
+      - name: Setup Bun
+        # Required by the Makefile's verify-versions target (TS version-sync check),
+        # which setup-dynamo-mocker depends on via the root Makefile.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
       - name: Setup Kind
         run: |
           go install sigs.k8s.io/kind@latest

--- a/.github/workflows/e2e-dynamo-mocker.yml
+++ b/.github/workflows/e2e-dynamo-mocker.yml
@@ -1,0 +1,85 @@
+name: E2E Dynamo Mocker Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-dynamo-mocker:
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: providers/dynamo/go.sum
+
+      - name: Setup Kind
+        run: |
+          go install sigs.k8s.io/kind@latest
+          kind create cluster --name airunway-e2e --wait 120s
+
+      - name: Install Dynamo platform (CPU/mocker)
+        run: |
+          # CPU-only install: no GPU pre-deployment check, no GAIE. The mocker
+          # backend runs python3 -m dynamo.mocker and needs no GPUs.
+          make -C providers/dynamo setup-dynamo-mocker
+          kubectl wait --for=condition=Available deployment -n dynamo-system --all --timeout=300s
+
+      - name: Build and deploy controller
+        run: |
+          make controller-docker-build CONTROLLER_IMG=airunway-controller:e2e
+          kind load docker-image airunway-controller:e2e --name airunway-e2e
+          make controller-deploy CONTROLLER_IMG=airunway-controller:e2e
+          kubectl wait --for=condition=Available deployment -n airunway-system -l control-plane=controller-manager --timeout=120s
+
+      - name: Build and deploy Dynamo provider
+        run: |
+          make -C providers/dynamo docker-build IMG=dynamo-provider:e2e
+          kind load docker-image dynamo-provider:e2e --name airunway-e2e
+          make -C providers/dynamo deploy IMG=dynamo-provider:e2e
+          kubectl wait --for=condition=Available deployment -n airunway-system -l control-plane=dynamo-provider --timeout=120s
+
+      - name: Wait for provider registration
+        run: |
+          kubectl wait --for=jsonpath='{.status.ready}'=true inferenceproviderconfig/dynamo --timeout=120s
+
+      - name: Run mocker E2E (aggregated + disaggregated)
+        run: |
+          make -C providers/dynamo test-e2e-mocker
+
+      - name: Collect debug info
+        if: failure()
+        run: |
+          echo "=== ModelDeployments ==="
+          kubectl get modeldeployments -A -o yaml
+          echo "=== DynamoGraphDeployments ==="
+          kubectl get dynamographdeployments.nvidia.com -A -o yaml
+          echo "=== InferenceProviderConfigs ==="
+          kubectl get inferenceproviderconfigs -o yaml
+          echo "=== Controller Logs ==="
+          kubectl logs -n airunway-system -l control-plane=controller-manager --tail=200
+          echo "=== Dynamo Provider Logs ==="
+          kubectl logs -n airunway-system -l control-plane=dynamo-provider --tail=200
+          echo "=== Dynamo Operator Logs ==="
+          kubectl logs -n dynamo-system --all-containers --tail=200 --prefix
+          echo "=== Events ==="
+          kubectl get events -A --sort-by=.lastTimestamp
+          echo "=== Pods ==="
+          kubectl get pods -A
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kind delete cluster --name airunway-e2e

--- a/controller/internal/controller/gateway_reconciler.go
+++ b/controller/internal/controller/gateway_reconciler.go
@@ -56,6 +56,18 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 		return nil
 	}
 
+	// Skip for the Dynamo mocker test backend. Mocker mode deploys a standalone
+	// Frontend and intentionally does not create a provider-managed
+	// InferencePool/EPP, so engaging gateway reconciliation here would wait
+	// forever on a pool that never appears (NotFound retries / a misleading
+	// GatewayReady=False status) on any cluster that does have the GAIE CRDs
+	// installed. This keeps the controller consistent with the dynamo
+	// transformer, which also forces the non-gateway path in mocker mode.
+	if isDynamoMockerMode(md) {
+		logger.V(1).Info("Skipping gateway reconciliation for Dynamo mocker test backend", "name", md.Name)
+		return nil
+	}
+
 	// Skip if gateway CRDs are not available
 	if !r.GatewayDetector.IsAvailable(ctx) {
 		// Warn if user explicitly enabled gateway but CRDs are missing
@@ -849,6 +861,26 @@ func resolvedProviderName(md *airunwayv1alpha1.ModelDeployment) string {
 		return md.Status.Provider.Name
 	}
 	return ""
+}
+
+// dynamoMockerAnnotation / dynamoMockerValue select the Dynamo provider's
+// internal, test-only mocker backend. The key is kept as a literal here (rather
+// than importing providers/dynamo) so the controller has no build dependency on
+// an out-of-tree provider module — see providers/dynamo/mocker.go
+// (AnnotationDynamoTestBackend / DynamoTestBackendMocker).
+const (
+	dynamoMockerAnnotation = "airunway.ai/dynamo-test-backend"
+	dynamoMockerValue      = "mocker"
+)
+
+// isDynamoMockerMode reports whether the ModelDeployment opts into the Dynamo
+// mocker test backend on the dynamo provider. Mocker mode runs the GPU-less
+// python3 -m dynamo.mocker behind a standalone Frontend and intentionally does
+// not create an InferencePool/EPP, so the controller must skip the GPU-oriented
+// validation and gateway/GAIE reconciliation it would otherwise apply.
+func isDynamoMockerMode(md *airunwayv1alpha1.ModelDeployment) bool {
+	return md.Annotations[dynamoMockerAnnotation] == dynamoMockerValue &&
+		md.Spec.Provider != nil && md.Spec.Provider.Name == "dynamo"
 }
 
 // resolveServicePort looks up the first HTTP port on the named service.

--- a/controller/internal/controller/gateway_reconciler_test.go
+++ b/controller/internal/controller/gateway_reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -265,6 +266,41 @@ func TestGateway_HTTPRouteCreation(t *testing.T) {
 	}
 	if route.OwnerReferences[0].Name != "test-model" {
 		t.Errorf("expected owner ref name %q, got %q", "test-model", route.OwnerReferences[0].Name)
+	}
+}
+
+func TestGateway_DynamoMockerSkipsCreation(t *testing.T) {
+	scheme := newTestScheme()
+	md := newModelDeployment("test-model", "default")
+	// Gateway is left at its default (enabled) and the GAIE CRDs are available,
+	// so only the mocker annotation should keep the controller off the gateway
+	// path. The dynamo standalone-Frontend mocker DGD never creates a
+	// provider-managed InferencePool, so engaging gateway would loop on NotFound.
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "dynamo"}
+	md.Annotations = map[string]string{"airunway.ai/dynamo-test-backend": "mocker"}
+	detector := fakeDetector(true, "my-gateway", "gateway-ns")
+	r := newTestReconciler(scheme, detector, md)
+	ctx := context.Background()
+
+	if err := r.reconcileGateway(ctx, md); err != nil {
+		t.Fatalf("reconcileGateway failed: %v", err)
+	}
+
+	// No InferencePool should be created.
+	var pool inferencev1.InferencePool
+	if err := r.Get(ctx, types.NamespacedName{Name: "test-model", Namespace: "default"}, &pool); err == nil {
+		t.Error("expected InferencePool to NOT be created in dynamo mocker mode")
+	}
+
+	// No HTTPRoute should be created.
+	var route gatewayv1.HTTPRoute
+	if err := r.Get(ctx, types.NamespacedName{Name: "test-model", Namespace: "default"}, &route); err == nil {
+		t.Error("expected HTTPRoute to NOT be created in dynamo mocker mode")
+	}
+
+	// And no GatewayReady condition should have been set (neither true nor false).
+	if c := meta.FindStatusCondition(md.Status.Conditions, airunwayv1alpha1.ConditionTypeGatewayReady); c != nil {
+		t.Errorf("expected no GatewayReady condition in mocker mode, got %q/%q", c.Status, c.Reason)
 	}
 }
 

--- a/controller/internal/controller/modeldeployment_controller.go
+++ b/controller/internal/controller/modeldeployment_controller.go
@@ -368,6 +368,20 @@ func (r *ModelDeploymentReconciler) validateSpec(ctx context.Context, md *airunw
 		return fmt.Errorf("engine.type must be specified or auto-selected from provider capabilities")
 	}
 
+	// Mocker mode escape hatch: a ModelDeployment annotated with
+	// airunway.ai/dynamo-test-backend=mocker targeting the dynamo provider runs
+	// the GPU-less python3 -m dynamo.mocker backend, so the GPU compatibility and
+	// disaggregated gpu.count checks below must not reject it. This mirrors the
+	// admission webhook (see modeldeployment_webhook.go) so the two cannot drift.
+	// The annotation key is kept as a literal to avoid importing the dynamo
+	// provider module into the controller (see providers/dynamo/mocker.go
+	// AnnotationDynamoTestBackend / DynamoTestBackendMocker). Mocker is vLLM-only.
+	isDynamoMocker := md.Annotations["airunway.ai/dynamo-test-backend"] == "mocker" &&
+		spec.Provider != nil && spec.Provider.Name == "dynamo"
+	if isDynamoMocker && engineType != airunwayv1alpha1.EngineTypeVLLM {
+		return fmt.Errorf("the dynamo mocker test backend only supports the vllm engine")
+	}
+
 	// Validate provider/engine/serving-mode/GPU-CPU compatibility via the
 	// shared helper so the webhook and reconciler cannot drift.
 	gpuCount := int32(0)
@@ -385,17 +399,19 @@ func (r *ModelDeploymentReconciler) validateSpec(ctx context.Context, md *airunw
 			}
 		}
 	}
-	if ces := validation.CheckProviderCompatibility(
-		providerName,
-		namedConfig,
-		providerConfigs,
-		engineType,
-		servingMode,
-		gpuCount,
-	); len(ces) > 0 {
-		// Return the first error to preserve the reconciler's existing
-		// single-error contract.
-		return fmt.Errorf("%s", ces[0].Message)
+	if !isDynamoMocker {
+		if ces := validation.CheckProviderCompatibility(
+			providerName,
+			namedConfig,
+			providerConfigs,
+			engineType,
+			servingMode,
+			gpuCount,
+		); len(ces) > 0 {
+			// Return the first error to preserve the reconciler's existing
+			// single-error contract.
+			return fmt.Errorf("%s", ces[0].Message)
+		}
 	}
 
 	// Validate disaggregated mode configuration
@@ -410,14 +426,19 @@ func (r *ModelDeploymentReconciler) validateSpec(ctx context.Context, md *airunw
 			return fmt.Errorf("disaggregated mode requires scaling.prefill and scaling.decode")
 		}
 
-		// Prefill must have GPU
-		if spec.Scaling.Prefill.GPU == nil || spec.Scaling.Prefill.GPU.Count == 0 {
-			return fmt.Errorf("disaggregated mode requires scaling.prefill.gpu.count > 0")
-		}
+		// The GPU-less mocker backend waives the per-component gpu.count
+		// requirement, but the prefill/decode blocks themselves are still
+		// required (above) so the dynamo transformer can build both workers.
+		if !isDynamoMocker {
+			// Prefill must have GPU
+			if spec.Scaling.Prefill.GPU == nil || spec.Scaling.Prefill.GPU.Count == 0 {
+				return fmt.Errorf("disaggregated mode requires scaling.prefill.gpu.count > 0")
+			}
 
-		// Decode must have GPU
-		if spec.Scaling.Decode.GPU == nil || spec.Scaling.Decode.GPU.Count == 0 {
-			return fmt.Errorf("disaggregated mode requires scaling.decode.gpu.count > 0")
+			// Decode must have GPU
+			if spec.Scaling.Decode.GPU == nil || spec.Scaling.Decode.GPU.Count == 0 {
+				return fmt.Errorf("disaggregated mode requires scaling.decode.gpu.count > 0")
+			}
 		}
 	}
 

--- a/controller/internal/controller/modeldeployment_controller.go
+++ b/controller/internal/controller/modeldeployment_controller.go
@@ -373,11 +373,8 @@ func (r *ModelDeploymentReconciler) validateSpec(ctx context.Context, md *airunw
 	// the GPU-less python3 -m dynamo.mocker backend, so the GPU compatibility and
 	// disaggregated gpu.count checks below must not reject it. This mirrors the
 	// admission webhook (see modeldeployment_webhook.go) so the two cannot drift.
-	// The annotation key is kept as a literal to avoid importing the dynamo
-	// provider module into the controller (see providers/dynamo/mocker.go
-	// AnnotationDynamoTestBackend / DynamoTestBackendMocker). Mocker is vLLM-only.
-	isDynamoMocker := md.Annotations["airunway.ai/dynamo-test-backend"] == "mocker" &&
-		spec.Provider != nil && spec.Provider.Name == "dynamo"
+	// Mocker is vLLM-only.
+	isDynamoMocker := isDynamoMockerMode(md)
 	if isDynamoMocker && engineType != airunwayv1alpha1.EngineTypeVLLM {
 		return fmt.Errorf("the dynamo mocker test backend only supports the vllm engine")
 	}

--- a/controller/internal/controller/validate_spec_test.go
+++ b/controller/internal/controller/validate_spec_test.go
@@ -127,6 +127,73 @@ func TestValidateSpec(t *testing.T) {
 			providerConfigs: allProviders(),
 		},
 		{
+			name: "valid: CPU-only aggregated vllm on dynamo with mocker annotation",
+			md: airunwayv1alpha1.ModelDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"airunway.ai/dynamo-test-backend": "mocker"},
+				},
+				Spec: airunwayv1alpha1.ModelDeploymentSpec{
+					Model:    airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace},
+					Engine:   airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM},
+					Provider: &airunwayv1alpha1.ProviderSpec{Name: "dynamo"},
+					// No resources.gpu: the GPU-less mocker backend waives it.
+				},
+			},
+			providerConfigs: allProviders(),
+		},
+		{
+			name: "valid: CPU-only disaggregated vllm on dynamo with mocker annotation",
+			md: airunwayv1alpha1.ModelDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"airunway.ai/dynamo-test-backend": "mocker"},
+				},
+				Spec: airunwayv1alpha1.ModelDeploymentSpec{
+					Model:    airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace},
+					Engine:   airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM},
+					Provider: &airunwayv1alpha1.ProviderSpec{Name: "dynamo"},
+					Serving:  &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated},
+					// prefill/decode blocks present but no gpu.count.
+					Scaling: &airunwayv1alpha1.ScalingSpec{
+						Prefill: &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+						Decode:  &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+					},
+				},
+			},
+			providerConfigs: allProviders(),
+		},
+		{
+			name: "invalid: non-vllm engine on dynamo even with mocker annotation",
+			md: airunwayv1alpha1.ModelDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"airunway.ai/dynamo-test-backend": "mocker"},
+				},
+				Spec: airunwayv1alpha1.ModelDeploymentSpec{
+					Model:    airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace},
+					Engine:   airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeSGLang},
+					Provider: &airunwayv1alpha1.ProviderSpec{Name: "dynamo"},
+				},
+			},
+			providerConfigs: allProviders(),
+			wantErr:         "only supports the vllm engine",
+		},
+		{
+			name: "invalid: CPU-only disaggregated vllm on dynamo WITHOUT mocker annotation",
+			md: airunwayv1alpha1.ModelDeployment{
+				Spec: airunwayv1alpha1.ModelDeploymentSpec{
+					Model:    airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace},
+					Engine:   airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM},
+					Provider: &airunwayv1alpha1.ProviderSpec{Name: "dynamo"},
+					Serving:  &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated},
+					Scaling: &airunwayv1alpha1.ScalingSpec{
+						Prefill: &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+						Decode:  &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+					},
+				},
+			},
+			providerConfigs: allProviders(),
+			wantErr:         "scaling.prefill.gpu.count > 0",
+		},
+		{
 			name: "valid: llamacpp CPU-only on kaito",
 			md: airunwayv1alpha1.ModelDeployment{
 				Spec: airunwayv1alpha1.ModelDeploymentSpec{

--- a/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
+++ b/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
@@ -395,7 +395,11 @@ func (v *ModelDeploymentCustomValidator) validateSpec(ctx context.Context, obj *
 					specPath.Child("scaling", "prefill"),
 					"disaggregated mode requires scaling.prefill",
 				))
-			} else {
+			} else if !isDynamoMocker {
+				// Mocker mode runs the GPU-less python3 -m dynamo.mocker backend,
+				// so a CPU-only disaggregated mocker deployment legitimately omits
+				// scaling.prefill.gpu.count. The prefill block itself is still
+				// required (above) so the dynamo transformer can build the worker.
 				if spec.Scaling.Prefill.GPU == nil || spec.Scaling.Prefill.GPU.Count == 0 {
 					allErrs = append(allErrs, field.Required(
 						specPath.Child("scaling", "prefill", "gpu", "count"),
@@ -409,7 +413,9 @@ func (v *ModelDeploymentCustomValidator) validateSpec(ctx context.Context, obj *
 					specPath.Child("scaling", "decode"),
 					"disaggregated mode requires scaling.decode",
 				))
-			} else {
+			} else if !isDynamoMocker {
+				// See the prefill note above: mocker mode waives the GPU-count
+				// requirement while still requiring the decode block.
 				if spec.Scaling.Decode.GPU == nil || spec.Scaling.Decode.GPU.Count == 0 {
 					allErrs = append(allErrs, field.Required(
 						specPath.Child("scaling", "decode", "gpu", "count"),

--- a/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
+++ b/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
@@ -303,6 +303,19 @@ func (v *ModelDeploymentCustomValidator) validateSpec(ctx context.Context, obj *
 	isDynamoMocker := obj.Annotations["airunway.ai/dynamo-test-backend"] == "mocker" &&
 		spec.Provider != nil && spec.Provider.Name == "dynamo"
 
+	// The Dynamo mocker backend only simulates the vLLM engine. Enforce the
+	// vLLM-only constraint at admission so a non-vllm engine + mocker annotation
+	// is rejected here rather than admitted and failing later during provider
+	// reconciliation (the dynamo provider re-validates this too). An empty engine
+	// type is allowed — the provider defaults it to vllm.
+	if isDynamoMocker && spec.Engine.Type != "" && spec.Engine.Type != airunwayv1alpha1.EngineTypeVLLM {
+		allErrs = append(allErrs, field.Invalid(
+			specPath.Child("engine", "type"),
+			spec.Engine.Type,
+			"the dynamo mocker test backend only supports the vllm engine",
+		))
+	}
+
 	if !isDynamoMocker && spec.Provider != nil && spec.Provider.Name != "" && spec.Engine.Type != "" && v.Reader != nil {
 		var providerConfig airunwayv1alpha1.InferenceProviderConfig
 		err := v.Reader.Get(ctx, client.ObjectKey{Name: spec.Provider.Name}, &providerConfig)

--- a/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
+++ b/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
@@ -291,7 +291,19 @@ func (v *ModelDeploymentCustomValidator) validateSpec(ctx context.Context, obj *
 	// admission; falls back to the uncached APIReader only when the cache
 	// reports NotFound, to absorb the race where a brand-new
 	// InferenceProviderConfig hasn't yet propagated to informers.
-	if spec.Provider != nil && spec.Provider.Name != "" && spec.Engine.Type != "" && v.Reader != nil {
+	//
+	// Mocker mode escape hatch: a ModelDeployment annotated with
+	// airunway.ai/dynamo-test-backend=mocker targeting the dynamo provider runs
+	// the GPU-less python3 -m dynamo.mocker backend, so the provider's GPU
+	// capability check must not reject it at admission. This is a test-only path
+	// (the dynamo provider re-validates compatibility during reconciliation).
+	// The annotation key is kept as a literal here to avoid importing the
+	// provider module from the controller webhook (see
+	// providers/dynamo/mocker.go AnnotationDynamoTestBackend / DynamoTestBackendMocker).
+	isDynamoMocker := obj.Annotations["airunway.ai/dynamo-test-backend"] == "mocker" &&
+		spec.Provider != nil && spec.Provider.Name == "dynamo"
+
+	if !isDynamoMocker && spec.Provider != nil && spec.Provider.Name != "" && spec.Engine.Type != "" && v.Reader != nil {
 		var providerConfig airunwayv1alpha1.InferenceProviderConfig
 		err := v.Reader.Get(ctx, client.ObjectKey{Name: spec.Provider.Name}, &providerConfig)
 		if apierrors.IsNotFound(err) && v.APIReader != nil {

--- a/controller/internal/webhook/v1alpha1/modeldeployment_webhook_test.go
+++ b/controller/internal/webhook/v1alpha1/modeldeployment_webhook_test.go
@@ -1446,5 +1446,16 @@ var _ = Describe("ModelDeployment Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("gpu.count > 0"))
 		})
+
+		It("Should reject a non-vllm engine on dynamo even with the mocker annotation", func() {
+			obj.Annotations = map[string]string{"airunway.ai/dynamo-test-backend": "mocker"}
+			obj.Spec.Model.ID = "Qwen/Qwen3-0.6B"
+			obj.Spec.Engine.Type = airunwayv1alpha1.EngineTypeSGLang
+			obj.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "dynamo"}
+			obj.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 0}}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("only supports the vllm engine"))
+		})
 	})
 })

--- a/controller/internal/webhook/v1alpha1/modeldeployment_webhook_test.go
+++ b/controller/internal/webhook/v1alpha1/modeldeployment_webhook_test.go
@@ -1416,5 +1416,35 @@ var _ = Describe("ModelDeployment Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("requires GPU"))
 		})
+
+		It("Should accept CPU-only disaggregated vllm on dynamo when mocker annotation is set", func() {
+			obj.Annotations = map[string]string{"airunway.ai/dynamo-test-backend": "mocker"}
+			obj.Spec.Model.ID = "Qwen/Qwen3-0.6B"
+			obj.Spec.Engine.Type = airunwayv1alpha1.EngineTypeVLLM
+			obj.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "dynamo"}
+			obj.Spec.Serving = &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated}
+			// No GPU counts on prefill/decode: the GPU-less mocker waives the
+			// disaggregated gpu.count requirement, but the blocks are still required.
+			obj.Spec.Scaling = &airunwayv1alpha1.ScalingSpec{
+				Prefill: &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+				Decode:  &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should still reject CPU-only disaggregated vllm on dynamo without the mocker annotation", func() {
+			obj.Spec.Model.ID = "Qwen/Qwen3-0.6B"
+			obj.Spec.Engine.Type = airunwayv1alpha1.EngineTypeVLLM
+			obj.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "dynamo"}
+			obj.Spec.Serving = &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated}
+			obj.Spec.Scaling = &airunwayv1alpha1.ScalingSpec{
+				Prefill: &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+				Decode:  &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+			}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("gpu.count > 0"))
+		})
 	})
 })

--- a/controller/internal/webhook/v1alpha1/modeldeployment_webhook_test.go
+++ b/controller/internal/webhook/v1alpha1/modeldeployment_webhook_test.go
@@ -1395,5 +1395,26 @@ var _ = Describe("ModelDeployment Webhook", func() {
 			_, err := validator.ValidateCreate(ctx, obj)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("Should accept CPU-only vllm on dynamo when mocker annotation is set", func() {
+			obj.Annotations = map[string]string{"airunway.ai/dynamo-test-backend": "mocker"}
+			obj.Spec.Model.ID = "Qwen/Qwen3-0.6B"
+			obj.Spec.Engine.Type = airunwayv1alpha1.EngineTypeVLLM
+			obj.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "dynamo"}
+			obj.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 0}}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should still reject CPU-only vllm on dynamo when mocker annotation has a different value", func() {
+			obj.Annotations = map[string]string{"airunway.ai/dynamo-test-backend": "real"}
+			obj.Spec.Model.ID = "Qwen/Qwen3-0.6B"
+			obj.Spec.Engine.Type = airunwayv1alpha1.EngineTypeVLLM
+			obj.Spec.Provider = &airunwayv1alpha1.ProviderSpec{Name: "dynamo"}
+			obj.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 0}}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("requires GPU"))
+		})
 	})
 })

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -92,23 +92,16 @@ cleanup-dynamo:
 ## Install Dynamo platform for the CPU-only mocker E2E lane (run before test-e2e-mocker).
 ## Unlike setup-dynamo this skips the GPU pre-deployment check and GAIE: the mocker
 ## backend (python3 -m dynamo.mocker) needs no GPUs and the standalone Frontend path
-## needs no Gateway API Inference Extension.
+## needs no Gateway API Inference Extension. Grove is left at its chart default (off):
+## it only orchestrates multinode PodCliqueSets, and the mocker runs single-node CPU pods.
 setup-dynamo-mocker: verify-versions
-	@if helm status dynamo-platform --namespace $(DYNAMO_NAMESPACE) >/dev/null 2>&1 && \
-		kubectl get deploy -n $(DYNAMO_NAMESPACE) -l app.kubernetes.io/name=dynamo-operator >/dev/null 2>&1; then \
-		echo "ℹ️  Dynamo platform already present in $(DYNAMO_NAMESPACE); skipping install."; \
-		echo "    (Re-running helm upgrade collides with grove-operator's runtime-managed"; \
-		echo "     webhook certs via server-side apply. Run 'make cleanup-dynamo' to reinstall.)"; \
-	else \
-		echo "Installing Dynamo platform v$(DYNAMO_VERSION) for CPU-only mocker E2E..."; \
-		helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
+	@echo "Installing Dynamo platform v$(DYNAMO_VERSION) for CPU-only mocker E2E..."
+	@helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
 			--namespace $(DYNAMO_NAMESPACE) \
 			--create-namespace \
 			--set "dynamo-operator.controllerManager.manager.image.tag=$(DYNAMO_VERSION)" \
-			--set "dynamo-operator.gpuDiscovery.enabled=false" \
-			--set "global.grove.install=true"; \
-		echo "✅ Dynamo platform v$(DYNAMO_VERSION) (CPU/mocker) installed in namespace $(DYNAMO_NAMESPACE)"; \
-	fi
+			--set "dynamo-operator.gpuDiscovery.enabled=false"
+	@echo "✅ Dynamo platform v$(DYNAMO_VERSION) (CPU/mocker) installed in namespace $(DYNAMO_NAMESPACE)"
 
 ## Run e2e tests (requires DYNAMO_INSTALLED=true and a cluster with dynamo provider deployed)
 test-e2e:

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -109,5 +109,7 @@ test-e2e:
 
 ## Run the CPU-only mocker e2e tests (aggregated + disaggregated). Requires a cluster
 ## with the Dynamo platform (see setup-dynamo-mocker) and the dynamo provider deployed.
+## No -run filter: the GPU lane (TestDynamoProviderE2E) self-skips without DYNAMO_INSTALLED,
+## so dropping it lets the unit-style TestInjectMockerAnnotation run here too.
 test-e2e-mocker:
-	DYNAMO_MOCKER=true go test -count=1 -tags=e2e -v -timeout 30m ./test/e2e/ -run TestDynamoMocker
+	DYNAMO_MOCKER=true go test -count=1 -tags=e2e -v -timeout 30m ./test/e2e/

--- a/providers/dynamo/Makefile
+++ b/providers/dynamo/Makefile
@@ -14,7 +14,7 @@ export
 # applies when bypassing this Makefile (e.g. `go run`, `go test`).
 LDFLAGS := -X github.com/kaito-project/airunway/providers/dynamo.DynamoVersion=$(DYNAMO_VERSION)
 
-.PHONY: build vet test docker-build deploy generate-deploy-manifests setup-dynamo cleanup-dynamo test-e2e verify-versions
+.PHONY: build vet test docker-build deploy generate-deploy-manifests setup-dynamo setup-dynamo-mocker cleanup-dynamo test-e2e test-e2e-mocker verify-versions
 
 ## Verify upstream versions are in sync (delegates to root Makefile).
 verify-versions:
@@ -89,6 +89,32 @@ cleanup-dynamo:
 	@helm uninstall dynamo-platform --namespace $(DYNAMO_NAMESPACE) --ignore-not-found
 	@echo "✅ Dynamo platform uninstalled from namespace $(DYNAMO_NAMESPACE)"
 
+## Install Dynamo platform for the CPU-only mocker E2E lane (run before test-e2e-mocker).
+## Unlike setup-dynamo this skips the GPU pre-deployment check and GAIE: the mocker
+## backend (python3 -m dynamo.mocker) needs no GPUs and the standalone Frontend path
+## needs no Gateway API Inference Extension.
+setup-dynamo-mocker: verify-versions
+	@if helm status dynamo-platform --namespace $(DYNAMO_NAMESPACE) >/dev/null 2>&1 && \
+		kubectl get deploy -n $(DYNAMO_NAMESPACE) -l app.kubernetes.io/name=dynamo-operator >/dev/null 2>&1; then \
+		echo "ℹ️  Dynamo platform already present in $(DYNAMO_NAMESPACE); skipping install."; \
+		echo "    (Re-running helm upgrade collides with grove-operator's runtime-managed"; \
+		echo "     webhook certs via server-side apply. Run 'make cleanup-dynamo' to reinstall.)"; \
+	else \
+		echo "Installing Dynamo platform v$(DYNAMO_VERSION) for CPU-only mocker E2E..."; \
+		helm upgrade -i dynamo-platform "$(DYNAMO_CHART_URL)" \
+			--namespace $(DYNAMO_NAMESPACE) \
+			--create-namespace \
+			--set "dynamo-operator.controllerManager.manager.image.tag=$(DYNAMO_VERSION)" \
+			--set "dynamo-operator.gpuDiscovery.enabled=false" \
+			--set "global.grove.install=true"; \
+		echo "✅ Dynamo platform v$(DYNAMO_VERSION) (CPU/mocker) installed in namespace $(DYNAMO_NAMESPACE)"; \
+	fi
+
 ## Run e2e tests (requires DYNAMO_INSTALLED=true and a cluster with dynamo provider deployed)
 test-e2e:
-	DYNAMO_INSTALLED=true go test -tags=e2e -v -timeout 45m ./test/e2e/
+	DYNAMO_INSTALLED=true go test -count=1 -tags=e2e -v -timeout 45m ./test/e2e/
+
+## Run the CPU-only mocker e2e tests (aggregated + disaggregated). Requires a cluster
+## with the Dynamo platform (see setup-dynamo-mocker) and the dynamo provider deployed.
+test-e2e-mocker:
+	DYNAMO_MOCKER=true go test -count=1 -tags=e2e -v -timeout 30m ./test/e2e/ -run TestDynamoMocker

--- a/providers/dynamo/controller.go
+++ b/providers/dynamo/controller.go
@@ -262,6 +262,22 @@ func (r *DynamoProviderReconciler) validateCompatibility(md *airunwayv1alpha1.Mo
 		return fmt.Errorf("Dynamo does not support llamacpp engine")
 	}
 
+	// Mocker mode (test-only): the python3 -m dynamo.mocker backend simulates
+	// serving without GPUs, so the GPU requirement is waived. It only supports
+	// the vLLM engine, and disaggregated mode still needs prefill+decode scaling
+	// blocks so the transformer can build both workers.
+	if isMockerMode(md) {
+		if md.ResolvedEngineType() != airunwayv1alpha1.EngineTypeVLLM {
+			return fmt.Errorf("Dynamo mocker mode only supports the vllm engine")
+		}
+		if md.Spec.Serving != nil && md.Spec.Serving.Mode == airunwayv1alpha1.ServingModeDisaggregated {
+			if md.Spec.Scaling == nil || md.Spec.Scaling.Prefill == nil || md.Spec.Scaling.Decode == nil {
+				return fmt.Errorf("Dynamo mocker disaggregated mode requires spec.scaling.prefill and spec.scaling.decode")
+			}
+		}
+		return nil
+	}
+
 	// Dynamo requires GPU
 	hasGPU := false
 	if md.Spec.Resources != nil && md.Spec.Resources.GPU != nil && md.Spec.Resources.GPU.Count > 0 {

--- a/providers/dynamo/go.mod
+++ b/providers/dynamo/go.mod
@@ -8,6 +8,7 @@ require (
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -98,7 +99,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace github.com/kaito-project/airunway/controller => ../../controller

--- a/providers/dynamo/mocker.go
+++ b/providers/dynamo/mocker.go
@@ -35,6 +35,14 @@ const (
 
 	// DynamoTestBackendMocker is the annotation value that enables mocker mode.
 	DynamoTestBackendMocker = "mocker"
+
+	// MockerWorkerCPU and MockerWorkerMemory are the CPU/memory requests and
+	// limits applied to mocker workers (and mirrored by the mocker Frontend
+	// defaults). They keep the pods Burstable — not BestEffort — so they survive
+	// memory pressure and satisfy namespace LimitRanges, while staying tiny
+	// enough to co-schedule on small CPU-only CI nodes.
+	MockerWorkerCPU    = "100m"
+	MockerWorkerMemory = "256Mi"
 )
 
 // defaultMockerImage is the image used for mocker Frontend and worker
@@ -80,11 +88,22 @@ func mockerCommand() []string {
 	return []string{"python3", "-m", "dynamo.mocker"}
 }
 
-// emptyResources returns an empty resource block (no GPU/CPU/memory requests or
-// limits) for mocker workers, which run on CPU-only nodes.
-func emptyResources() map[string]interface{} {
+// mockerWorkerResources returns the resource block for mocker workers. It sets
+// small CPU/memory requests and limits (and no GPU) so the worker schedules on
+// CPU-only nodes while remaining Burstable rather than BestEffort: BestEffort
+// pods are first to be evicted under memory pressure and are rejected outright
+// in namespaces whose LimitRange mandates requests/limits, both of which would
+// make the CPU-only E2E lane flaky. The values mirror the mocker Frontend
+// defaults and are ample for the lightweight python3 -m dynamo.mocker process.
+func mockerWorkerResources() map[string]interface{} {
 	return map[string]interface{}{
-		"limits":   map[string]interface{}{},
-		"requests": map[string]interface{}{},
+		"requests": map[string]interface{}{
+			"cpu":    MockerWorkerCPU,
+			"memory": MockerWorkerMemory,
+		},
+		"limits": map[string]interface{}{
+			"cpu":    MockerWorkerCPU,
+			"memory": MockerWorkerMemory,
+		},
 	}
 }

--- a/providers/dynamo/mocker.go
+++ b/providers/dynamo/mocker.go
@@ -37,10 +37,12 @@ const (
 	DynamoTestBackendMocker = "mocker"
 
 	// MockerWorkerCPU and MockerWorkerMemory are the CPU/memory requests and
-	// limits applied to mocker workers (and mirrored by the mocker Frontend
-	// defaults). They keep the pods Burstable — not BestEffort — so they survive
-	// memory pressure and satisfy namespace LimitRanges, while staying tiny
-	// enough to co-schedule on small CPU-only CI nodes.
+	// limits applied to mocker workers, and the request values used by the mocker
+	// Frontend (which sets requests only). On a worker, equal requests and limits
+	// make the pod Guaranteed QoS; the goal is only to avoid BestEffort — which is
+	// evicted first under memory pressure and rejected by namespace LimitRanges
+	// that mandate requests/limits — while staying tiny enough to co-schedule on
+	// small CPU-only CI nodes.
 	MockerWorkerCPU    = "100m"
 	MockerWorkerMemory = "256Mi"
 )
@@ -90,11 +92,11 @@ func mockerCommand() []string {
 
 // mockerWorkerResources returns the resource block for mocker workers. It sets
 // small CPU/memory requests and limits (and no GPU) so the worker schedules on
-// CPU-only nodes while remaining Burstable rather than BestEffort: BestEffort
-// pods are first to be evicted under memory pressure and are rejected outright
-// in namespaces whose LimitRange mandates requests/limits, both of which would
-// make the CPU-only E2E lane flaky. The values mirror the mocker Frontend
-// defaults and are ample for the lightweight python3 -m dynamo.mocker process.
+// CPU-only nodes. Equal requests and limits make the pod Guaranteed QoS; the
+// intent is only to avoid BestEffort — which is evicted first under memory
+// pressure and rejected outright in namespaces whose LimitRange mandates
+// requests/limits, both of which would make the CPU-only E2E lane flaky. The
+// values are ample for the lightweight python3 -m dynamo.mocker process.
 func mockerWorkerResources() map[string]interface{} {
 	return map[string]interface{}{
 		"requests": map[string]interface{}{

--- a/providers/dynamo/mocker.go
+++ b/providers/dynamo/mocker.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamo
+
+import (
+	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
+)
+
+// Mocker mode is an internal, test-only Dynamo backend that swaps the real
+// engine runtime (vLLM/SGLang/TRT-LLM) for `python3 -m dynamo.mocker`. The
+// mocker simulates LLM scheduling, KV-cache behavior, and OpenAI-compatible
+// serving without any GPU, which lets the full Airunway → Dynamo control path
+// run on GPU-less GitHub-hosted CI runners.
+//
+// It is opt-in via the `airunway.ai/dynamo-test-backend: mocker` annotation on
+// the ModelDeployment and is not intended for production use.
+const (
+	// AnnotationDynamoTestBackend selects an internal test backend for the
+	// Dynamo provider. The only supported value is "mocker".
+	AnnotationDynamoTestBackend = "airunway.ai/dynamo-test-backend"
+
+	// DynamoTestBackendMocker is the annotation value that enables mocker mode.
+	DynamoTestBackendMocker = "mocker"
+)
+
+// defaultMockerImage is the image used for mocker Frontend and worker
+// containers. Upstream mocker examples use the dynamo-planner image because it
+// bundles the ai-dynamo wheel, ai-dynamo-runtime, and planner/profiler
+// dependencies that mocker needs. Declared as a var (not const) so a build-time
+// ldflags override of DynamoVersion flows through automatically.
+var defaultMockerImage = "nvcr.io/nvidia/ai-dynamo/dynamo-planner:" + DynamoVersion
+
+// isMockerMode reports whether the ModelDeployment requests the internal mocker
+// test backend via the airunway.ai/dynamo-test-backend annotation.
+func isMockerMode(md *airunwayv1alpha1.ModelDeployment) bool {
+	if md == nil || md.Annotations == nil {
+		return false
+	}
+	return md.Annotations[AnnotationDynamoTestBackend] == DynamoTestBackendMocker
+}
+
+// buildMockerArgs returns the base argument list for `python3 -m dynamo.mocker`.
+// Callers append role-specific flags (e.g. --disaggregation-mode) for
+// disaggregated prefill/decode workers.
+func buildMockerArgs(md *airunwayv1alpha1.ModelDeployment) []string {
+	modelName := md.Spec.Model.ServedName
+	if modelName == "" {
+		modelName = md.Spec.Model.ID
+	}
+
+	return []string{
+		"--model-path", md.Spec.Model.ID,
+		"--model-name", modelName,
+		// High speedup ratio keeps CI fast — the mocker compresses simulated
+		// token timing by this factor.
+		"--speedup-ratio", "1000.0",
+		// Small, CI-friendly cache geometry.
+		"--num-gpu-blocks-override", "4096",
+		"--block-size", DefaultKVCacheBlockSize,
+		"--max-num-seqs", "64",
+	}
+}
+
+// mockerCommand returns the container command for a mocker worker.
+func mockerCommand() []string {
+	return []string{"python3", "-m", "dynamo.mocker"}
+}
+
+// emptyResources returns an empty resource block (no GPU/CPU/memory requests or
+// limits) for mocker workers, which run on CPU-only nodes.
+func emptyResources() map[string]interface{} {
+	return map[string]interface{}{
+		"limits":   map[string]interface{}{},
+		"requests": map[string]interface{}{},
+	}
+}

--- a/providers/dynamo/mocker_test.go
+++ b/providers/dynamo/mocker_test.go
@@ -211,6 +211,28 @@ func TestTransformMockerUsesServedName(t *testing.T) {
 	}
 }
 
+// TestTransformMockerImageWinsOverOverride asserts the planner image is used in
+// mocker mode even when spec.Image is set: the dynamo.mocker module only exists
+// in the planner image, so an arbitrary override would break the test backend.
+func TestTransformMockerImageWinsOverOverride(t *testing.T) {
+	tr := NewTransformer()
+	md := newMockerMD("mock-img")
+	md.Spec.Image = "example.com/some/custom-image:latest"
+
+	resources, err := tr.Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	worker := dgdService(t, resources[0], "VllmWorker")
+	image, _ := mainContainer(t, worker)["image"].(string)
+	if !strings.Contains(image, "dynamo-planner") {
+		t.Errorf("worker image=%q, expected dynamo-planner to win over spec.Image", image)
+	}
+	if strings.Contains(image, "custom-image") {
+		t.Errorf("worker image=%q must not use the spec.Image override in mocker mode", image)
+	}
+}
+
 func TestTransformMockerDisaggregated(t *testing.T) {
 	tr := NewTransformer()
 	md := newMockerMD("mock-disagg")

--- a/providers/dynamo/mocker_test.go
+++ b/providers/dynamo/mocker_test.go
@@ -186,12 +186,21 @@ func TestTransformMockerAggregated(t *testing.T) {
 		}
 	}
 
-	// No GPU resource requests/limits.
+	// No GPU, but small CPU/memory requests+limits (Burstable, not BestEffort).
 	res, _ := worker["resources"].(map[string]interface{})
 	requests, _ := res["requests"].(map[string]interface{})
 	limits, _ := res["limits"].(map[string]interface{})
-	if len(requests) != 0 || len(limits) != 0 {
-		t.Errorf("expected empty resources in mocker mode, got requests=%v limits=%v", requests, limits)
+	if _, hasGPU := requests["gpu"]; hasGPU {
+		t.Errorf("expected no GPU request in mocker mode, got requests=%v", requests)
+	}
+	if _, hasGPU := limits["gpu"]; hasGPU {
+		t.Errorf("expected no GPU limit in mocker mode, got limits=%v", limits)
+	}
+	if requests["cpu"] != MockerWorkerCPU || requests["memory"] != MockerWorkerMemory {
+		t.Errorf("expected CPU/memory requests %s/%s, got %v", MockerWorkerCPU, MockerWorkerMemory, requests)
+	}
+	if limits["cpu"] != MockerWorkerCPU || limits["memory"] != MockerWorkerMemory {
+		t.Errorf("expected CPU/memory limits %s/%s, got %v", MockerWorkerCPU, MockerWorkerMemory, limits)
 	}
 }
 
@@ -280,8 +289,11 @@ func TestTransformMockerDisaggregated(t *testing.T) {
 
 		res, _ := worker["resources"].(map[string]interface{})
 		requests, _ := res["requests"].(map[string]interface{})
-		if len(requests) != 0 {
-			t.Errorf("%s expected no resource requests, got %v", svcName, requests)
+		if _, hasGPU := requests["gpu"]; hasGPU {
+			t.Errorf("%s expected no GPU request, got %v", svcName, requests)
+		}
+		if requests["cpu"] != MockerWorkerCPU || requests["memory"] != MockerWorkerMemory {
+			t.Errorf("%s expected CPU/memory requests %s/%s, got %v", svcName, MockerWorkerCPU, MockerWorkerMemory, requests)
 		}
 	}
 }

--- a/providers/dynamo/mocker_test.go
+++ b/providers/dynamo/mocker_test.go
@@ -186,7 +186,8 @@ func TestTransformMockerAggregated(t *testing.T) {
 		}
 	}
 
-	// No GPU, but small CPU/memory requests+limits (Burstable, not BestEffort).
+	// No GPU, but small CPU/memory requests+limits. Equal requests and limits
+	// make the pod Guaranteed QoS (the point is only to avoid BestEffort).
 	res, _ := worker["resources"].(map[string]interface{})
 	requests, _ := res["requests"].(map[string]interface{})
 	limits, _ := res["limits"].(map[string]interface{})

--- a/providers/dynamo/mocker_test.go
+++ b/providers/dynamo/mocker_test.go
@@ -1,0 +1,275 @@
+package dynamo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	airunwayv1alpha1 "github.com/kaito-project/airunway/controller/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// newMockerMD builds an aggregated mocker-annotated ModelDeployment with no GPU.
+func newMockerMD(name string) *airunwayv1alpha1.ModelDeployment {
+	md := newTestMD(name, "default")
+	md.Annotations = map[string]string{AnnotationDynamoTestBackend: DynamoTestBackendMocker}
+	md.Spec.Model.ID = "Qwen/Qwen3-0.6B"
+	md.Spec.Resources = nil
+	return md
+}
+
+// dgdService extracts a service map from a transformed DGD.
+func dgdService(t *testing.T, dgd *unstructured.Unstructured, name string) map[string]interface{} {
+	t.Helper()
+	services, found, err := unstructured.NestedMap(dgd.Object, "spec", "services")
+	if err != nil || !found {
+		t.Fatalf("spec.services not found: err=%v found=%v", err, found)
+	}
+	svc, ok := services[name].(map[string]interface{})
+	if !ok {
+		t.Fatalf("service %q not found in services (have %v)", name, keysOf(services))
+	}
+	return svc
+}
+
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// mainContainer returns the worker/frontend main container map.
+func mainContainer(t *testing.T, svc map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	pod, ok := svc["extraPodSpec"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("extraPodSpec missing")
+	}
+	c, ok := pod["mainContainer"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mainContainer missing")
+	}
+	return c
+}
+
+func toStringSlice(t *testing.T, v interface{}) []string {
+	t.Helper()
+	raw, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("expected []interface{}, got %T", v)
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s, ok := e.(string)
+		if !ok {
+			t.Fatalf("expected string element, got %T", e)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func TestIsMockerMode(t *testing.T) {
+	if isMockerMode(nil) {
+		t.Error("nil md should not be mocker mode")
+	}
+	md := newTestMD("x", "default")
+	if isMockerMode(md) {
+		t.Error("md without annotation should not be mocker mode")
+	}
+	md.Annotations = map[string]string{AnnotationDynamoTestBackend: "something-else"}
+	if isMockerMode(md) {
+		t.Error("md with other annotation value should not be mocker mode")
+	}
+	md.Annotations[AnnotationDynamoTestBackend] = DynamoTestBackendMocker
+	if !isMockerMode(md) {
+		t.Error("md with mocker annotation should be mocker mode")
+	}
+}
+
+func TestValidateCompatibilityMocker(t *testing.T) {
+	r := &DynamoProviderReconciler{}
+
+	t.Run("aggregated CPU-only mocker is compatible", func(t *testing.T) {
+		md := newMockerMD("agg")
+		if err := r.validateCompatibility(md); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("disaggregated CPU-only mocker with scaling is compatible", func(t *testing.T) {
+		md := newMockerMD("disagg")
+		md.Spec.Serving = &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated}
+		md.Spec.Scaling = &airunwayv1alpha1.ScalingSpec{
+			Prefill: &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+			Decode:  &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+		}
+		if err := r.validateCompatibility(md); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("disaggregated mocker missing scaling is rejected", func(t *testing.T) {
+		md := newMockerMD("disagg-bad")
+		md.Spec.Serving = &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated}
+		err := r.validateCompatibility(md)
+		if err == nil || !strings.Contains(err.Error(), "prefill and spec.scaling.decode") {
+			t.Fatalf("expected prefill/decode error, got %v", err)
+		}
+	})
+
+	t.Run("non-vllm mocker is rejected", func(t *testing.T) {
+		md := newMockerMD("sglang")
+		md.Spec.Engine.Type = airunwayv1alpha1.EngineTypeSGLang
+		err := r.validateCompatibility(md)
+		if err == nil || !strings.Contains(err.Error(), "only supports the vllm engine") {
+			t.Fatalf("expected vllm-only error, got %v", err)
+		}
+	})
+
+	t.Run("non-mocker CPU-only still rejected", func(t *testing.T) {
+		md := newTestMD("nogpu", "default")
+		md.Spec.Resources = nil
+		err := r.validateCompatibility(md)
+		if err == nil || !strings.Contains(err.Error(), "Dynamo requires GPU") {
+			t.Fatalf("expected GPU-required error, got %v", err)
+		}
+	})
+}
+
+func TestTransformMockerAggregated(t *testing.T) {
+	tr := NewTransformer()
+	md := newMockerMD("mock-agg")
+
+	resources, err := tr.Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dgd := resources[0]
+
+	// Standalone Frontend, no EPP (gateway forced off in mocker mode).
+	if _, found, _ := unstructured.NestedMap(dgd.Object, "spec", "services"); !found {
+		t.Fatal("spec.services missing")
+	}
+	frontend := dgdService(t, dgd, "Frontend")
+	fImage, _ := mainContainer(t, frontend)["image"].(string)
+	if !strings.Contains(fImage, "dynamo-planner") {
+		t.Errorf("frontend image=%q, expected dynamo-planner", fImage)
+	}
+
+	worker := dgdService(t, dgd, "VllmWorker")
+	c := mainContainer(t, worker)
+
+	image, _ := c["image"].(string)
+	if !strings.Contains(image, "dynamo-planner") {
+		t.Errorf("worker image=%q, expected dynamo-planner", image)
+	}
+
+	command := toStringSlice(t, c["command"])
+	if strings.Join(command, " ") != "python3 -m dynamo.mocker" {
+		t.Errorf("worker command=%v, expected python3 -m dynamo.mocker", command)
+	}
+
+	args := strings.Join(toStringSlice(t, c["args"]), " ")
+	for _, want := range []string{
+		"--model-path Qwen/Qwen3-0.6B",
+		"--model-name Qwen/Qwen3-0.6B",
+		"--speedup-ratio 1000.0",
+		"--num-gpu-blocks-override 4096",
+		"--block-size 16",
+		"--max-num-seqs 64",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("worker args %q missing %q", args, want)
+		}
+	}
+
+	// No GPU resource requests/limits.
+	res, _ := worker["resources"].(map[string]interface{})
+	requests, _ := res["requests"].(map[string]interface{})
+	limits, _ := res["limits"].(map[string]interface{})
+	if len(requests) != 0 || len(limits) != 0 {
+		t.Errorf("expected empty resources in mocker mode, got requests=%v limits=%v", requests, limits)
+	}
+}
+
+func TestTransformMockerUsesServedName(t *testing.T) {
+	tr := NewTransformer()
+	md := newMockerMD("mock-served")
+	md.Spec.Model.ServedName = "my-model"
+
+	resources, err := tr.Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	worker := dgdService(t, resources[0], "VllmWorker")
+	args := strings.Join(toStringSlice(t, mainContainer(t, worker)["args"]), " ")
+	if !strings.Contains(args, "--model-name my-model") {
+		t.Errorf("expected --model-name my-model, got %q", args)
+	}
+}
+
+func TestTransformMockerDisaggregated(t *testing.T) {
+	tr := NewTransformer()
+	md := newMockerMD("mock-disagg")
+	md.Spec.Serving = &airunwayv1alpha1.ServingSpec{Mode: airunwayv1alpha1.ServingModeDisaggregated}
+	md.Spec.Scaling = &airunwayv1alpha1.ScalingSpec{
+		Prefill: &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+		Decode:  &airunwayv1alpha1.ComponentScalingSpec{Replicas: 1},
+	}
+
+	resources, err := tr.Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dgd := resources[0]
+
+	// Standalone Frontend present, no EPP.
+	if _, ok := dgdServiceOK(dgd, "Epp"); ok {
+		t.Error("did not expect Epp service in mocker mode")
+	}
+	if _, ok := dgdServiceOK(dgd, "Frontend"); !ok {
+		t.Error("expected standalone Frontend in mocker mode")
+	}
+
+	cases := map[string]string{
+		"VllmPrefillWorker": "prefill",
+		"VllmDecodeWorker":  "decode",
+	}
+	for svcName, mode := range cases {
+		worker := dgdService(t, dgd, svcName)
+		c := mainContainer(t, worker)
+
+		command := strings.Join(toStringSlice(t, c["command"]), " ")
+		if command != "python3 -m dynamo.mocker" {
+			t.Errorf("%s command=%q, expected python3 -m dynamo.mocker", svcName, command)
+		}
+
+		args := strings.Join(toStringSlice(t, c["args"]), " ")
+		if !strings.Contains(args, "--disaggregation-mode "+mode) {
+			t.Errorf("%s args %q missing --disaggregation-mode %s", svcName, args, mode)
+		}
+		// Mocker must NOT use the real-vLLM NIXL flag.
+		if strings.Contains(args, "--kv-transfer-config") {
+			t.Errorf("%s args %q must not contain --kv-transfer-config in mocker mode", svcName, args)
+		}
+
+		res, _ := worker["resources"].(map[string]interface{})
+		requests, _ := res["requests"].(map[string]interface{})
+		if len(requests) != 0 {
+			t.Errorf("%s expected no resource requests, got %v", svcName, requests)
+		}
+	}
+}
+
+// dgdServiceOK reports whether a named service exists in the DGD.
+func dgdServiceOK(dgd *unstructured.Unstructured, name string) (map[string]interface{}, bool) {
+	services, found, err := unstructured.NestedMap(dgd.Object, "spec", "services")
+	if err != nil || !found {
+		return nil, false
+	}
+	svc, ok := services[name].(map[string]interface{})
+	return svc, ok
+}

--- a/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
+++ b/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
@@ -138,6 +138,15 @@ func runMockerCase(t *testing.T, tc mockerCase) {
 		testMockerInferenceServing(t, tc)
 	})
 
+	// Skip the explicit Cleanup subtest if an earlier step failed: the registered
+	// t.Cleanup above still deletes the ModelDeployment best-effort, but leaving
+	// the in-cluster state intact (and collectDebugInfo's dump) is more useful for
+	// debugging than tearing it down here.
+	if t.Failed() {
+		t.Log("skipping explicit Cleanup subtest due to earlier failure; relying on t.Cleanup teardown")
+		return
+	}
+
 	t.Run("Cleanup", func(t *testing.T) {
 		testMockerCleanup(t, tc)
 	})
@@ -228,9 +237,15 @@ func testMockerDGDCreated(t *testing.T, tc mockerCase) {
 			t.Fatalf("worker %s command=%q, expected to contain dynamo.mocker", svc, command)
 		}
 
-		// Mocker workers must not request GPUs.
-		gpu := getDGDServiceField(t, tc.name, mdNamespace, svc,
-			fmt.Sprintf("{.spec.services.%s.resources.requests.gpu}", svc))
+		// Mocker workers must not request GPUs. Query kubectl directly (rather
+		// than getDGDServiceField, which swallows errors and returns "") so a
+		// failed jsonpath lookup is a hard failure instead of silently passing.
+		gpu, err := kubectlMayFail(t, "get", "dynamographdeployments.nvidia.com", tc.name,
+			"-n", mdNamespace,
+			"-o", fmt.Sprintf("jsonpath={.spec.services.%s.resources.requests.gpu}", svc))
+		if err != nil {
+			t.Fatalf("worker %s: failed to read GPU request: %v", svc, err)
+		}
 		if gpu != "" {
 			t.Fatalf("worker %s requests gpu=%q, expected no GPU request in mocker mode", svc, gpu)
 		}

--- a/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
+++ b/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
@@ -152,8 +152,8 @@ func testCreateMockerModelDeployment(t *testing.T, tc mockerCase) {
 		t.Fatalf("failed to read fixture %s: %v", path, err)
 	}
 
-	yaml := injectMockerAnnotation(t, string(raw))
-	out, err := kubectlApplyLiteral(t, yaml)
+	manifest := injectMockerAnnotation(t, string(raw))
+	out, err := kubectlApplyLiteral(t, manifest)
 	if err != nil {
 		t.Fatalf("failed to apply mocker ModelDeployment: %v\nOutput: %s", err, out)
 	}

--- a/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
+++ b/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
@@ -160,11 +160,20 @@ func testCreateMockerModelDeployment(t *testing.T, tc mockerCase) {
 	t.Logf("applied mocker ModelDeployment %s from %s", tc.name, tc.fixture)
 }
 
-// injectMockerAnnotation parses a single-document ModelDeployment manifest and
-// sets the mocker annotation via the unstructured API, then re-serializes it.
-// SetAnnotations handles all the fixture-evolution cases for free: it creates
-// metadata.annotations if absent, merges into an existing block, and overwrites
-// (no duplicate) if the key is already present — no string/line surgery.
+// injectMockerAnnotation parses a single-document ModelDeployment manifest, sets
+// the mocker annotation, and strips every GPU field so the applied spec is
+// genuinely CPU-only. Both happen via the unstructured API, then it re-serializes.
+//
+// Setting the annotation handles all the fixture-evolution cases for free:
+// SetAnnotations creates metadata.annotations if absent, merges into an existing
+// block, and overwrites (no duplicate) if the key is already present.
+//
+// Stripping the GPU fields (spec.resources.gpu, spec.scaling.prefill.gpu,
+// spec.scaling.decode.gpu) is what makes this test meaningful: the shared
+// fixtures carry gpu.count so the GPU lane can reuse them, but the mocker backend
+// is GPU-less. Removing the counts forces the request through the same CPU-only
+// path real users hit, so the webhook AND reconciler mocker bypasses are actually
+// exercised end-to-end — not satisfied trivially by a leftover gpu.count.
 func injectMockerAnnotation(t *testing.T, manifest string) string {
 	t.Helper()
 
@@ -179,6 +188,11 @@ func injectMockerAnnotation(t *testing.T, manifest string) string {
 	}
 	ann[mockerAnnotationKey] = mockerAnnotationValue
 	obj.SetAnnotations(ann)
+
+	// Drop GPU requests everywhere so the mocker spec is CPU-only.
+	unstructured.RemoveNestedField(obj.Object, "spec", "resources", "gpu")
+	unstructured.RemoveNestedField(obj.Object, "spec", "scaling", "prefill", "gpu")
+	unstructured.RemoveNestedField(obj.Object, "spec", "scaling", "decode", "gpu")
 
 	out, err := yaml.Marshal(obj.Object)
 	if err != nil {

--- a/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
+++ b/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
@@ -27,12 +27,18 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
-// mockerAnnotation is the ModelDeployment annotation that switches the Dynamo
-// provider into its GPU-less mocker test backend. It must match
+// mockerAnnotationKey/Value are the ModelDeployment annotation that switches the
+// Dynamo provider into its GPU-less mocker test backend. They must match
 // providers/dynamo/mocker.go (AnnotationDynamoTestBackend / DynamoTestBackendMocker).
-const mockerAnnotation = "airunway.ai/dynamo-test-backend: mocker"
+const (
+	mockerAnnotationKey   = "airunway.ai/dynamo-test-backend"
+	mockerAnnotationValue = "mocker"
+)
 
 // mockerPlannerImageSubstr is the image substring expected on mocker workers.
 const mockerPlannerImageSubstr = "dynamo-planner"
@@ -154,18 +160,31 @@ func testCreateMockerModelDeployment(t *testing.T, tc mockerCase) {
 	t.Logf("applied mocker ModelDeployment %s from %s", tc.name, tc.fixture)
 }
 
-// injectMockerAnnotation inserts the mocker annotation under the first metadata
-// block of a single-document ModelDeployment manifest.
+// injectMockerAnnotation parses a single-document ModelDeployment manifest and
+// sets the mocker annotation via the unstructured API, then re-serializes it.
+// SetAnnotations handles all the fixture-evolution cases for free: it creates
+// metadata.annotations if absent, merges into an existing block, and overwrites
+// (no duplicate) if the key is already present — no string/line surgery.
 func injectMockerAnnotation(t *testing.T, manifest string) string {
 	t.Helper()
-	const marker = "metadata:\n"
-	idx := strings.Index(manifest, marker)
-	if idx < 0 {
-		t.Fatalf("fixture has no metadata block to annotate")
+
+	var obj unstructured.Unstructured
+	if err := yaml.Unmarshal([]byte(manifest), &obj.Object); err != nil {
+		t.Fatalf("failed to parse fixture as YAML: %v", err)
 	}
-	insertAt := idx + len(marker)
-	annotations := "  annotations:\n    " + mockerAnnotation + "\n"
-	return manifest[:insertAt] + annotations + manifest[insertAt:]
+
+	ann := obj.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	ann[mockerAnnotationKey] = mockerAnnotationValue
+	obj.SetAnnotations(ann)
+
+	out, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		t.Fatalf("failed to re-serialize annotated manifest: %v", err)
+	}
+	return string(out)
 }
 
 // testMockerDGDCreated waits for the DGD to exist and asserts the generated

--- a/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
+++ b/providers/dynamo/test/e2e/dynamo_mocker_e2e_test.go
@@ -1,0 +1,331 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockerAnnotation is the ModelDeployment annotation that switches the Dynamo
+// provider into its GPU-less mocker test backend. It must match
+// providers/dynamo/mocker.go (AnnotationDynamoTestBackend / DynamoTestBackendMocker).
+const mockerAnnotation = "airunway.ai/dynamo-test-backend: mocker"
+
+// mockerPlannerImageSubstr is the image substring expected on mocker workers.
+const mockerPlannerImageSubstr = "dynamo-planner"
+
+// mockerCase parametrizes a mocker E2E run so the aggregated and disaggregated
+// lanes can share one subtest sequence.
+type mockerCase struct {
+	// name is the ModelDeployment / DGD name.
+	name string
+	// fixture is the testdata YAML filename to apply (with the mocker
+	// annotation injected at apply-time).
+	fixture string
+	// frontendSvc is the generated standalone Frontend service: <name>-frontend.
+	frontendSvc string
+	// workerServices are the DGD service keys whose container we assert on.
+	workerServices []string
+	// disaggregated indicates the prefill/decode worker assertions should run.
+	disaggregated bool
+}
+
+// TestDynamoMockerE2E verifies the full CPU-only Dynamo mocker pipeline for
+// aggregated serving:
+//
+//	ModelDeployment (mocker annotation) → Airunway controller → dynamo-provider
+//	→ DynamoGraphDeployment (mocker workers) → Dynamo operator
+//	→ mocker-backed OpenAI-compatible /v1/chat/completions
+//
+// It reuses the existing aggregated fixture (testdata/dynamo-modeldeployment.yaml)
+// with the mocker annotation injected, so the GPU values in that fixture are
+// ignored and the worker runs python3 -m dynamo.mocker on CPU.
+//
+// Gated by DYNAMO_MOCKER=true (distinct from DYNAMO_INSTALLED so the GPU and
+// CPU suites never both run on a single invocation).
+func TestDynamoMockerE2E(t *testing.T) {
+	if os.Getenv("DYNAMO_MOCKER") != "true" {
+		t.Skip("skipping: DYNAMO_MOCKER is not set to true")
+	}
+
+	runMockerCase(t, mockerCase{
+		name:           "qwen3-0-6b",
+		fixture:        "dynamo-modeldeployment.yaml",
+		frontendSvc:    "qwen3-0-6b-frontend",
+		workerServices: []string{"VllmWorker"},
+		disaggregated:  false,
+	})
+}
+
+// TestDynamoMockerDisaggE2E verifies the CPU-only Dynamo mocker pipeline for
+// disaggregated serving (standalone Frontend + prefill + decode mocker workers).
+//
+// Gated by DYNAMO_MOCKER=true.
+func TestDynamoMockerDisaggE2E(t *testing.T) {
+	if os.Getenv("DYNAMO_MOCKER") != "true" {
+		t.Skip("skipping: DYNAMO_MOCKER is not set to true")
+	}
+
+	runMockerCase(t, mockerCase{
+		name:           "qwen3-0-6b-disagg",
+		fixture:        "dynamo-disagg-modeldeployment.yaml",
+		frontendSvc:    "qwen3-0-6b-disagg-frontend",
+		workerServices: []string{"VllmPrefillWorker", "VllmDecodeWorker"},
+		disaggregated:  true,
+	})
+}
+
+// runMockerCase executes the shared mocker subtest sequence for a case.
+func runMockerCase(t *testing.T, tc mockerCase) {
+	t.Cleanup(func() {
+		if t.Failed() {
+			collectDebugInfo(t, tc.name, mdNamespace)
+		}
+		// Best-effort teardown so a failed run does not leak resources.
+		deleteModelDeployment(t, tc.name)
+	})
+
+	t.Run("ProviderReady", func(t *testing.T) {
+		testProviderReady(t)
+	})
+
+	t.Run("CreateModelDeployment", func(t *testing.T) {
+		testCreateMockerModelDeployment(t, tc)
+	})
+
+	t.Run("DGDCreated", func(t *testing.T) {
+		testMockerDGDCreated(t, tc)
+	})
+
+	t.Run("DGDSuccessful", func(t *testing.T) {
+		testMockerDGDSuccessful(t, tc)
+	})
+
+	t.Run("PhaseRunning", func(t *testing.T) {
+		testMockerPhaseRunning(t, tc)
+	})
+
+	t.Run("InferenceServing", func(t *testing.T) {
+		testMockerInferenceServing(t, tc)
+	})
+
+	t.Run("Cleanup", func(t *testing.T) {
+		testMockerCleanup(t, tc)
+	})
+}
+
+// testCreateMockerModelDeployment applies the fixture with the mocker annotation
+// injected into metadata so it is present on the very first reconcile.
+func testCreateMockerModelDeployment(t *testing.T, tc mockerCase) {
+	path := testdataPath(t, tc.fixture)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", path, err)
+	}
+
+	yaml := injectMockerAnnotation(t, string(raw))
+	out, err := kubectlApplyLiteral(t, yaml)
+	if err != nil {
+		t.Fatalf("failed to apply mocker ModelDeployment: %v\nOutput: %s", err, out)
+	}
+	t.Logf("applied mocker ModelDeployment %s from %s", tc.name, tc.fixture)
+}
+
+// injectMockerAnnotation inserts the mocker annotation under the first metadata
+// block of a single-document ModelDeployment manifest.
+func injectMockerAnnotation(t *testing.T, manifest string) string {
+	t.Helper()
+	const marker = "metadata:\n"
+	idx := strings.Index(manifest, marker)
+	if idx < 0 {
+		t.Fatalf("fixture has no metadata block to annotate")
+	}
+	insertAt := idx + len(marker)
+	annotations := "  annotations:\n    " + mockerAnnotation + "\n"
+	return manifest[:insertAt] + annotations + manifest[insertAt:]
+}
+
+// testMockerDGDCreated waits for the DGD to exist and asserts the generated
+// mocker shape: planner image, python3 -m dynamo.mocker command, and no GPU
+// resource requests. For disaggregated cases it also checks the prefill/decode
+// workers carry --disaggregation-mode and omit --kv-transfer-config.
+func testMockerDGDCreated(t *testing.T, tc mockerCase) {
+	waitFor(t, 3*time.Minute, 5*time.Second, "DGD created", func() error {
+		_, err := kubectlMayFail(t, "get", "dynamographdeployments.nvidia.com", tc.name,
+			"-n", mdNamespace)
+		if err != nil {
+			return fmt.Errorf("DynamoGraphDeployment %s not found: %v", tc.name, err)
+		}
+		return nil
+	})
+
+	for _, svc := range tc.workerServices {
+		base := fmt.Sprintf("{.spec.services.%s.extraPodSpec.mainContainer.", svc)
+
+		image := getDGDServiceField(t, tc.name, mdNamespace, svc, base+"image}")
+		if !strings.Contains(image, mockerPlannerImageSubstr) {
+			t.Fatalf("worker %s image=%q, expected to contain %q", svc, image, mockerPlannerImageSubstr)
+		}
+
+		command := getDGDServiceField(t, tc.name, mdNamespace, svc, base+"command}")
+		if !strings.Contains(command, "dynamo.mocker") {
+			t.Fatalf("worker %s command=%q, expected to contain dynamo.mocker", svc, command)
+		}
+
+		// Mocker workers must not request GPUs.
+		gpu := getDGDServiceField(t, tc.name, mdNamespace, svc,
+			fmt.Sprintf("{.spec.services.%s.resources.requests.gpu}", svc))
+		if gpu != "" {
+			t.Fatalf("worker %s requests gpu=%q, expected no GPU request in mocker mode", svc, gpu)
+		}
+
+		args := getDGDServiceField(t, tc.name, mdNamespace, svc, base+"args}")
+		if tc.disaggregated {
+			if !strings.Contains(args, "--disaggregation-mode") {
+				t.Fatalf("disagg worker %s args=%q, expected --disaggregation-mode", svc, args)
+			}
+			if strings.Contains(args, "--kv-transfer-config") {
+				t.Fatalf("disagg mocker worker %s args=%q, must not contain --kv-transfer-config", svc, args)
+			}
+		}
+	}
+
+	t.Log("DynamoGraphDeployment created with mocker shape")
+}
+
+// testMockerDGDSuccessful waits for the DGD to reach status.state=successful.
+func testMockerDGDSuccessful(t *testing.T, tc mockerCase) {
+	waitFor(t, 15*time.Minute, 10*time.Second, "DGD successful", func() error {
+		state, err := kubectlMayFail(t, "get", "dynamographdeployments.nvidia.com", tc.name,
+			"-n", mdNamespace, "-o", "jsonpath={.status.state}")
+		if err != nil {
+			return fmt.Errorf("failed to read DGD state: %v", err)
+		}
+		if state != "successful" {
+			return fmt.Errorf("DGD state=%q, waiting for successful", state)
+		}
+		return nil
+	})
+	t.Log("DynamoGraphDeployment reached state=successful")
+}
+
+// testMockerPhaseRunning waits for the ModelDeployment to reach Running phase.
+func testMockerPhaseRunning(t *testing.T, tc mockerCase) {
+	const failedThreshold = 3
+	failedCount := 0
+
+	waitFor(t, 10*time.Minute, 10*time.Second, "ModelDeployment Running", func() error {
+		phase := getPhase(t, tc.name, mdNamespace)
+		switch phase {
+		case "Running":
+			return nil
+		case "Failed":
+			failedCount++
+			msg, _ := kubectlMayFail(t, "get", "modeldeployment", tc.name,
+				"-n", mdNamespace, "-o", "jsonpath={.status.message}")
+			if failedCount >= failedThreshold {
+				t.Fatalf("ModelDeployment persistently Failed (%d consecutive): %s", failedCount, msg)
+			}
+			return fmt.Errorf("phase is Failed (attempt %d/%d, will retry): %s", failedCount, failedThreshold, msg)
+		default:
+			failedCount = 0
+			return fmt.Errorf("phase is %q, waiting for Running", phase)
+		}
+	})
+
+	providerName := kubectl(t, "get", "modeldeployment", tc.name,
+		"-n", mdNamespace, "-o", "jsonpath={.status.provider.name}")
+	if providerName != "dynamo" {
+		t.Fatalf("status.provider.name=%q, expected dynamo", providerName)
+	}
+	t.Log("ModelDeployment is Running")
+}
+
+// testMockerInferenceServing port-forwards the standalone Frontend and sends a
+// chat completion request, asserting a valid OpenAI-compatible response.
+func testMockerInferenceServing(t *testing.T, tc mockerCase) {
+	session := startPortForward(t, tc.frontendSvc, frontendPort, mdNamespace)
+
+	waitFor(t, 2*time.Minute, 5*time.Second, "inference response", func() error {
+		requestBody := `{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Say hello in one word."}],"max_tokens":10}`
+		cmd := exec.Command("curl", "-s", "-X", "POST",
+			fmt.Sprintf("http://localhost:%s/v1/chat/completions", session.localPort),
+			"-H", "Content-Type: application/json",
+			"-d", requestBody,
+			"--max-time", "30")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("curl failed: %v, output: %s", err, string(output))
+		}
+
+		t.Logf("inference response: %s", string(output))
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(output, &response); err != nil {
+			return fmt.Errorf("response is not valid JSON: %v", err)
+		}
+
+		choices, ok := response["choices"].([]interface{})
+		if !ok || len(choices) == 0 {
+			return fmt.Errorf("response missing choices: %v", response)
+		}
+
+		firstChoice, ok := choices[0].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("first choice is not an object")
+		}
+
+		message, ok := firstChoice["message"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("choice missing message field")
+		}
+
+		content, ok := message["content"].(string)
+		if !ok || content == "" {
+			return fmt.Errorf("message content is empty or missing")
+		}
+
+		return nil
+	})
+
+	t.Log("mocker inference serving verified successfully")
+}
+
+// testMockerCleanup deletes the ModelDeployment and verifies the DGD cascades.
+func testMockerCleanup(t *testing.T, tc mockerCase) {
+	kubectl(t, "delete", "modeldeployment", tc.name, "-n", mdNamespace, "--timeout=5m")
+	t.Log("ModelDeployment deleted")
+
+	waitFor(t, 3*time.Minute, 5*time.Second, "DGD deleted", func() error {
+		out, _ := kubectlMayFail(t, "get", "dynamographdeployments.nvidia.com", tc.name,
+			"-n", mdNamespace, "--ignore-not-found")
+		if out == "" {
+			return nil
+		}
+		return fmt.Errorf("DGD %s still exists", tc.name)
+	})
+	t.Log("DynamoGraphDeployment deleted")
+}

--- a/providers/dynamo/test/e2e/inject_annotation_test.go
+++ b/providers/dynamo/test/e2e/inject_annotation_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -42,16 +43,31 @@ func TestInjectMockerAnnotation(t *testing.T) {
 	}
 
 	cases := map[string]string{
-		"bare metadata, no annotations": "" +
-			"apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
-			"metadata:\n  name: x\n  namespace: default\nspec:\n  model:\n    id: m\n",
-		"existing annotations block": "" +
-			"apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
-			"metadata:\n  name: x\n  annotations:\n    foo/bar: baz\nspec: {}\n",
-		"key already present": "" +
-			"apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
-			"metadata:\n  annotations:\n    " + mockerAnnotationKey + ": " + mockerAnnotationValue +
-			"\n  name: x\nspec: {}\n",
+		"bare metadata, no annotations": `apiVersion: airunway.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: x
+  namespace: default
+spec:
+  model:
+    id: m
+`,
+		"existing annotations block": `apiVersion: airunway.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: x
+  annotations:
+    foo/bar: baz
+spec: {}
+`,
+		"key already present": fmt.Sprintf(`apiVersion: airunway.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  annotations:
+    %s: %s
+  name: x
+spec: {}
+`, mockerAnnotationKey, mockerAnnotationValue),
 	}
 
 	for name, in := range cases {
@@ -64,8 +80,15 @@ func TestInjectMockerAnnotation(t *testing.T) {
 	}
 
 	t.Run("preserves sibling annotations and metadata fields", func(t *testing.T) {
-		in := "apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
-			"metadata:\n  name: keepme\n  namespace: default\n  annotations:\n    foo/bar: baz\nspec: {}\n"
+		in := `apiVersion: airunway.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: keepme
+  namespace: default
+  annotations:
+    foo/bar: baz
+spec: {}
+`
 		out := injectMockerAnnotation(t, in)
 
 		var obj unstructured.Unstructured

--- a/providers/dynamo/test/e2e/inject_annotation_test.go
+++ b/providers/dynamo/test/e2e/inject_annotation_test.go
@@ -1,0 +1,86 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// TestInjectMockerAnnotation exercises annotation injection via the unstructured
+// API, including the fixture-evolution cases raised in review: an existing
+// annotations block, an already-present key, and a bare metadata block. The
+// assertions are semantic (re-parsed), not string-based, since the helper
+// re-serializes the manifest.
+func TestInjectMockerAnnotation(t *testing.T) {
+	parseAnnotations := func(t *testing.T, manifest string) map[string]string {
+		t.Helper()
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(manifest), &obj.Object); err != nil {
+			t.Fatalf("failed to re-parse output: %v", err)
+		}
+		return obj.GetAnnotations()
+	}
+
+	cases := map[string]string{
+		"bare metadata, no annotations": "" +
+			"apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
+			"metadata:\n  name: x\n  namespace: default\nspec:\n  model:\n    id: m\n",
+		"existing annotations block": "" +
+			"apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
+			"metadata:\n  name: x\n  annotations:\n    foo/bar: baz\nspec: {}\n",
+		"key already present": "" +
+			"apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
+			"metadata:\n  annotations:\n    " + mockerAnnotationKey + ": " + mockerAnnotationValue +
+			"\n  name: x\nspec: {}\n",
+	}
+
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			ann := parseAnnotations(t, injectMockerAnnotation(t, in))
+			if ann[mockerAnnotationKey] != mockerAnnotationValue {
+				t.Fatalf("mocker annotation missing/wrong: %v", ann)
+			}
+		})
+	}
+
+	t.Run("preserves sibling annotations and metadata fields", func(t *testing.T) {
+		in := "apiVersion: airunway.ai/v1alpha1\nkind: ModelDeployment\n" +
+			"metadata:\n  name: keepme\n  namespace: default\n  annotations:\n    foo/bar: baz\nspec: {}\n"
+		out := injectMockerAnnotation(t, in)
+
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(out), &obj.Object); err != nil {
+			t.Fatalf("failed to re-parse output: %v", err)
+		}
+		ann := obj.GetAnnotations()
+		if ann["foo/bar"] != "baz" {
+			t.Errorf("sibling annotation lost: %v", ann)
+		}
+		if ann[mockerAnnotationKey] != mockerAnnotationValue {
+			t.Errorf("mocker annotation missing: %v", ann)
+		}
+		if obj.GetName() != "keepme" || obj.GetNamespace() != "default" {
+			t.Errorf("metadata fields lost: name=%q ns=%q", obj.GetName(), obj.GetNamespace())
+		}
+	})
+}

--- a/providers/dynamo/test/e2e/inject_annotation_test.go
+++ b/providers/dynamo/test/e2e/inject_annotation_test.go
@@ -83,4 +83,45 @@ func TestInjectMockerAnnotation(t *testing.T) {
 			t.Errorf("metadata fields lost: name=%q ns=%q", obj.GetName(), obj.GetNamespace())
 		}
 	})
+
+	t.Run("strips GPU fields so the spec is CPU-only", func(t *testing.T) {
+		in := `apiVersion: airunway.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: gpu
+spec:
+  resources:
+    gpu:
+      count: 1
+  scaling:
+    prefill:
+      replicas: 1
+      gpu:
+        count: 1
+    decode:
+      replicas: 1
+      gpu:
+        count: 1
+`
+		out := injectMockerAnnotation(t, in)
+
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(out), &obj.Object); err != nil {
+			t.Fatalf("failed to re-parse output: %v", err)
+		}
+		for _, path := range [][]string{
+			{"spec", "resources", "gpu"},
+			{"spec", "scaling", "prefill", "gpu"},
+			{"spec", "scaling", "decode", "gpu"},
+		} {
+			if _, found, _ := unstructured.NestedFieldNoCopy(obj.Object, path...); found {
+				t.Errorf("expected %v to be stripped, but it is still present", path)
+			}
+		}
+		// Sibling fields under the same parents must survive. (yaml decodes
+		// numbers as float64, so compare without asserting the Go integer type.)
+		if _, found, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec", "scaling", "prefill", "replicas"); !found {
+			t.Errorf("prefill.replicas was lost when stripping prefill.gpu")
+		}
+	})
 }

--- a/providers/dynamo/test/e2e/testdata/dynamo-disagg-modeldeployment.yaml
+++ b/providers/dynamo/test/e2e/testdata/dynamo-disagg-modeldeployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: airunway.ai/v1alpha1
+kind: ModelDeployment
+metadata:
+  name: qwen3-0-6b-disagg
+  namespace: default
+spec:
+  model:
+    id: Qwen/Qwen3-0.6B
+    source: huggingface
+  provider:
+    name: dynamo
+  engine:
+    type: vllm
+    contextLength: 4096
+    trustRemoteCode: false
+  serving:
+    mode: disaggregated
+  scaling:
+    prefill:
+      replicas: 1
+      gpu:
+        count: 1
+    decode:
+      replicas: 1
+      gpu:
+        count: 1

--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -514,7 +514,9 @@ func (t *Transformer) buildAggregatedWorker(md *airunwayv1alpha1.ModelDeployment
 
 	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and replace
 	// the GPU resources with small CPU/memory requests+limits (no GPU) so the
-	// worker schedules on CPU-only nodes while staying Burstable, not BestEffort.
+	// worker schedules on CPU-only nodes. Equal requests and limits make the pod
+	// Guaranteed QoS — the point is simply to avoid BestEffort, which is evicted
+	// first under memory pressure and rejected by request-mandating LimitRanges.
 	if isMockerMode(md) {
 		command = mockerCommand()
 		args = buildMockerArgs(md)

--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -283,8 +283,8 @@ func (t *Transformer) buildFrontendService(md *airunwayv1alpha1.ModelDeployment,
 	// is a lightweight router, so default to modest requests (overridable) to
 	// leave headroom for the mocker worker on the same node.
 	if isMockerMode(md) {
-		cpu = "100m"
-		memory = "256Mi"
+		cpu = MockerWorkerCPU
+		memory = MockerWorkerMemory
 	}
 	if overrides.Frontend != nil && overrides.Frontend.Resources != nil {
 		if overrides.Frontend.Resources.CPU != "" {
@@ -517,7 +517,7 @@ func (t *Transformer) buildAggregatedWorker(md *airunwayv1alpha1.ModelDeployment
 	if isMockerMode(md) {
 		command = mockerCommand()
 		args = buildMockerArgs(md)
-		resources = emptyResources()
+		resources = mockerWorkerResources()
 	}
 
 	worker := map[string]interface{}{
@@ -616,7 +616,7 @@ func (t *Transformer) buildPrefillWorker(md *airunwayv1alpha1.ModelDeployment, i
 	if isMockerMode(md) {
 		command = mockerCommand()
 		args = append(buildMockerArgs(md), "--disaggregation-mode", SubComponentTypePrefill)
-		resources = emptyResources()
+		resources = mockerWorkerResources()
 	}
 
 	worker := map[string]interface{}{
@@ -692,7 +692,7 @@ func (t *Transformer) buildDecodeWorker(md *airunwayv1alpha1.ModelDeployment, im
 	if isMockerMode(md) {
 		command = mockerCommand()
 		args = append(buildMockerArgs(md), "--disaggregation-mode", SubComponentTypeDecode)
-		resources = emptyResources()
+		resources = mockerWorkerResources()
 	}
 
 	worker := map[string]interface{}{

--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -512,8 +512,9 @@ func (t *Transformer) buildAggregatedWorker(md *airunwayv1alpha1.ModelDeployment
 
 	command := t.engineCommand(md.ResolvedEngineType())
 
-	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and drop
-	// all GPU/CPU resource requests so the worker schedules on CPU-only nodes.
+	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and replace
+	// the GPU resources with small CPU/memory requests+limits (no GPU) so the
+	// worker schedules on CPU-only nodes while staying Burstable, not BestEffort.
 	if isMockerMode(md) {
 		command = mockerCommand()
 		args = buildMockerArgs(md)
@@ -610,9 +611,10 @@ func (t *Transformer) buildPrefillWorker(md *airunwayv1alpha1.ModelDeployment, i
 
 	command := t.engineCommand(md.ResolvedEngineType())
 
-	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and drop
-	// GPU resource requests. The mocker keeps --disaggregation-mode but does
-	// NOT use --kv-transfer-config (that NIXL flag is real-vLLM-only).
+	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and replace
+	// the GPU resources with small CPU/memory requests+limits (no GPU). The mocker
+	// keeps --disaggregation-mode but does NOT use --kv-transfer-config (that NIXL
+	// flag is real-vLLM-only).
 	if isMockerMode(md) {
 		command = mockerCommand()
 		args = append(buildMockerArgs(md), "--disaggregation-mode", SubComponentTypePrefill)
@@ -686,9 +688,10 @@ func (t *Transformer) buildDecodeWorker(md *airunwayv1alpha1.ModelDeployment, im
 
 	command := t.engineCommand(md.ResolvedEngineType())
 
-	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and drop
-	// GPU resource requests. The mocker keeps --disaggregation-mode but does
-	// NOT use --kv-transfer-config (that NIXL flag is real-vLLM-only).
+	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and replace
+	// the GPU resources with small CPU/memory requests+limits (no GPU). The mocker
+	// keeps --disaggregation-mode but does NOT use --kv-transfer-config (that NIXL
+	// flag is real-vLLM-only).
 	if isMockerMode(md) {
 		command = mockerCommand()
 		args = append(buildMockerArgs(md), "--disaggregation-mode", SubComponentTypeDecode)

--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -895,15 +895,17 @@ var defaultImages = map[airunwayv1alpha1.EngineType]string{
 
 // getImage returns the container image to use
 func (t *Transformer) getImage(md *airunwayv1alpha1.ModelDeployment) string {
+	// Mocker mode runs python3 -m dynamo.mocker, which lives only in the
+	// dynamo-planner image. This is annotation-gated, test-only behavior, so the
+	// planner image must win even over an explicit spec.image: a custom image
+	// without the dynamo.mocker module would silently break the test backend.
+	if isMockerMode(md) {
+		return defaultMockerImage
+	}
+
 	// Use custom image if specified
 	if md.Spec.Image != "" {
 		return md.Spec.Image
-	}
-
-	// Mocker mode runs python3 -m dynamo.mocker, which lives in the
-	// dynamo-planner image rather than the per-engine runtime images.
-	if isMockerMode(md) {
-		return defaultMockerImage
 	}
 
 	// Use default image for engine type

--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -213,6 +213,13 @@ func (t *Transformer) buildServices(md *airunwayv1alpha1.ModelDeployment, overri
 
 	gatewayEnabled := md.Spec.Gateway == nil || md.Spec.Gateway.Enabled == nil || *md.Spec.Gateway.Enabled
 
+	// Mocker mode always uses the standalone Frontend path. It exercises the
+	// Dynamo Frontend → mocker worker slice without EPP/GAIE complexity, so the
+	// gateway/EPP branch is never taken regardless of spec.gateway.enabled.
+	if isMockerMode(md) {
+		gatewayEnabled = false
+	}
+
 	if gatewayEnabled {
 		// GAIE path: Gateway → EPP → worker frontendSidecar. No standalone
 		// Frontend — each worker's sidecar handles requests locally.
@@ -272,6 +279,13 @@ func (t *Transformer) buildFrontendService(md *airunwayv1alpha1.ModelDeployment,
 
 	cpu := "2"
 	memory := "4Gi"
+	// Mocker mode targets GPU-less CI nodes that are often small. The Frontend
+	// is a lightweight router, so default to modest requests (overridable) to
+	// leave headroom for the mocker worker on the same node.
+	if isMockerMode(md) {
+		cpu = "100m"
+		memory = "256Mi"
+	}
 	if overrides.Frontend != nil && overrides.Frontend.Resources != nil {
 		if overrides.Frontend.Resources.CPU != "" {
 			cpu = overrides.Frontend.Resources.CPU
@@ -496,6 +510,16 @@ func (t *Transformer) buildAggregatedWorker(md *airunwayv1alpha1.ModelDeployment
 		return nil, err
 	}
 
+	command := t.engineCommand(md.ResolvedEngineType())
+
+	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and drop
+	// all GPU/CPU resource requests so the worker schedules on CPU-only nodes.
+	if isMockerMode(md) {
+		command = mockerCommand()
+		args = buildMockerArgs(md)
+		resources = emptyResources()
+	}
+
 	worker := map[string]interface{}{
 		"componentType": ComponentTypeWorker,
 		"replicas":      replicas,
@@ -503,7 +527,7 @@ func (t *Transformer) buildAggregatedWorker(md *airunwayv1alpha1.ModelDeployment
 		"extraPodSpec": map[string]interface{}{
 			"mainContainer": map[string]interface{}{
 				"image":   image,
-				"command": toInterfaceSlice(t.engineCommand(md.ResolvedEngineType())),
+				"command": toInterfaceSlice(command),
 				"args":    toInterfaceSlice(args),
 			},
 		},
@@ -584,6 +608,17 @@ func (t *Transformer) buildPrefillWorker(md *airunwayv1alpha1.ModelDeployment, i
 		args = append(args, "--kv-transfer-config", VLLMKVTransferConfig)
 	}
 
+	command := t.engineCommand(md.ResolvedEngineType())
+
+	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and drop
+	// GPU resource requests. The mocker keeps --disaggregation-mode but does
+	// NOT use --kv-transfer-config (that NIXL flag is real-vLLM-only).
+	if isMockerMode(md) {
+		command = mockerCommand()
+		args = append(buildMockerArgs(md), "--disaggregation-mode", SubComponentTypePrefill)
+		resources = emptyResources()
+	}
+
 	worker := map[string]interface{}{
 		"componentType":    ComponentTypeWorker,
 		"subComponentType": SubComponentTypePrefill,
@@ -592,7 +627,7 @@ func (t *Transformer) buildPrefillWorker(md *airunwayv1alpha1.ModelDeployment, i
 		"extraPodSpec": map[string]interface{}{
 			"mainContainer": map[string]interface{}{
 				"image":   image,
-				"command": toInterfaceSlice(t.engineCommand(md.ResolvedEngineType())),
+				"command": toInterfaceSlice(command),
 				"args":    toInterfaceSlice(args),
 			},
 		},
@@ -649,6 +684,17 @@ func (t *Transformer) buildDecodeWorker(md *airunwayv1alpha1.ModelDeployment, im
 		args = append(args, "--kv-transfer-config", VLLMKVTransferConfig)
 	}
 
+	command := t.engineCommand(md.ResolvedEngineType())
+
+	// Mocker mode: swap the real engine for python3 -m dynamo.mocker and drop
+	// GPU resource requests. The mocker keeps --disaggregation-mode but does
+	// NOT use --kv-transfer-config (that NIXL flag is real-vLLM-only).
+	if isMockerMode(md) {
+		command = mockerCommand()
+		args = append(buildMockerArgs(md), "--disaggregation-mode", SubComponentTypeDecode)
+		resources = emptyResources()
+	}
+
 	worker := map[string]interface{}{
 		"componentType":    ComponentTypeWorker,
 		"subComponentType": SubComponentTypeDecode,
@@ -657,7 +703,7 @@ func (t *Transformer) buildDecodeWorker(md *airunwayv1alpha1.ModelDeployment, im
 		"extraPodSpec": map[string]interface{}{
 			"mainContainer": map[string]interface{}{
 				"image":   image,
-				"command": toInterfaceSlice(t.engineCommand(md.ResolvedEngineType())),
+				"command": toInterfaceSlice(command),
 				"args":    toInterfaceSlice(args),
 			},
 		},
@@ -852,6 +898,12 @@ func (t *Transformer) getImage(md *airunwayv1alpha1.ModelDeployment) string {
 	// Use custom image if specified
 	if md.Spec.Image != "" {
 		return md.Spec.Image
+	}
+
+	// Mocker mode runs python3 -m dynamo.mocker, which lives in the
+	// dynamo-planner image rather than the per-engine runtime images.
+	if isMockerMode(md) {
+		return defaultMockerImage
 	}
 
 	// Use default image for engine type


### PR DESCRIPTION
## Description

Adds an annotation-gated, CPU-only "mocker mode" to the Dynamo provider so the full
deployment path (`ModelDeployment` → controller → `dynamo-provider` → `DynamoGraphDeployment`
→ Dynamo operator → mocker frontend → `/v1/chat/completions`) can run on GPU-less,
GitHub-hosted CI runners. Mocker mode is enabled per-deployment via the annotation
`airunway.ai/dynamo-test-backend: mocker` (no CRD/API changes) and supports both
aggregated and disaggregated serving in code and in CI.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Related Issues

Fixes #290

## Changes Made

- **Mocker mode in the Dynamo provider** (`providers/dynamo/mocker.go`, `transformer.go`,
  `controller.go`): added the `airunway.ai/dynamo-test-backend: mocker` annotation helper and
  CPU-only transform path. In mocker mode `getImage` returns the `dynamo-planner:<DynamoVersion>`
  image, workers run `python3 -m dynamo.mocker` with mocker args (`--model-path`, `--model-name`,
  `--speedup-ratio`, `--num-gpu-blocks-override`, `--block-size`, `--max-num-seqs`), and GPU
  resources are replaced with small CPU/memory requests+limits (Guaranteed QoS). `buildServices`
  forces the standalone-`Frontend` (non-gateway) path and dispatches to a single `VllmWorker`
  (aggregated) or `VllmPrefillWorker` + `VllmDecodeWorker` (disaggregated). Disaggregated workers
  keep `--disaggregation-mode prefill|decode` but omit `--kv-transfer-config` (a real-vLLM/NIXL-only
  flag). `validateCompatibility` allows CPU-only specs in mocker mode while still requiring the
  `vllm` engine.
- **Honor mocker mode across all gates in the core controller**: the validating webhook
  (`modeldeployment_webhook.go`) skips the GPU `CheckProviderCompatibility` branch and the
  disaggregated `gpu.count > 0` checks when the mocker annotation is present on a `dynamo`
  deployment, while still rejecting non-`vllm` engines at admission. `ModelDeploymentReconciler.validateSpec`
  applies the same bypass via a shared `isDynamoMockerMode` helper, and `reconcileGateway` skips
  gateway reconciliation entirely in mocker mode so it never waits on a provider-managed
  `InferencePool` that mocker mode intentionally does not create.
- **Tests**: added `providers/dynamo/mocker_test.go` (aggregated + disaggregated transform,
  resources, args), `inject_annotation_test.go`, controller `validate_spec_test.go` and
  `gateway_reconciler_test.go` cases, and webhook test cases for CPU-only acceptance and non-`vllm`
  rejection. New gated E2E (`//go:build e2e`, `DYNAMO_MOCKER=true`) in
  `dynamo_mocker_e2e_test.go` covering both serving modes, with a new generic disaggregated
  fixture `dynamo-disagg-modeldeployment.yaml` reused by both the GPU and mocker suites.
- **Build/CI**: added `setup-dynamo-mocker` and `test-e2e-mocker` targets to
  `providers/dynamo/Makefile` and a new CPU-only kind-based workflow
  `.github/workflows/e2e-dynamo-mocker.yml`.

## Testing

- [x] Unit tests pass (provider `go test ./...`, controller `go test ./...`, webhook tests)
- [x] Manual testing performed (end-to-end against a CPU cluster: DGD `status.state=successful`,
  MD `status.phase=Running`, `/v1/chat/completions` returns valid OpenAI-compatible JSON, no GPU
  resource requests, for both aggregated and disaggregated fixtures)
- [x] Tested with a Kubernetes cluster (new `e2e-dynamo-mocker` CI lane on kind)

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `bun run lint` (Go-only change; ran `gofmt` + `go vet`)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Additional Notes

Mocker mode is strictly test-only and gated behind an annotation — no CRD/API changes and no
impact on the default GPU path. Gateway/EPP/GAIE mocker support and the `v1alpha1`→`v1beta1`
migration are out of scope (per the issue). The existing GPU Dynamo E2E (`DYNAMO_INSTALLED=true`)
remains unchanged for self-hosted runners.
