### PR TITLE
feat: estimate inference throughput for models on cluster GPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,6 @@ providers/*/bin/
 frontend/test-results/
 frontend/playwright-report/
 frontend/blob-report/
+.playwright-mcp/
 
 docs/ignore

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,0 +1,36 @@
+// Flat ESLint config (ESLint v9+). Replaces the old .eslintrc + `--ext` flow,
+// which ESLint v9 removed. TypeScript is linted via the typescript-eslint
+// plugin's `flat/recommended` preset, which bundles the parser, the plugin, and
+// a non-type-checked rule set (fast, low false-positive noise).
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
+
+export default [
+  // Only application source is linted (mirrors the previous `eslint src` scope).
+  {
+    ignores: ['dist/**', 'node_modules/**', '*.config.*', 'coverage/**'],
+  },
+
+  // typescript-eslint's flat/recommended turns off core rules that clash with
+  // TS (e.g. no-undef), wires up the parser, and enables the recommended rules.
+  ...tseslint.configs['flat/recommended'],
+
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tsparser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    rules: {
+      // Pre-existing debt: this codebase predates any ESLint config (the v8→v10
+      // bump first introduced one), so `recommended` surfaces ~120 historical
+      // violations of these two rules — none in newly-written code. Demote them
+      // to warnings so lint is green and CI-usable today, while still surfacing
+      // the backlog for incremental burndown. Promote back to "error" once the
+      // existing hits are cleared.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
+  },
+];

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "compile:darwin-x64": "bun run scripts/compile.ts --target=bun-darwin-x64 --outfile=airunway-darwin-x64",
     "compile:darwin-arm64": "bun run scripts/compile.ts --target=bun-darwin-arm64 --outfile=airunway-darwin-arm64",
     "compile:windows-x64": "bun run scripts/compile.ts --target=bun-windows-x64 --outfile=airunway-windows-x64.exe",
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint src",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage"
@@ -33,6 +33,8 @@
     "@types/bun": "latest",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.1",
+    "@typescript-eslint/eslint-plugin": "^8.60.0",
+    "@typescript-eslint/parser": "^8.60.0",
     "eslint": "^10.4.0",
     "pino-pretty": "^13.1.3",
     "typescript": "6.0.3"

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -3,6 +3,7 @@ import { PINNED_GAIE_VERSION } from '@airunway/shared';
 import app from '../hono-app';
 import { kubernetesService } from '../services/kubernetes';
 import { helmService } from '../services/helm';
+import { huggingFaceService } from '../services/huggingface';
 import { mockServiceMethod } from '../test/helpers';
 import {
   mockInferenceProviderConfig,
@@ -1165,6 +1166,69 @@ describe('Gateway Installation Routes', () => {
 
       const res = await app.request('/api/installation/gpu-throughput?gpuModel=A100-80GB');
       expect(res.status).toBe(404);
+    });
+
+    test('flags doesNotFit when model weights exceed available VRAM', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        // Valid architecture so capacity is high-confidence (not lowConfidence).
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
+          numLayers: 80,
+          numKvHeads: 8,
+          headDim: 128,
+        })),
+      );
+
+      // ~200B params in bf16 (2 bytes) → ~400GB weights; even split across the
+      // A100 pool's 2 GPUs/node leaves ~200GB/GPU, far exceeding 80GB VRAM.
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=A100-80GB&modelId=org/huge&paramCount=200000000000&quantization=bf16',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.doesNotFit).toBe(true);
+      expect(data.concurrentSequences).toBe(0);
+      expect(data.lowConfidence).toBe(false);
+    });
+
+    test('caps inferred context length at the model max when no contextLen is provided', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        // Model advertises a 1M-token window but caller sends no contextLen.
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
+          numLayers: 80,
+          numKvHeads: 8,
+          headDim: 128,
+          maxPositionEmbeddings: 1_000_000,
+        })),
+      );
+
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=org/long-ctx&paramCount=8000000000&quantization=bf16',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      // Falls back to maxPositionEmbeddings but capped at MAX_INFERRED_CONTEXT_LEN (32768).
+      expect(data.contextLen).toBe(32768);
+    });
+
+    test('respects an explicit contextLen query param over the model max', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
+          numLayers: 80,
+          numKvHeads: 8,
+          headDim: 128,
+          maxPositionEmbeddings: 1_000_000,
+        })),
+      );
+
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=org/long-ctx&paramCount=8000000000&quantization=bf16&contextLen=8192',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.contextLen).toBe(8192);
     });
   });
 });

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1168,6 +1168,55 @@ describe('Gateway Installation Routes', () => {
       expect(res.status).toBe(404);
     });
 
+    test('returns 404 when the only pool runs a GPU absent from the static spec table', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => ({
+          totalGpus: 8,
+          allocatedGpus: 0,
+          availableGpus: 8,
+          maxContiguousAvailable: 8,
+          maxNodeGpuCapacity: 8,
+          gpuNodeCount: 1,
+          totalMemoryGb: 0,
+          // A brand-new / unsupported GPU label. It must be treated as unknown
+          // (skipped) rather than silently coerced to an A10 estimate.
+          nodePools: [
+            { name: 'b200-pool', gpuCount: 8, nodeCount: 1, availableGpus: 8, gpuModel: 'NVIDIA-B200-192GB' },
+          ],
+        })),
+      );
+
+      const res = await app.request('/api/installation/gpu-throughput?gpuModel=NVIDIA-B200-192GB');
+      expect(res.status).toBe(404);
+    });
+
+    test('skips an unknown-GPU pool and estimates on the known pool instead', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => ({
+          totalGpus: 16,
+          allocatedGpus: 0,
+          availableGpus: 16,
+          maxContiguousAvailable: 8,
+          maxNodeGpuCapacity: 8,
+          gpuNodeCount: 2,
+          totalMemoryGb: 0,
+          // Mixed cluster: one unrecognized GPU pool + one known A100 pool. The
+          // unknown pool must be skipped so the estimate resolves to the A100,
+          // never an A10 substitution for the B200.
+          nodePools: [
+            { name: 'b200-pool', gpuCount: 8, nodeCount: 1, availableGpus: 8, gpuModel: 'NVIDIA-B200-192GB' },
+            { name: 'a100-pool', gpuCount: 8, nodeCount: 4, availableGpus: 8, gpuModel: 'NVIDIA-A100-SXM4-80GB' },
+          ],
+        })),
+      );
+
+      const res = await app.request('/api/installation/gpu-throughput?tpSize=8');
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.gpuModel).toBe('A100-80GB');
+      expect(data.perGpuMemoryGb).toBe(80);
+    });
+
     test('flags doesNotFit when model weights exceed available VRAM', async () => {
       restores.push(
         mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
@@ -1298,7 +1347,7 @@ describe('Gateway Installation Routes', () => {
       ).toBeLessThanOrEqual(data.concurrentSequences);
     });
 
-    test('rejects a malformed modelId with 400 and never calls the HF service', async () => {
+    test('degrades to a low-confidence estimate for a malformed modelId without calling the HF service', async () => {
       let archCalls = 0;
       restores.push(
         mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
@@ -1308,11 +1357,43 @@ describe('Gateway Installation Routes', () => {
         }),
       );
 
+      // A malformed id (path-traversal here) no longer hard-400s: paramCount is
+      // enough for a bandwidth-only estimate. Security is preserved by gating the
+      // token-bearing HF fetch on isValidHfRepoId, so the id never reaches it.
       const res = await app.request(
         '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=../../etc/passwd&paramCount=8000000000',
       );
-      // zValidator rejects the bad id before the handler runs.
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      // No arch → low-confidence, per-chat-only (no concurrency number).
+      expect(data.lowConfidence).toBe(true);
+      expect(data.perChatTokensPerSec).toBeGreaterThan(0);
+      expect(data.concurrentSequences).toBeUndefined();
+      // Security: the invalid id must never trigger a token-bearing HF request.
+      expect(archCalls).toBe(0);
+    });
+
+    test('produces a param-count-only estimate for a non-HF custom modelId without calling the HF service', async () => {
+      let archCalls = 0;
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => {
+          archCalls += 1;
+          return undefined;
+        }),
+      );
+
+      // A curated/custom id that is valid for Airunway but not a HuggingFace repo
+      // (three path segments) must not 400 — it degrades to the bandwidth-only
+      // estimate from paramCount and skips the HF architecture lookup entirely.
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=catalog/custom/model&paramCount=8000000000',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.lowConfidence).toBe(true);
+      expect(data.perChatTokensPerSec).toBeGreaterThan(0);
+      expect(data.concurrentSequences).toBeUndefined();
       expect(archCalls).toBe(0);
     });
 

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1230,5 +1230,51 @@ describe('Gateway Installation Routes', () => {
       const data = await res.json();
       expect(data.contextLen).toBe(8192);
     });
+
+    test('reports fp8Supported=true for a Hopper GPU', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
+          numLayers: 80,
+          numKvHeads: 8,
+          headDim: 128,
+        })),
+      );
+
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=org/m&paramCount=8000000000',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.fp8Supported).toBe(true);
+      // aggregate ≈ concurrentSequences × perChatTokensPerSec (single-stream rate).
+      // The response rounds perChat, so allow a small rounding margin.
+      expect(data.aggregateTokensPerSec).toBeGreaterThan(0);
+      expect(
+        Math.abs(data.aggregateTokensPerSec - data.concurrentSequences * data.perChatTokensPerSec)
+      ).toBeLessThanOrEqual(data.concurrentSequences);
+    });
+
+    test('reports fp8Supported=false for a non-Hopper GPU', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
+          numLayers: 80,
+          numKvHeads: 8,
+          headDim: 128,
+        })),
+      );
+
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=A100-80GB&modelId=org/m&paramCount=8000000000',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.fp8Supported).toBe(false);
+      expect(data.aggregateTokensPerSec).toBeGreaterThan(0);
+      expect(
+        Math.abs(data.aggregateTokensPerSec - data.concurrentSequences * data.perChatTokensPerSec)
+      ).toBeLessThanOrEqual(data.concurrentSequences);
+    });
   });
 });

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1276,5 +1276,39 @@ describe('Gateway Installation Routes', () => {
         Math.abs(data.aggregateTokensPerSec - data.concurrentSequences * data.perChatTokensPerSec)
       ).toBeLessThanOrEqual(data.concurrentSequences);
     });
+
+    test('rejects a malformed modelId with 400 and never calls the HF service', async () => {
+      let archCalls = 0;
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => {
+          archCalls += 1;
+          return undefined;
+        }),
+      );
+
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=../../etc/passwd&paramCount=8000000000',
+      );
+      // zValidator rejects the bad id before the handler runs.
+      expect(res.status).toBe(400);
+      expect(archCalls).toBe(0);
+    });
+
+    test('accepts a well-formed modelId (200)', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
+          numLayers: 80,
+          numKvHeads: 8,
+          headDim: 128,
+        })),
+      );
+
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=meta-llama/Meta-Llama-3-70B&paramCount=8000000000',
+      );
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1301,7 +1301,7 @@ describe('Gateway Installation Routes', () => {
       expect(data.contextLen).toBe(32768);
     });
 
-    test('reports fp8Supported=true for a Hopper GPU', async () => {
+    test('reports fp8Supported=true for an FP8-capable GPU', async () => {
       restores.push(
         mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
         mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
@@ -1325,7 +1325,7 @@ describe('Gateway Installation Routes', () => {
       ).toBeLessThanOrEqual(data.concurrentSequences);
     });
 
-    test('reports fp8Supported=false for a non-Hopper GPU', async () => {
+    test('reports fp8Supported=false for a GPU without an FP8 datapath', async () => {
       restores.push(
         mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
         mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1295,6 +1295,24 @@ describe('Gateway Installation Routes', () => {
       expect(archCalls).toBe(0);
     });
 
+    test('rejects a paramCount above the maximum with 400 and never estimates', async () => {
+      let archCalls = 0;
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => {
+          archCalls += 1;
+          return undefined;
+        }),
+      );
+
+      // 9T + 1 exceeds the .max(9_000_000_000_000) cap; zValidator rejects before the handler runs.
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&paramCount=9000000000001',
+      );
+      expect(res.status).toBe(400);
+      expect(archCalls).toBe(0);
+    });
+
     test('accepts a well-formed modelId (200)', async () => {
       restores.push(
         mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1080,4 +1080,91 @@ describe('Gateway Installation Routes', () => {
       expect(res.status).toBe(500);
     });
   });
+
+  // ==========================================================================
+  // GET /api/installation/gpu-throughput
+  // ==========================================================================
+  describe('GET /api/installation/gpu-throughput', () => {
+    // A cluster with two pools: a multi-node A100 pool (8 GPUs across 4 nodes =
+    // 2 per node) and a single-node H100 pool (8 GPUs on 1 node = 8 per node).
+    function mockCapacity() {
+      return {
+        totalGpus: 16,
+        allocatedGpus: 0,
+        availableGpus: 16,
+        maxContiguousAvailable: 8,
+        maxNodeGpuCapacity: 8,
+        gpuNodeCount: 5,
+        totalMemoryGb: 1280,
+        nodePools: [
+          { name: 'a100-pool', gpuCount: 8, nodeCount: 4, availableGpus: 8, gpuModel: 'NVIDIA-A100-SXM4-80GB' },
+          { name: 'h100-pool', gpuCount: 8, nodeCount: 1, availableGpus: 8, gpuModel: 'NVIDIA-H100-80GB-HBM3' },
+        ],
+      };
+    }
+
+    test('bounds tpSize and label to the requested pool per-node GPU count', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+      );
+
+      // A100 pool hosts 2 GPUs per node, so a requested tpSize=8 is clamped to 2.
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=A100-80GB&tpSize=8',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.gpuModel).toBe('A100-80GB');
+      expect(data.tpSize).toBe(2);
+      expect(data.capacityLabel).toBe('2x80 GB');
+    });
+
+    test('ignores a requested gpuModel absent from the cluster and falls back to highest-VRAM pool', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+      );
+
+      // H200 is not in any pool; should fall through to the highest-VRAM pool.
+      // A100 and H100 are both 80GB; the first-seen (A100) wins the >, so the
+      // resolved model is whichever pool has strictly greater VRAM — here equal,
+      // so the first pool (A100) is kept. Either way it must be a real pool model.
+      const res = await app.request('/api/installation/gpu-throughput?gpuModel=H200');
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(['A100-80GB', 'H100-80GB']).toContain(data.gpuModel);
+      // maxContiguous comes from the selected pool's per-node count (2 for A100).
+      expect(data.tpSize).toBeLessThanOrEqual(8);
+    });
+
+    test('uses per-node count for the fallback (no explicit gpuModel) path', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+      );
+
+      const res = await app.request('/api/installation/gpu-throughput?tpSize=8');
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      // Highest-VRAM pool selected (A100, first of the equal-VRAM pools): 2/node.
+      expect(data.capacityLabel).toBe('2x80 GB');
+      expect(data.tpSize).toBe(2);
+    });
+
+    test('returns 404 when no pool maps to a known GPU spec', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => ({
+          totalGpus: 0,
+          allocatedGpus: 0,
+          availableGpus: 0,
+          maxContiguousAvailable: 0,
+          maxNodeGpuCapacity: 0,
+          gpuNodeCount: 0,
+          totalMemoryGb: 0,
+          nodePools: [],
+        })),
+      );
+
+      const res = await app.request('/api/installation/gpu-throughput?gpuModel=A100-80GB');
+      expect(res.status).toBe(404);
+    });
+  });
 });

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1208,7 +1208,7 @@ describe('Gateway Installation Routes', () => {
       );
       expect(res.status).toBe(200);
       const data = await res.json();
-      // Falls back to maxPositionEmbeddings but capped at MAX_INFERRED_CONTEXT_LEN (32768).
+      // Falls back to maxPositionEmbeddings but capped at MAX_CONTEXT_LEN (32768).
       expect(data.contextLen).toBe(32768);
     });
 
@@ -1229,6 +1229,27 @@ describe('Gateway Installation Routes', () => {
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(data.contextLen).toBe(8192);
+    });
+
+    test('caps an explicit contextLen that exceeds the max', async () => {
+      restores.push(
+        mockServiceMethod(kubernetesService, 'getDetailedClusterGpuCapacity', async () => mockCapacity()),
+        mockServiceMethod(huggingFaceService, 'getModelArchitecture', async () => ({
+          numLayers: 80,
+          numKvHeads: 8,
+          headDim: 128,
+          maxPositionEmbeddings: 1_000_000,
+        })),
+      );
+
+      // A caller forwarding a model's huge advertised window (here 256K) must be
+      // clamped to MAX_CONTEXT_LEN so the concurrency estimate doesn't collapse.
+      const res = await app.request(
+        '/api/installation/gpu-throughput?gpuModel=H100-80GB&modelId=org/long-ctx&paramCount=8000000000&quantization=bf16&contextLen=262144',
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.contextLen).toBe(32768);
     });
 
     test('reports fp8Supported=true for a Hopper GPU', async () => {

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { kubernetesService } from '../services/kubernetes';
 import { helmService } from '../services/helm';
 import { getProviderHealth } from '../services/providerHealth';
-import { getGpuInfo, normalizeGpuModel, gpuSupportsFp8 } from '../services/costEstimation';
+import { getKnownGpuInfo, normalizeKnownGpuModel, gpuSupportsFp8 } from '../services/costEstimation';
 import { huggingFaceService, isValidHfRepoId } from '../services/huggingface';
 import {
   bytesPerWeightFor,
@@ -43,12 +43,13 @@ const MAX_CONTEXT_LEN = 32768;
 
 /** Query schema for GET /gpu-throughput. */
 const gpuThroughputQuerySchema = z.object({
-  modelId: z
-    .string()
-    .min(1)
-    .max(200)
-    .refine(isValidHfRepoId, 'Invalid Hugging Face model id')
-    .optional(),
+  // Accept any reasonably-bounded string here rather than enforcing a valid HF
+  // repo id at the schema level. The estimate can be produced from `paramCount`
+  // alone (low-confidence, bandwidth-only), so a curated/custom model id that is
+  // valid for Airunway but not a HuggingFace repo must NOT hard-400. The handler
+  // gates the token-bearing HF architecture fetch on `isValidHfRepoId(modelId)`,
+  // so an invalid/non-HF id simply skips that lookup and degrades gracefully.
+  modelId: z.string().min(1).max(200).optional(),
   paramCount: z.coerce.number().positive().max(9_000_000_000_000).optional(),
   contextLen: z.coerce.number().int().positive().max(1_048_576).optional(),
   quantization: z.enum(['fp8', 'int8', 'fp16', 'bf16']).optional(),
@@ -92,12 +93,17 @@ function selectGpuForEstimate(
 
   // 1. Explicit request: only honor it if a cluster pool actually runs that GPU
   //    model. Otherwise fall through so we never estimate for absent hardware.
-  if (requestedGpuModel) {
-    const requestedNormalized = normalizeGpuModel(requestedGpuModel);
+  //    Strict normalization: an unrecognized requested label yields `undefined`
+  //    here, so we never match it against a pool and instead fall through to the
+  //    highest-VRAM known pool (rather than coercing it to an A10).
+  const requestedNormalized = requestedGpuModel
+    ? normalizeKnownGpuModel(requestedGpuModel)
+    : undefined;
+  if (requestedNormalized) {
     const matchedPool = pools.find(
-      (p) => normalizeGpuModel(p.gpuModel as string) === requestedNormalized
+      (p) => normalizeKnownGpuModel(p.gpuModel as string) === requestedNormalized
     );
-    const info = matchedPool ? getGpuInfo(matchedPool.gpuModel as string) : undefined;
+    const info = matchedPool ? getKnownGpuInfo(matchedPool.gpuModel as string) : undefined;
     if (matchedPool && info) {
       const perNode = perNodeGpuCount(matchedPool);
       return {
@@ -110,15 +116,17 @@ function selectGpuForEstimate(
     }
   }
 
-  // 2. Otherwise choose the pool with the most per-GPU VRAM.
+  // 2. Otherwise choose the pool with the most per-GPU VRAM. Pools whose GPU
+  //    label isn't in our static spec table are skipped (getKnownGpuInfo →
+  //    undefined) so an unknown GPU is never silently estimated as an A10.
   let best: GpuEstimateSelection | undefined;
   for (const pool of pools) {
-    const info = getGpuInfo(pool.gpuModel as string);
+    const info = getKnownGpuInfo(pool.gpuModel as string);
     if (!info) continue;
     if (!best || info.memoryGb > best.perGpuMemoryGb) {
       const perNode = perNodeGpuCount(pool);
       best = {
-        resolvedGpuModel: normalizeGpuModel(pool.gpuModel as string),
+        resolvedGpuModel: normalizeKnownGpuModel(pool.gpuModel as string) as string,
         perGpuMemoryGb: info.memoryGb,
         memBandwidthGBs: info.memBandwidthGBs,
         capacityLabel: `${perNode}x${info.memoryGb} GB`,
@@ -354,8 +362,14 @@ const installation = new Hono()
     });
 
     // Architecture details (config.json) are needed for the concurrency number;
-    // degrade gracefully to per-chat-only when unavailable.
-    const arch = modelId ? await huggingFaceService.getModelArchitecture(modelId, hfToken) : undefined;
+    // degrade gracefully to per-chat-only when unavailable. Only a valid HF repo
+    // id triggers the token-bearing fetch — a curated/custom id (valid for
+    // Airunway but not a HuggingFace repo) skips the lookup and still produces
+    // the bandwidth-only estimate from `paramCount` instead of erroring.
+    const arch =
+      modelId && isValidHfRepoId(modelId)
+        ? await huggingFaceService.getModelArchitecture(modelId, hfToken)
+        : undefined;
 
     // Resolve the context length used for KV sizing *after* fetching arch, so
     // HuggingFace models (which carry no explicit contextLen) use their real

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -6,7 +6,7 @@ import { kubernetesService } from '../services/kubernetes';
 import { helmService } from '../services/helm';
 import { getProviderHealth } from '../services/providerHealth';
 import { getGpuInfo, normalizeGpuModel, gpuSupportsFp8 } from '../services/costEstimation';
-import { huggingFaceService } from '../services/huggingface';
+import { huggingFaceService, isValidHfRepoId } from '../services/huggingface';
 import {
   bytesPerWeightFor,
   bytesPerKvFor,
@@ -40,7 +40,12 @@ const MAX_INFERRED_CONTEXT_LEN = 32768;
 
 /** Query schema for GET /gpu-throughput. */
 const gpuThroughputQuerySchema = z.object({
-  modelId: z.string().min(1).optional(),
+  modelId: z
+    .string()
+    .min(1)
+    .max(200)
+    .refine(isValidHfRepoId, 'Invalid Hugging Face model id')
+    .optional(),
   paramCount: z.coerce.number().positive().optional(),
   contextLen: z.coerce.number().int().positive().max(1_048_576).optional(),
   quantization: z.enum(['fp8', 'int8', 'fp16', 'bf16']).optional(),

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -322,18 +322,19 @@ const installation = new Hono()
     const effectiveTpSize = Math.max(1, Math.min(requestedTpSize, maxContiguous || requestedTpSize || 1));
 
     // KV-cache precision is independent of weight quantization. Default to
-    // fp16/bf16 (2 bytes); an explicit fp8 KV cache is only realistic on Hopper,
-    // so downgrade fp8 → fp16 on older generations for the estimate. (int8 KV is
-    // not an FP8-datapath concern, so it is honored on any GPU.)
+    // fp16/bf16 (2 bytes); an explicit fp8 KV cache is only realistic on GPUs
+    // with a native FP8 datapath (Ada Lovelace and Hopper), so downgrade
+    // fp8 → fp16 on older generations for the estimate. (int8 KV is not an
+    // FP8-datapath concern, so it is honored on any GPU.)
     let effectiveKvDtype: 'fp8' | 'int8' | 'fp16' | 'bf16' = kvCacheDtype ?? 'fp16';
     if (effectiveKvDtype === 'fp8' && !gpuSupportsFp8(resolvedGpuModel)) {
       effectiveKvDtype = 'fp16';
     }
     const bytesPerKv = bytesPerKvFor(effectiveKvDtype);
 
-    // Whether the resolved GPU has a native FP8 datapath (Hopper). Surfaced so
-    // the UI can block FP8 deployments on non-Hopper hardware without
-    // re-implementing the GPU→generation mapping client-side.
+    // Whether the resolved GPU has a native FP8 datapath (Ada Lovelace or
+    // Hopper). Surfaced so the UI can block FP8 deployments on non-FP8 hardware
+    // without re-implementing the GPU→generation mapping client-side.
     const fp8Supported = gpuSupportsFp8(resolvedGpuModel);
 
     // paramCount is required to compute anything; without it return a shaped

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -329,6 +329,7 @@ const installation = new Hono()
       paramCount,
       bytesPerWeight,
       memBandwidthGBs,
+      tpSize: effectiveTpSize,
     });
 
     // Architecture details (config.json) are needed for the concurrency number;

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -12,7 +12,7 @@ import {
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
 } from '../services/gpuPerformance';
-import type { GpuThroughputEstimate } from '@airunway/shared';
+import type { GpuThroughputEstimate, NodePoolInfo } from '@airunway/shared';
 import logger from '../lib/logger';
 import { aggregateRequiresCRDFromCapabilities, getAnnotatedProviderDisplayName, getProviderDisplayName, providerRequiresRuntimeCRD } from '../lib/providers';
 
@@ -49,9 +49,23 @@ interface GpuEstimateSelection {
 }
 
 /**
+ * GPUs hosted on a single node of this pool, i.e. the most GPUs that can back a
+ * single replica (tensor-parallel group). Pools report `gpuCount` as the total
+ * across all nodes, so divide by `nodeCount` (assuming homogeneous pools).
+ */
+function perNodeGpuCount(pool: NodePoolInfo): number {
+  if (!pool.nodeCount || pool.nodeCount <= 0) return pool.gpuCount || 1;
+  return Math.max(1, Math.floor(pool.gpuCount / pool.nodeCount));
+}
+
+/**
  * Pick the node pool / GPU model to base the throughput estimate on. Prefers a
  * pool matching an explicitly-requested gpuModel, else the highest-VRAM GPU
  * pool. Returns undefined when no pool maps to a GPU we have specs for.
+ *
+ * `maxContiguous` is the per-node GPU count of the selected pool (not a
+ * cluster-wide or pool-total value) so it correctly bounds the per-replica
+ * tensor-parallel size.
  */
 function selectGpuForEstimate(
   capacity: Awaited<ReturnType<typeof kubernetesService.getDetailedClusterGpuCapacity>>,
@@ -59,18 +73,22 @@ function selectGpuForEstimate(
 ): GpuEstimateSelection | undefined {
   const pools = (capacity.nodePools || []).filter((p) => p.gpuModel);
 
-  // 1. Explicit request: resolve directly from the GPU spec table.
+  // 1. Explicit request: only honor it if a cluster pool actually runs that GPU
+  //    model. Otherwise fall through so we never estimate for absent hardware.
   if (requestedGpuModel) {
-    const info = getGpuInfo(requestedGpuModel);
-    if (info) {
+    const requestedNormalized = normalizeGpuModel(requestedGpuModel);
+    const matchedPool = pools.find(
+      (p) => normalizeGpuModel(p.gpuModel as string) === requestedNormalized
+    );
+    const info = matchedPool ? getGpuInfo(matchedPool.gpuModel as string) : undefined;
+    if (matchedPool && info) {
+      const perNode = perNodeGpuCount(matchedPool);
       return {
-        resolvedGpuModel: normalizeGpuModel(requestedGpuModel),
+        resolvedGpuModel: requestedNormalized,
         perGpuMemoryGb: info.memoryGb,
         memBandwidthGBs: info.memBandwidthGBs,
-        capacityLabel: capacity.maxContiguousAvailable
-          ? `${capacity.maxContiguousAvailable}x${info.memoryGb} GB`
-          : undefined,
-        maxContiguous: capacity.maxContiguousAvailable || capacity.maxNodeGpuCapacity || 1,
+        capacityLabel: `${perNode}x${info.memoryGb} GB`,
+        maxContiguous: perNode,
       };
     }
   }
@@ -81,12 +99,13 @@ function selectGpuForEstimate(
     const info = getGpuInfo(pool.gpuModel as string);
     if (!info) continue;
     if (!best || info.memoryGb > best.perGpuMemoryGb) {
+      const perNode = perNodeGpuCount(pool);
       best = {
         resolvedGpuModel: normalizeGpuModel(pool.gpuModel as string),
         perGpuMemoryGb: info.memoryGb,
         memBandwidthGBs: info.memBandwidthGBs,
-        capacityLabel: `${pool.gpuCount}x${info.memoryGb} GB`,
-        maxContiguous: capacity.maxContiguousAvailable || pool.gpuCount || 1,
+        capacityLabel: `${perNode}x${info.memoryGb} GB`,
+        maxContiguous: perNode,
       };
     }
   }

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -166,7 +166,9 @@ function extractProviderDetails(config: any) {
     defaultNamespace: installation.defaultNamespace || 'default',
     requiresCRD: providerRequiresRuntimeCRD(name, aggregateRequiresCRDFromCapabilities(capabilities), annotatedDisplayName),
     crdConfig: {
-      apiGroup: capabilities.engines?.length ? '' : '',
+      // The real CRD apiGroup isn't stored on the InferenceProviderConfig, so we
+      // can't derive it here; emit an empty string to satisfy the CRDConfig type.
+      apiGroup: '',
     },
     helmRepos: (installation.helmRepos || []).map((r: any) => ({
       name: r.name,

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -5,10 +5,11 @@ import { z } from 'zod';
 import { kubernetesService } from '../services/kubernetes';
 import { helmService } from '../services/helm';
 import { getProviderHealth } from '../services/providerHealth';
-import { getGpuInfo, normalizeGpuModel } from '../services/costEstimation';
+import { getGpuInfo, normalizeGpuModel, gpuSupportsFp8 } from '../services/costEstimation';
 import { huggingFaceService } from '../services/huggingface';
 import {
   bytesPerWeightFor,
+  bytesPerKvFor,
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
 } from '../services/gpuPerformance';
@@ -43,6 +44,7 @@ const gpuThroughputQuerySchema = z.object({
   paramCount: z.coerce.number().positive().optional(),
   contextLen: z.coerce.number().int().positive().max(1_048_576).optional(),
   quantization: z.enum(['fp8', 'int8', 'fp16', 'bf16']).optional(),
+  kvCacheDtype: z.enum(['fp8', 'int8', 'fp16', 'bf16']).optional(),
   gpuModel: z.string().min(1).optional(),
   tpSize: z.coerce.number().int().positive().max(64).optional(),
 });
@@ -268,7 +270,7 @@ const installation = new Hono()
     return c.json(capacity);
   })
   .get('/gpu-throughput', zValidator('query', gpuThroughputQuerySchema), async (c) => {
-    const { modelId, paramCount, contextLen, quantization, gpuModel, tpSize } = c.req.valid('query');
+    const { modelId, paramCount, contextLen, quantization, kvCacheDtype, gpuModel, tpSize } = c.req.valid('query');
     const hfToken = c.req.header('X-HF-Token') || undefined;
 
     // Resolve the node pool / GPU model to estimate for.
@@ -285,6 +287,21 @@ const installation = new Hono()
     const effectiveTpSize = Math.max(1, Math.min(tpSize ?? 1, maxContiguous || tpSize || 1));
     const bytesPerWeight = bytesPerWeightFor(quantization);
 
+    // KV-cache precision is independent of weight quantization. Default to
+    // fp16/bf16 (2 bytes); an explicit fp8 KV cache is only realistic on Hopper,
+    // so downgrade fp8 → fp16 on older generations for the estimate. (int8 KV is
+    // not an FP8-datapath concern, so it is honored on any GPU.)
+    let effectiveKvDtype: 'fp8' | 'int8' | 'fp16' | 'bf16' = kvCacheDtype ?? 'fp16';
+    if (effectiveKvDtype === 'fp8' && !gpuSupportsFp8(resolvedGpuModel)) {
+      effectiveKvDtype = 'fp16';
+    }
+    const bytesPerKv = bytesPerKvFor(effectiveKvDtype);
+
+    // Whether the resolved GPU has a native FP8 datapath (Hopper). Surfaced so
+    // the UI can block FP8 deployments on non-Hopper hardware without
+    // re-implementing the GPU→generation mapping client-side.
+    const fp8Supported = gpuSupportsFp8(resolvedGpuModel);
+
     // paramCount is required to compute anything; without it return a shaped
     // low-confidence response rather than guessing.
     if (!paramCount || paramCount <= 0) {
@@ -295,6 +312,8 @@ const installation = new Hono()
         memBandwidthGBs,
         tpSize: effectiveTpSize,
         contextLen: contextLen ?? DEFAULT_CONTEXT_LEN,
+        kvCacheDtype: effectiveKvDtype,
+        fp8Supported,
         capacityLabel,
         lowConfidence: true,
       };
@@ -329,6 +348,7 @@ const installation = new Hono()
           tpSize: effectiveTpSize,
           contextLen: resolvedContextLen,
           bytesPerWeight,
+          bytesPerKv,
           perChatTokensPerSec,
         })
       : undefined;
@@ -342,6 +362,8 @@ const installation = new Hono()
       memBandwidthGBs,
       tpSize: effectiveTpSize,
       contextLen: resolvedContextLen,
+      kvCacheDtype: effectiveKvDtype,
+      fp8Supported,
       capacityLabel,
       lowConfidence: !capacityResult,
       // High-confidence "model does not fit": arch was available and KV budget

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -46,7 +46,7 @@ const gpuThroughputQuerySchema = z.object({
     .max(200)
     .refine(isValidHfRepoId, 'Invalid Hugging Face model id')
     .optional(),
-  paramCount: z.coerce.number().positive().optional(),
+  paramCount: z.coerce.number().positive().max(9_000_000_000_000).optional(),
   contextLen: z.coerce.number().int().positive().max(1_048_576).optional(),
   quantization: z.enum(['fp8', 'int8', 'fp16', 'bf16']).optional(),
   kvCacheDtype: z.enum(['fp8', 'int8', 'fp16', 'bf16']).optional(),

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -10,6 +10,7 @@ import { huggingFaceService, isValidHfRepoId } from '../services/huggingface';
 import {
   bytesPerWeightFor,
   bytesPerKvFor,
+  deriveTpSizeToFitWeights,
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
 } from '../services/gpuPerformance';
@@ -288,9 +289,25 @@ const installation = new Hono()
     }
     const { resolvedGpuModel, perGpuMemoryGb, memBandwidthGBs, capacityLabel, maxContiguous } = selection;
 
-    // TP size = GPUs per replica, bounded by what a single node can host.
-    const effectiveTpSize = Math.max(1, Math.min(tpSize ?? 1, maxContiguous || tpSize || 1));
     const bytesPerWeight = bytesPerWeightFor(quantization);
+
+    // TP size = GPUs per replica, bounded by what a single node can host. An
+    // explicit request (deployment form, curated cards carrying minGpus) is
+    // honored as-is. When omitted — notably HuggingFace search cards, whose
+    // model objects carry no minGpus hint — derive the smallest TP size whose
+    // weight shard still leaves room for a KV cache, so a large model is
+    // estimated at a topology that fits (e.g. tp=2 on 80 GB) instead of
+    // defaulting to tp=1 and spuriously reporting "does not fit" while the
+    // curated/Deploy tabs show full capacity for the same model and cluster.
+    const requestedTpSize =
+      tpSize ??
+      deriveTpSizeToFitWeights({
+        paramCount: paramCount ?? 0,
+        bytesPerWeight,
+        perGpuMemoryGb,
+        maxContiguous,
+      });
+    const effectiveTpSize = Math.max(1, Math.min(requestedTpSize, maxContiguous || requestedTpSize || 1));
 
     // KV-cache precision is independent of weight quantization. Default to
     // fp16/bf16 (2 bytes); an explicit fp8 KV cache is only realistic on Hopper,

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -30,6 +30,13 @@ interface ProviderHelmChartDetails {
 /** Default context length (tokens) assumed when a model doesn't specify one. */
 const DEFAULT_CONTEXT_LEN = 4096;
 
+/**
+ * Cap applied to a model's advertised max context length when used to size KV
+ * cache. Some models advertise very large windows (128K–1M); serving rarely uses
+ * the full window, and using it would collapse concurrency estimates to ~zero.
+ */
+const MAX_INFERRED_CONTEXT_LEN = 32768;
+
 /** Query schema for GET /gpu-throughput. */
 const gpuThroughputQuerySchema = z.object({
   modelId: z.string().min(1).optional(),
@@ -300,18 +307,27 @@ const installation = new Hono()
       memBandwidthGBs,
     });
 
-    const effectiveContextLen = contextLen ?? DEFAULT_CONTEXT_LEN;
-
     // Architecture details (config.json) are needed for the concurrency number;
     // degrade gracefully to per-chat-only when unavailable.
     const arch = modelId ? await huggingFaceService.getModelArchitecture(modelId, hfToken) : undefined;
+
+    // Resolve the context length used for KV sizing *after* fetching arch, so
+    // HuggingFace models (which carry no explicit contextLen) use their real
+    // advertised window (capped) rather than the 4K default. An explicit query
+    // param always wins; otherwise fall back to the model's max, capped.
+    const resolvedContextLen = contextLen
+      ? contextLen
+      : arch?.maxPositionEmbeddings
+        ? Math.min(arch.maxPositionEmbeddings, MAX_INFERRED_CONTEXT_LEN)
+        : DEFAULT_CONTEXT_LEN;
+
     const capacityResult = arch
       ? estimateConcurrentCapacity({
           paramCount,
           arch,
           perGpuMemoryGb,
           tpSize: effectiveTpSize,
-          contextLen: effectiveContextLen,
+          contextLen: resolvedContextLen,
           bytesPerWeight,
           perChatTokensPerSec,
         })
@@ -325,9 +341,12 @@ const installation = new Hono()
       perGpuMemoryGb,
       memBandwidthGBs,
       tpSize: effectiveTpSize,
-      contextLen: effectiveContextLen,
+      contextLen: resolvedContextLen,
       capacityLabel,
       lowConfidence: !capacityResult,
+      // High-confidence "model does not fit": arch was available and KV budget
+      // left no room for even a single sequence.
+      doesNotFit: capacityResult ? capacityResult.concurrentSequences === 0 : undefined,
     };
     return c.json(estimate);
   })

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -1,8 +1,18 @@
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
 import { kubernetesService } from '../services/kubernetes';
 import { helmService } from '../services/helm';
 import { getProviderHealth } from '../services/providerHealth';
+import { getGpuInfo, normalizeGpuModel } from '../services/costEstimation';
+import { huggingFaceService } from '../services/huggingface';
+import {
+  bytesPerWeightFor,
+  estimatePerChatTokensPerSec,
+  estimateConcurrentCapacity,
+} from '../services/gpuPerformance';
+import type { GpuThroughputEstimate } from '@airunway/shared';
 import logger from '../lib/logger';
 import { aggregateRequiresCRDFromCapabilities, getAnnotatedProviderDisplayName, getProviderDisplayName, providerRequiresRuntimeCRD } from '../lib/providers';
 
@@ -15,6 +25,72 @@ interface ProviderHelmChartDetails {
   values?: Record<string, unknown>;
   preInstallMissingCrds?: boolean;
   skipCrds?: boolean;
+}
+
+/** Default context length (tokens) assumed when a model doesn't specify one. */
+const DEFAULT_CONTEXT_LEN = 4096;
+
+/** Query schema for GET /gpu-throughput. */
+const gpuThroughputQuerySchema = z.object({
+  modelId: z.string().min(1).optional(),
+  paramCount: z.coerce.number().positive().optional(),
+  contextLen: z.coerce.number().int().positive().max(1_048_576).optional(),
+  quantization: z.enum(['fp8', 'int8', 'fp16', 'bf16']).optional(),
+  gpuModel: z.string().min(1).optional(),
+  tpSize: z.coerce.number().int().positive().max(64).optional(),
+});
+
+interface GpuEstimateSelection {
+  resolvedGpuModel: string;
+  perGpuMemoryGb: number;
+  memBandwidthGBs: number;
+  capacityLabel?: string;
+  maxContiguous: number;
+}
+
+/**
+ * Pick the node pool / GPU model to base the throughput estimate on. Prefers a
+ * pool matching an explicitly-requested gpuModel, else the highest-VRAM GPU
+ * pool. Returns undefined when no pool maps to a GPU we have specs for.
+ */
+function selectGpuForEstimate(
+  capacity: Awaited<ReturnType<typeof kubernetesService.getDetailedClusterGpuCapacity>>,
+  requestedGpuModel?: string
+): GpuEstimateSelection | undefined {
+  const pools = (capacity.nodePools || []).filter((p) => p.gpuModel);
+
+  // 1. Explicit request: resolve directly from the GPU spec table.
+  if (requestedGpuModel) {
+    const info = getGpuInfo(requestedGpuModel);
+    if (info) {
+      return {
+        resolvedGpuModel: normalizeGpuModel(requestedGpuModel),
+        perGpuMemoryGb: info.memoryGb,
+        memBandwidthGBs: info.memBandwidthGBs,
+        capacityLabel: capacity.maxContiguousAvailable
+          ? `${capacity.maxContiguousAvailable}x${info.memoryGb} GB`
+          : undefined,
+        maxContiguous: capacity.maxContiguousAvailable || capacity.maxNodeGpuCapacity || 1,
+      };
+    }
+  }
+
+  // 2. Otherwise choose the pool with the most per-GPU VRAM.
+  let best: GpuEstimateSelection | undefined;
+  for (const pool of pools) {
+    const info = getGpuInfo(pool.gpuModel as string);
+    if (!info) continue;
+    if (!best || info.memoryGb > best.perGpuMemoryGb) {
+      best = {
+        resolvedGpuModel: normalizeGpuModel(pool.gpuModel as string),
+        perGpuMemoryGb: info.memoryGb,
+        memBandwidthGBs: info.memBandwidthGBs,
+        capacityLabel: `${pool.gpuCount}x${info.memoryGb} GB`,
+        maxContiguous: capacity.maxContiguousAvailable || pool.gpuCount || 1,
+      };
+    }
+  }
+  return best;
 }
 
 /**
@@ -164,6 +240,77 @@ const installation = new Hono()
   .get('/gpu-capacity/detailed', async (c) => {
     const capacity = await kubernetesService.getDetailedClusterGpuCapacity();
     return c.json(capacity);
+  })
+  .get('/gpu-throughput', zValidator('query', gpuThroughputQuerySchema), async (c) => {
+    const { modelId, paramCount, contextLen, quantization, gpuModel, tpSize } = c.req.valid('query');
+    const hfToken = c.req.header('X-HF-Token') || undefined;
+
+    // Resolve the node pool / GPU model to estimate for.
+    const capacity = await kubernetesService.getDetailedClusterGpuCapacity();
+    const selection = selectGpuForEstimate(capacity, gpuModel);
+    if (!selection) {
+      throw new HTTPException(404, {
+        message: 'No GPU node pool with known specs found in the cluster.',
+      });
+    }
+    const { resolvedGpuModel, perGpuMemoryGb, memBandwidthGBs, capacityLabel, maxContiguous } = selection;
+
+    // TP size = GPUs per replica, bounded by what a single node can host.
+    const effectiveTpSize = Math.max(1, Math.min(tpSize ?? 1, maxContiguous || tpSize || 1));
+    const bytesPerWeight = bytesPerWeightFor(quantization);
+
+    // paramCount is required to compute anything; without it return a shaped
+    // low-confidence response rather than guessing.
+    if (!paramCount || paramCount <= 0) {
+      const empty: GpuThroughputEstimate = {
+        perChatTokensPerSec: 0,
+        gpuModel: resolvedGpuModel,
+        perGpuMemoryGb,
+        memBandwidthGBs,
+        tpSize: effectiveTpSize,
+        contextLen: contextLen ?? DEFAULT_CONTEXT_LEN,
+        capacityLabel,
+        lowConfidence: true,
+      };
+      return c.json(empty);
+    }
+
+    const perChatTokensPerSec = estimatePerChatTokensPerSec({
+      paramCount,
+      bytesPerWeight,
+      memBandwidthGBs,
+    });
+
+    const effectiveContextLen = contextLen ?? DEFAULT_CONTEXT_LEN;
+
+    // Architecture details (config.json) are needed for the concurrency number;
+    // degrade gracefully to per-chat-only when unavailable.
+    const arch = modelId ? await huggingFaceService.getModelArchitecture(modelId, hfToken) : undefined;
+    const capacityResult = arch
+      ? estimateConcurrentCapacity({
+          paramCount,
+          arch,
+          perGpuMemoryGb,
+          tpSize: effectiveTpSize,
+          contextLen: effectiveContextLen,
+          bytesPerWeight,
+          perChatTokensPerSec,
+        })
+      : undefined;
+
+    const estimate: GpuThroughputEstimate = {
+      perChatTokensPerSec: Math.round(perChatTokensPerSec),
+      concurrentSequences: capacityResult?.concurrentSequences,
+      aggregateTokensPerSec: capacityResult?.aggregateTokensPerSec,
+      gpuModel: resolvedGpuModel,
+      perGpuMemoryGb,
+      memBandwidthGBs,
+      tpSize: effectiveTpSize,
+      contextLen: effectiveContextLen,
+      capacityLabel,
+      lowConfidence: !capacityResult,
+    };
+    return c.json(estimate);
   })
   .post('/gpu-operator/install', async (c) => {
     const helmStatus = await helmService.checkHelmAvailable();

--- a/backend/src/routes/installation.ts
+++ b/backend/src/routes/installation.ts
@@ -33,11 +33,13 @@ interface ProviderHelmChartDetails {
 const DEFAULT_CONTEXT_LEN = 4096;
 
 /**
- * Cap applied to a model's advertised max context length when used to size KV
- * cache. Some models advertise very large windows (128K–1M); serving rarely uses
- * the full window, and using it would collapse concurrency estimates to ~zero.
+ * Cap applied to the context length used to size KV cache. Some models advertise
+ * very large windows (128K–1M) and callers may forward that advertised value as
+ * an explicit `contextLen`; serving rarely uses the full window, and sizing KV
+ * against it would collapse concurrency estimates to ~zero. Applied to both the
+ * arch-inferred max and an explicit `contextLen` query param.
  */
-const MAX_INFERRED_CONTEXT_LEN = 32768;
+const MAX_CONTEXT_LEN = 32768;
 
 /** Query schema for GET /gpu-throughput. */
 const gpuThroughputQuerySchema = z.object({
@@ -333,7 +335,7 @@ const installation = new Hono()
         perGpuMemoryGb,
         memBandwidthGBs,
         tpSize: effectiveTpSize,
-        contextLen: contextLen ?? DEFAULT_CONTEXT_LEN,
+        contextLen: Math.min(contextLen ?? DEFAULT_CONTEXT_LEN, MAX_CONTEXT_LEN),
         kvCacheDtype: effectiveKvDtype,
         fp8Supported,
         capacityLabel,
@@ -355,13 +357,12 @@ const installation = new Hono()
 
     // Resolve the context length used for KV sizing *after* fetching arch, so
     // HuggingFace models (which carry no explicit contextLen) use their real
-    // advertised window (capped) rather than the 4K default. An explicit query
-    // param always wins; otherwise fall back to the model's max, capped.
-    const resolvedContextLen = contextLen
-      ? contextLen
-      : arch?.maxPositionEmbeddings
-        ? Math.min(arch.maxPositionEmbeddings, MAX_INFERRED_CONTEXT_LEN)
-        : DEFAULT_CONTEXT_LEN;
+    // advertised window rather than the 4K default. An explicit query param wins
+    // over the model's max; either way the value is capped at MAX_CONTEXT_LEN so
+    // a huge advertised window (which callers forward verbatim) can't collapse
+    // the concurrency estimate to ~zero.
+    const requestedContextLen = contextLen ?? arch?.maxPositionEmbeddings ?? DEFAULT_CONTEXT_LEN;
+    const resolvedContextLen = Math.min(requestedContextLen, MAX_CONTEXT_LEN);
 
     const capacityResult = arch
       ? estimateConcurrentCapacity({

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { HTTPException } from 'hono/http-exception';
-import { huggingFaceService } from '../services/huggingface';
+import { huggingFaceService, isValidHfRepoId } from '../services/huggingface';
 import models from '../data/models.json';
 import logger from '../lib/logger';
 
@@ -45,7 +45,13 @@ const modelsRoute = new Hono()
   })
   .get('/:modelId{.+}/gguf-files', async (c) => {
     const modelId = c.req.param('modelId');
-    
+
+    // Validate before any token-bearing outbound request (this is a greedy
+    // path param, so reject traversal / malformed ids up front).
+    if (!isValidHfRepoId(modelId)) {
+      throw new HTTPException(400, { message: 'Invalid Hugging Face model id' });
+    }
+
     // Extract HuggingFace token from dedicated header (not Authorization, which is for cluster auth)
     const hfToken = c.req.header('X-HF-Token') || undefined;
 

--- a/backend/src/services/costEstimation.test.ts
+++ b/backend/src/services/costEstimation.test.ts
@@ -1,11 +1,13 @@
 import { describe, test, expect } from 'bun:test';
 import {
   normalizeGpuModel,
+  normalizeKnownGpuModel,
   estimateCost,
   estimateNodePoolCosts,
   getSupportedGpuModels,
   costEstimationService,
   getGpuInfo,
+  getKnownGpuInfo,
 } from './costEstimation';
 import type { NodePoolInfo } from '@airunway/shared';
 
@@ -82,6 +84,42 @@ describe('getGpuInfo', () => {
     const info = getGpuInfo('Unknown-GPU');
     expect(info).toBeDefined();
     expect(info!.memoryGb).toBe(24);
+  });
+});
+
+describe('normalizeKnownGpuModel (strict — no A10 fallback)', () => {
+  test('returns the matched key for recognized labels', () => {
+    expect(normalizeKnownGpuModel('NVIDIA-A100-SXM4-80GB')).toBe('A100-80GB');
+    expect(normalizeKnownGpuModel('H100')).toBe('H100-80GB');
+    expect(normalizeKnownGpuModel('NVIDIA-H200-141GB-HBM3e')).toBe('H200-141GB');
+  });
+
+  test('returns undefined for unrecognized or empty labels', () => {
+    // Unlike normalizeGpuModel, an unknown GPU is NOT coerced to A10 — the
+    // throughput estimator relies on this to skip unknown hardware.
+    expect(normalizeKnownGpuModel('NVIDIA-B200-192GB')).toBeUndefined();
+    expect(normalizeKnownGpuModel('Unknown-GPU-Model')).toBeUndefined();
+    expect(normalizeKnownGpuModel('')).toBeUndefined();
+  });
+
+  test('diverges from the lenient normalizer on unknown input', () => {
+    expect(normalizeGpuModel('Totally-New-GPU')).toBe('A10');
+    expect(normalizeKnownGpuModel('Totally-New-GPU')).toBeUndefined();
+  });
+});
+
+describe('getKnownGpuInfo (strict — no A10 fallback)', () => {
+  test('returns specs for known models', () => {
+    const info = getKnownGpuInfo('NVIDIA-A100-SXM4-80GB');
+    expect(info).toBeDefined();
+    expect(info!.memoryGb).toBe(80);
+    expect(info!.generation).toBe('Ampere');
+  });
+
+  test('returns undefined for an unknown GPU instead of A10 specs', () => {
+    // getGpuInfo would return A10 (24 GB) here; the strict variant must not.
+    expect(getGpuInfo('NVIDIA-B200-192GB')!.memoryGb).toBe(24);
+    expect(getKnownGpuInfo('NVIDIA-B200-192GB')).toBeUndefined();
   });
 });
 

--- a/backend/src/services/costEstimation.test.ts
+++ b/backend/src/services/costEstimation.test.ts
@@ -28,6 +28,13 @@ describe('normalizeGpuModel', () => {
     expect(normalizeGpuModel('H100')).toBe('H100-80GB');
   });
 
+  test('normalizes H200 variants', () => {
+    expect(normalizeGpuModel('NVIDIA-H200')).toBe('H200-141GB');
+    expect(normalizeGpuModel('NVIDIA-H200-141GB-HBM3e')).toBe('H200-141GB');
+    expect(normalizeGpuModel('H200')).toBe('H200-141GB');
+    expect(getGpuInfo('NVIDIA-H200')?.memBandwidthGBs).toBe(4800);
+  });
+
   test('normalizes T4 variants', () => {
     expect(normalizeGpuModel('Tesla-T4')).toBe('T4');
     expect(normalizeGpuModel('NVIDIA-Tesla-T4')).toBe('T4');

--- a/backend/src/services/costEstimation.ts
+++ b/backend/src/services/costEstimation.ts
@@ -163,6 +163,16 @@ export function getGpuInfo(gpuModel: string): GpuModelInfo | undefined {
 }
 
 /**
+ * Whether a GPU model has a native FP8 datapath. Used to gate FP8 KV-cache
+ * sizing in the throughput estimator: only Hopper (H100, H200) has hardware FP8
+ * support, so requesting an FP8 KV cache on older generations should fall back
+ * to 2-byte (fp16/bf16) for a realistic estimate.
+ */
+export function gpuSupportsFp8(gpuModel: string): boolean {
+  return getGpuInfo(gpuModel)?.generation === 'Hopper';
+}
+
+/**
  * @deprecated Use cloudPricing.ts for real-time pricing
  * This function is kept for backward compatibility but returns low-confidence estimates
  */

--- a/backend/src/services/costEstimation.ts
+++ b/backend/src/services/costEstimation.ts
@@ -93,14 +93,17 @@ const GPU_MODELS: Record<string, GpuModelInfo> = {
 const DEFAULT_GPU = 'A10';
 
 /**
- * Normalize GPU model name from Kubernetes node label to our GPU key
+ * Match a raw GPU label to a known GPU_MODELS key, or `undefined` when no entry
+ * matches. This is the strict core shared by both the lenient and strict public
+ * helpers — it never substitutes a default, so callers that must distinguish
+ * "unknown GPU" from "real match" (e.g. the throughput estimator) can do so.
  *
  * @param gpuLabel - The raw GPU label from nvidia.com/gpu.product
- * @returns Normalized GPU model name
+ * @returns The matched GPU_MODELS key, or undefined if unrecognized
  */
-export function normalizeGpuModel(gpuLabel: string): string {
+export function normalizeKnownGpuModel(gpuLabel: string): string | undefined {
   if (!gpuLabel) {
-    return DEFAULT_GPU;
+    return undefined;
   }
 
   const normalizedLabel = gpuLabel.trim();
@@ -149,12 +152,37 @@ export function normalizeGpuModel(gpuLabel: string): string {
     }
   }
 
+  return undefined;
+}
+
+/**
+ * Normalize GPU model name from Kubernetes node label to our GPU key.
+ *
+ * Lenient: unrecognized labels fall back to {@link DEFAULT_GPU} (A10). This is
+ * acceptable for the legacy cost-estimation paths (which only label the result
+ * and never silently report wrong specs), but NOT for the throughput estimator —
+ * an A10 substitution there yields confidently-wrong speed and FP8 numbers. Use
+ * {@link normalizeKnownGpuModel} when an unknown GPU must be treated as unknown.
+ *
+ * @param gpuLabel - The raw GPU label from nvidia.com/gpu.product
+ * @returns Normalized GPU model name (defaults to A10 when unrecognized)
+ */
+export function normalizeGpuModel(gpuLabel: string): string {
+  const matched = normalizeKnownGpuModel(gpuLabel);
+  if (matched) {
+    return matched;
+  }
   logger.warn({ gpuLabel }, 'Could not normalize GPU model, using default');
   return DEFAULT_GPU;
 }
 
 /**
- * Get GPU model info (memory, generation) for a GPU model
+ * Get GPU model info (memory, generation) for a GPU model.
+ *
+ * Lenient: an unrecognized label resolves through the A10 default, so this
+ * returns A10's info rather than `undefined` for unknown GPUs. For estimation
+ * paths that must skip unknown hardware, use {@link getKnownGpuInfo}.
+ *
  * Note: For actual pricing, use cloudPricing.ts
  */
 export function getGpuInfo(gpuModel: string): GpuModelInfo | undefined {
@@ -163,13 +191,28 @@ export function getGpuInfo(gpuModel: string): GpuModelInfo | undefined {
 }
 
 /**
+ * Strict variant of {@link getGpuInfo}: returns the GPU's specs only when the
+ * label maps to a known GPU_MODELS entry, and `undefined` otherwise (no A10
+ * fallback). The throughput estimator uses this so a new/unsupported GPU label
+ * is skipped or surfaced as "unknown" instead of silently estimated as an A10.
+ */
+export function getKnownGpuInfo(gpuModel: string): GpuModelInfo | undefined {
+  const normalizedModel = normalizeKnownGpuModel(gpuModel);
+  return normalizedModel ? GPU_MODELS[normalizedModel] : undefined;
+}
+
+/**
  * Whether a GPU model has a native FP8 datapath. Used to gate FP8 KV-cache
  * sizing in the throughput estimator: only Hopper (H100, H200) has hardware FP8
  * support, so requesting an FP8 KV cache on older generations should fall back
  * to 2-byte (fp16/bf16) for a realistic estimate.
+ *
+ * Uses the strict lookup so an unknown GPU label reports `false` because we
+ * genuinely don't know it supports FP8 — not because it was coerced to a
+ * (non-Hopper) A10 default.
  */
 export function gpuSupportsFp8(gpuModel: string): boolean {
-  return getGpuInfo(gpuModel)?.generation === 'Hopper';
+  return getKnownGpuInfo(gpuModel)?.generation === 'Hopper';
 }
 
 /**
@@ -251,7 +294,9 @@ export function getSupportedGpuModels(): Array<{
  */
 export const costEstimationService = {
   normalizeGpuModel,
+  normalizeKnownGpuModel,
   getGpuInfo,
+  getKnownGpuInfo,
   estimateCost,
   estimateNodePoolCosts,
   getSupportedGpuModels,

--- a/backend/src/services/costEstimation.ts
+++ b/backend/src/services/costEstimation.ts
@@ -202,17 +202,27 @@ export function getKnownGpuInfo(gpuModel: string): GpuModelInfo | undefined {
 }
 
 /**
+ * GPU generations with a native FP8 datapath (W8A8 / FP8 KV cache). vLLM gates
+ * full FP8 on compute capability >= 8.9, i.e. Ada Lovelace (L40S, L4) and Hopper
+ * (H100, H200). Ampere and older (A100, A10, T4, V100) lack the FP8 Tensor-Core
+ * path — A100 only does weight-only W8A16 via Marlin, which is not what the KV
+ * cache models — so they are excluded.
+ */
+const FP8_CAPABLE_GENERATIONS = new Set(['Ada Lovelace', 'Hopper']);
+
+/**
  * Whether a GPU model has a native FP8 datapath. Used to gate FP8 KV-cache
- * sizing in the throughput estimator: only Hopper (H100, H200) has hardware FP8
- * support, so requesting an FP8 KV cache on older generations should fall back
- * to 2-byte (fp16/bf16) for a realistic estimate.
+ * sizing in the throughput estimator: only Ada Lovelace (L40S, L4) and Hopper
+ * (H100, H200) have hardware FP8 support, so requesting an FP8 KV cache on older
+ * generations should fall back to 2-byte (fp16/bf16) for a realistic estimate.
  *
  * Uses the strict lookup so an unknown GPU label reports `false` because we
  * genuinely don't know it supports FP8 — not because it was coerced to a
- * (non-Hopper) A10 default.
+ * (non-FP8) A10 default.
  */
 export function gpuSupportsFp8(gpuModel: string): boolean {
-  return getKnownGpuInfo(gpuModel)?.generation === 'Hopper';
+  const generation = getKnownGpuInfo(gpuModel)?.generation;
+  return generation !== undefined && FP8_CAPABLE_GENERATIONS.has(generation);
 }
 
 /**

--- a/backend/src/services/costEstimation.ts
+++ b/backend/src/services/costEstimation.ts
@@ -15,57 +15,78 @@ const DEFAULT_HOURS_PER_MONTH = 730;
  * This is now only used for GPU name normalization, not pricing.
  * Actual pricing comes from cloudPricing.ts via cloud provider APIs.
  */
-interface GpuModelInfo {
+export interface GpuModelInfo {
   aliases: string[];
   memoryGb: number;
   generation: string;
+  /**
+   * Peak HBM memory bandwidth in GB/s (decimal, vendor spec).
+   * Used by the inference-throughput estimator (gpuPerformance.ts) — decode
+   * speed is memory-bandwidth-bound, so this is the dominant per-token factor.
+   */
+  memBandwidthGBs: number;
 }
 
 const GPU_MODELS: Record<string, GpuModelInfo> = {
+  'H200-141GB': {
+    aliases: ['NVIDIA-H200', 'NVIDIA-H200-141GB-HBM3e', 'H200', 'NVIDIA H200'],
+    memoryGb: 141,
+    generation: 'Hopper',
+    memBandwidthGBs: 4800,
+  },
   'H100-80GB': {
     aliases: ['NVIDIA-H100-80GB-HBM3', 'H100', 'NVIDIA H100'],
     memoryGb: 80,
     generation: 'Hopper',
+    memBandwidthGBs: 3350,
   },
   'A100-80GB': {
     aliases: ['NVIDIA-A100-SXM4-80GB', 'NVIDIA-A100-80GB-PCIe', 'A100-80GB', 'A100 80GB'],
     memoryGb: 80,
     generation: 'Ampere',
+    memBandwidthGBs: 2039,
   },
   'A100-40GB': {
     aliases: ['NVIDIA-A100-SXM4-40GB', 'NVIDIA-A100-40GB-PCIe', 'A100-40GB', 'A100 40GB', 'A100'],
     memoryGb: 40,
     generation: 'Ampere',
+    memBandwidthGBs: 1555,
   },
   L40S: {
     aliases: ['NVIDIA-L40S', 'L40S'],
     memoryGb: 48,
     generation: 'Ada Lovelace',
+    memBandwidthGBs: 864,
   },
   L4: {
     aliases: ['NVIDIA-L4', 'L4'],
     memoryGb: 24,
     generation: 'Ada Lovelace',
+    memBandwidthGBs: 300,
   },
   A10G: {
     aliases: ['NVIDIA-A10G', 'A10G', 'NVIDIA A10G'],
     memoryGb: 24,
     generation: 'Ampere',
+    memBandwidthGBs: 600,
   },
   A10: {
     aliases: ['NVIDIA-A10', 'A10', 'NVIDIA A10'],
     memoryGb: 24,
     generation: 'Ampere',
+    memBandwidthGBs: 600,
   },
   T4: {
     aliases: ['NVIDIA-Tesla-T4', 'Tesla-T4', 'T4', 'NVIDIA T4'],
     memoryGb: 16,
     generation: 'Turing',
+    memBandwidthGBs: 320,
   },
   V100: {
     aliases: ['NVIDIA-Tesla-V100', 'Tesla-V100', 'V100', 'V100-SXM2-16GB', 'V100-PCIE-16GB'],
     memoryGb: 16,
     generation: 'Volta',
+    memBandwidthGBs: 900,
   },
 };
 
@@ -109,7 +130,7 @@ export function normalizeGpuModel(gpuLabel: string): string {
   const memoryGb = memoryMatch ? parseInt(memoryMatch[1], 10) : null;
 
   // Check for known GPU families
-  const gpuFamilies = ['H100', 'A100', 'L40S', 'L40', 'L4', 'A10G', 'A10', 'T4', 'V100', 'MI300'];
+  const gpuFamilies = ['H200', 'H100', 'A100', 'L40S', 'L40', 'L4', 'A10G', 'A10', 'T4', 'V100', 'MI300'];
   for (const family of gpuFamilies) {
     if (normalizedLabel.toUpperCase().includes(family)) {
       // If we have memory info, try to find exact match

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -2,9 +2,11 @@ import { describe, test, expect } from 'bun:test';
 import {
   resolveParamCount,
   bytesPerWeightFor,
+  bytesPerKvFor,
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
 } from './gpuPerformance';
+import { gpuSupportsFp8 } from './costEstimation';
 import type { ModelArchitecture } from '@airunway/shared';
 
 describe('resolveParamCount', () => {
@@ -44,6 +46,34 @@ describe('bytesPerWeightFor', () => {
   });
 });
 
+describe('bytesPerKvFor', () => {
+  test('maps fp8/int8 to 1 byte', () => {
+    expect(bytesPerKvFor('fp8')).toBe(1);
+    expect(bytesPerKvFor('int8')).toBe(1);
+  });
+
+  test('defaults to 2 bytes (decoupled from weight quantization)', () => {
+    expect(bytesPerKvFor('fp16')).toBe(2);
+    expect(bytesPerKvFor('bf16')).toBe(2);
+    expect(bytesPerKvFor(undefined)).toBe(2);
+  });
+});
+
+describe('gpuSupportsFp8 (KV-cache FP8 gating)', () => {
+  test('true only for Hopper GPUs', () => {
+    expect(gpuSupportsFp8('H100')).toBe(true);
+    expect(gpuSupportsFp8('NVIDIA-H200')).toBe(true);
+  });
+
+  test('false for non-Hopper generations', () => {
+    expect(gpuSupportsFp8('L4')).toBe(false);
+    expect(gpuSupportsFp8('L40S')).toBe(false);
+    expect(gpuSupportsFp8('A100-80GB')).toBe(false);
+    expect(gpuSupportsFp8('T4')).toBe(false);
+    expect(gpuSupportsFp8('V100')).toBe(false);
+  });
+});
+
 describe('estimatePerChatTokensPerSec', () => {
   test('Llama-3-70B FP8 on H100 (~38 tok/s)', () => {
     const tps = estimatePerChatTokensPerSec({
@@ -66,7 +96,7 @@ describe('estimateConcurrentCapacity', () => {
   // Llama-3-70B architecture (GQA): 80 layers, 8 KV heads, head dim 128.
   const llama70bArch: ModelArchitecture = { numLayers: 80, numKvHeads: 8, headDim: 128 };
 
-  test('Llama-3-70B FP8 on 4xH100-80GB / 4K context lands in expected bands', () => {
+  test('Llama-3-70B FP8 weights + FP8 KV on 4xH100-80GB / 4K context lands in expected bands', () => {
     const perChat = estimatePerChatTokensPerSec({
       paramCount: 70e9,
       bytesPerWeight: 1,
@@ -79,13 +109,57 @@ describe('estimateConcurrentCapacity', () => {
       tpSize: 4,
       contextLen: 4096,
       bytesPerWeight: 1,
+      bytesPerKv: 1, // explicit FP8 KV cache (Hopper)
       perChatTokensPerSec: perChat,
     });
     expect(result).toBeDefined();
     expect(result!.concurrentSequences).toBeGreaterThan(250);
     expect(result!.concurrentSequences).toBeLessThan(450);
-    expect(result!.aggregateTokensPerSec).toBeGreaterThan(10_000);
-    expect(result!.aggregateTokensPerSec).toBeLessThan(25_000);
+    // aggregate = concurrentSequences × perChatTokensPerSec (single-stream rate).
+    expect(result!.aggregateTokensPerSec).toBe(
+      Math.round(result!.concurrentSequences * perChat)
+    );
+  });
+
+  test('aggregate scales with perChatTokensPerSec; concurrency does not', () => {
+    const base = {
+      paramCount: 70e9,
+      arch: llama70bArch,
+      perGpuMemoryGb: 80,
+      tpSize: 4,
+      contextLen: 4096,
+      bytesPerWeight: 1,
+      bytesPerKv: 1,
+    };
+    const slow = estimateConcurrentCapacity({ ...base, perChatTokensPerSec: 5 })!;
+    const fast = estimateConcurrentCapacity({ ...base, perChatTokensPerSec: 5000 })!;
+    // Concurrency is KV-budget gated, so the single-stream speed must not change it.
+    expect(fast.concurrentSequences).toBe(slow.concurrentSequences);
+    // Aggregate is concurrency × single-stream rate, so it tracks perChat.
+    expect(slow.aggregateTokensPerSec).toBe(Math.round(slow.concurrentSequences * 5));
+    expect(fast.aggregateTokensPerSec).toBe(Math.round(fast.concurrentSequences * 5000));
+  });
+
+  test('FP8 weights still use 2-byte KV by default (KV decoupled from weight quant)', () => {
+    const base = {
+      paramCount: 70e9,
+      arch: llama70bArch,
+      perGpuMemoryGb: 80,
+      tpSize: 4,
+      contextLen: 4096,
+      bytesPerWeight: 1, // fp8 weights
+      perChatTokensPerSec: 40,
+    };
+    // No bytesPerKv => defaults to 2 (fp16/bf16), NOT 1 (which would follow weights).
+    const defaultKv = estimateConcurrentCapacity(base)!;
+    const explicitFp8Kv = estimateConcurrentCapacity({ ...base, bytesPerKv: 1 })!;
+    // 2-byte KV halves per-seq KV cost => ~2x concurrency vs 1-byte KV.
+    expect(explicitFp8Kv.concurrentSequences).toBeGreaterThan(defaultKv.concurrentSequences);
+    expect(defaultKv.concurrentSequences).toBeGreaterThan(0);
+    // Roughly half (allow slack for weight/headroom terms in the budget).
+    const ratio = explicitFp8Kv.concurrentSequences / defaultKv.concurrentSequences;
+    expect(ratio).toBeGreaterThan(1.8);
+    expect(ratio).toBeLessThan(2.2);
   });
 
   test('returns undefined when architecture is incomplete', () => {

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -193,6 +193,14 @@ describe('gpuSupportsFp8 (KV-cache FP8 gating)', () => {
     expect(gpuSupportsFp8('T4')).toBe(false);
     expect(gpuSupportsFp8('V100')).toBe(false);
   });
+
+  test('false for an unknown GPU (strict lookup — not coerced to a default)', () => {
+    // An unrecognized label resolves to undefined under the strict lookup, so
+    // FP8 is reported unsupported because we genuinely don't know it — never
+    // because it was coerced to an A10 (or, worse, mistaken for Hopper).
+    expect(gpuSupportsFp8('NVIDIA-B200-192GB')).toBe(false);
+    expect(gpuSupportsFp8('Some-Future-GPU')).toBe(false);
+  });
 });
 
 describe('estimatePerChatTokensPerSec', () => {

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   bytesPerWeightFor,
   bytesPerKvFor,
+  deriveTpSizeToFitWeights,
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
   TP_DECODE_EFFICIENCY,
@@ -57,6 +58,125 @@ describe('bytesPerKvFor', () => {
     expect(bytesPerKvFor('fp16')).toBe(2);
     expect(bytesPerKvFor('bf16')).toBe(2);
     expect(bytesPerKvFor(undefined)).toBe(2);
+  });
+});
+
+describe('deriveTpSizeToFitWeights', () => {
+  test('bumps TP until a large model fits (70B fp16 on 80GB -> tp=2)', () => {
+    // 140GB of weights don't fit one 80GB GPU (75GB usable after headroom) but
+    // fit across two, so the derived TP should be 2 rather than the bare default 1.
+    expect(
+      deriveTpSizeToFitWeights({
+        paramCount: 70e9,
+        bytesPerWeight: 2,
+        perGpuMemoryGb: 80,
+        maxContiguous: 8,
+      })
+    ).toBe(2);
+  });
+
+  test('stops at maxContiguous even when weights still do not fit', () => {
+    // 140GB of weights never fit across 8x24GB; cap at maxContiguous and let the
+    // downstream capacity estimate report "does not fit".
+    expect(
+      deriveTpSizeToFitWeights({
+        paramCount: 70e9,
+        bytesPerWeight: 2,
+        perGpuMemoryGb: 24,
+        maxContiguous: 8,
+      })
+    ).toBe(8);
+  });
+
+  test('never exceeds a single-GPU cap', () => {
+    expect(
+      deriveTpSizeToFitWeights({
+        paramCount: 70e9,
+        bytesPerWeight: 2,
+        perGpuMemoryGb: 80,
+        maxContiguous: 1,
+      })
+    ).toBe(1);
+  });
+
+  test('small model that fits one GPU stays at tp=1', () => {
+    expect(
+      deriveTpSizeToFitWeights({
+        paramCount: 7e9,
+        bytesPerWeight: 2,
+        perGpuMemoryGb: 80,
+        maxContiguous: 8,
+      })
+    ).toBe(1);
+  });
+
+  test('fp8 weights let a 70B model fit one 80GB GPU (tp=1)', () => {
+    // 70GB of fp8 weights fit within 75GB usable, so no TP bump is needed.
+    expect(
+      deriveTpSizeToFitWeights({
+        paramCount: 70e9,
+        bytesPerWeight: 1,
+        perGpuMemoryGb: 80,
+        maxContiguous: 8,
+      })
+    ).toBe(1);
+  });
+
+  test('returns 1 when paramCount is unknown (<= 0)', () => {
+    expect(
+      deriveTpSizeToFitWeights({
+        paramCount: 0,
+        bytesPerWeight: 2,
+        perGpuMemoryGb: 80,
+        maxContiguous: 8,
+      })
+    ).toBe(1);
+  });
+
+  test('estimates at the cap when headroom alone exceeds VRAM', () => {
+    // A tiny GPU whose headroom reserve already exceeds its VRAM: no TP size
+    // helps, so fall back to the cap.
+    expect(
+      deriveTpSizeToFitWeights({
+        paramCount: 70e9,
+        bytesPerWeight: 2,
+        perGpuMemoryGb: 4,
+        maxContiguous: 8,
+      })
+    ).toBe(8);
+  });
+
+  test('derived TP fits where tp=1 reports "does not fit" (cross-tab consistency)', () => {
+    // Mirrors the HF-search bug: with tp=1 a 70B model on 80GB returns
+    // concurrentSequences=0 ("does not fit"); the derived TP must leave room.
+    const arch: ModelArchitecture = { numLayers: 80, numKvHeads: 8, headDim: 128 };
+    const atTp1 = estimateConcurrentCapacity({
+      paramCount: 70e9,
+      arch,
+      perGpuMemoryGb: 80,
+      tpSize: 1,
+      contextLen: 4096,
+      bytesPerWeight: 2,
+      perChatTokensPerSec: 10,
+    })!;
+    expect(atTp1.concurrentSequences).toBe(0);
+
+    const tp = deriveTpSizeToFitWeights({
+      paramCount: 70e9,
+      bytesPerWeight: 2,
+      perGpuMemoryGb: 80,
+      maxContiguous: 8,
+    });
+    const atDerived = estimateConcurrentCapacity({
+      paramCount: 70e9,
+      arch,
+      perGpuMemoryGb: 80,
+      tpSize: tp,
+      contextLen: 4096,
+      bytesPerWeight: 2,
+      perChatTokensPerSec: 10,
+    })!;
+    expect(atDerived.concurrentSequences).toBeGreaterThan(0);
   });
 });
 

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -4,6 +4,7 @@ import {
   bytesPerKvFor,
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
+  TP_DECODE_EFFICIENCY,
 } from './gpuPerformance';
 import { resolveModelParamCount } from '@airunway/shared';
 import { gpuSupportsFp8 } from './costEstimation';
@@ -89,6 +90,39 @@ describe('estimatePerChatTokensPerSec', () => {
     const big = estimatePerChatTokensPerSec({ paramCount: 70e9, bytesPerWeight: 2, memBandwidthGBs: 3350 });
     const small = estimatePerChatTokensPerSec({ paramCount: 8e9, bytesPerWeight: 2, memBandwidthGBs: 3350 });
     expect(small).toBeGreaterThan(big);
+  });
+
+  test('tensor parallelism speeds up single-stream decode by ~tpSize × efficiency', () => {
+    const single = estimatePerChatTokensPerSec({
+      paramCount: 70e9,
+      bytesPerWeight: 2,
+      memBandwidthGBs: 3350,
+      tpSize: 1,
+    });
+    const quad = estimatePerChatTokensPerSec({
+      paramCount: 70e9,
+      bytesPerWeight: 2,
+      memBandwidthGBs: 3350,
+      tpSize: 4,
+    });
+    expect(quad).toBeGreaterThan(single);
+    // Aggregated bandwidth scales by tpSize × TP_DECODE_EFFICIENCY.
+    expect(quad / single).toBeCloseTo(4 * TP_DECODE_EFFICIENCY, 5);
+  });
+
+  test('tpSize=1 matches the omitted-tpSize single-GPU number exactly', () => {
+    const omitted = estimatePerChatTokensPerSec({
+      paramCount: 70e9,
+      bytesPerWeight: 2,
+      memBandwidthGBs: 3350,
+    });
+    const explicit = estimatePerChatTokensPerSec({
+      paramCount: 70e9,
+      bytesPerWeight: 2,
+      memBandwidthGBs: 3350,
+      tpSize: 1,
+    });
+    expect(explicit).toBe(omitted);
   });
 });
 

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -183,15 +183,18 @@ describe('deriveTpSizeToFitWeights', () => {
 });
 
 describe('gpuSupportsFp8 (KV-cache FP8 gating)', () => {
-  test('true only for Hopper GPUs', () => {
+  test('true for Ada Lovelace and Hopper GPUs', () => {
     expect(gpuSupportsFp8('H100')).toBe(true);
     expect(gpuSupportsFp8('NVIDIA-H200')).toBe(true);
+    expect(gpuSupportsFp8('L4')).toBe(true);
+    expect(gpuSupportsFp8('L40S')).toBe(true);
   });
 
-  test('false for non-Hopper generations', () => {
-    expect(gpuSupportsFp8('L4')).toBe(false);
-    expect(gpuSupportsFp8('L40S')).toBe(false);
+  test('false for pre-Ada generations (no native FP8 datapath)', () => {
+    // Ampere (A100) only does weight-only W8A16 via Marlin, not the W8A8/FP8-KV
+    // path modeled here; Turing/Volta have no FP8 support at all.
     expect(gpuSupportsFp8('A100-80GB')).toBe(false);
+    expect(gpuSupportsFp8('A10')).toBe(false);
     expect(gpuSupportsFp8('T4')).toBe(false);
     expect(gpuSupportsFp8('V100')).toBe(false);
   });
@@ -199,7 +202,7 @@ describe('gpuSupportsFp8 (KV-cache FP8 gating)', () => {
   test('false for an unknown GPU (strict lookup — not coerced to a default)', () => {
     // An unrecognized label resolves to undefined under the strict lookup, so
     // FP8 is reported unsupported because we genuinely don't know it — never
-    // because it was coerced to an A10 (or, worse, mistaken for Hopper).
+    // because it was coerced to an A10 (or, worse, mistaken for an FP8 GPU).
     expect(gpuSupportsFp8('NVIDIA-B200-192GB')).toBe(false);
     expect(gpuSupportsFp8('Some-Future-GPU')).toBe(false);
   });
@@ -303,7 +306,7 @@ describe('estimateConcurrentCapacity', () => {
       tpSize: 4,
       contextLen: 4096,
       bytesPerWeight: 1,
-      bytesPerKv: 1, // explicit FP8 KV cache (Hopper)
+      bytesPerKv: 1, // explicit FP8 KV cache (Ada Lovelace / Hopper)
       perChatTokensPerSec: perChat,
     });
     expect(result).toBeDefined();

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -1,35 +1,35 @@
 import { describe, test, expect } from 'bun:test';
 import {
-  resolveParamCount,
   bytesPerWeightFor,
   bytesPerKvFor,
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
 } from './gpuPerformance';
+import { resolveModelParamCount } from '@airunway/shared';
 import { gpuSupportsFp8 } from './costEstimation';
 import type { ModelArchitecture } from '@airunway/shared';
 
-describe('resolveParamCount', () => {
+describe('resolveModelParamCount', () => {
   test('prefers explicit parameterCount', () => {
-    expect(resolveParamCount({ parameterCount: 8_000_000_000, id: 'x/y-3B' })).toBe(8_000_000_000);
+    expect(resolveModelParamCount({ parameterCount: 8_000_000_000, id: 'x/y-3B' })).toBe(8_000_000_000);
   });
 
   test('falls back to parameters', () => {
-    expect(resolveParamCount({ parameters: 7_000_000_000, id: 'x/y' })).toBe(7_000_000_000);
+    expect(resolveModelParamCount({ parameters: 7_000_000_000, id: 'x/y' })).toBe(7_000_000_000);
   });
 
   test('parses from model id', () => {
-    expect(resolveParamCount({ id: 'meta-llama/Meta-Llama-3-70B' })).toBe(70_000_000_000);
+    expect(resolveModelParamCount({ id: 'meta-llama/Meta-Llama-3-70B' })).toBe(70_000_000_000);
   });
 
   test('parses from size string', () => {
-    expect(resolveParamCount({ id: 'x/curated', size: '3.8B' })).toBe(3_800_000_000);
-    expect(resolveParamCount({ id: 'x/curated', size: '0.6B' })).toBe(600_000_000);
+    expect(resolveModelParamCount({ id: 'x/curated', size: '3.8B' })).toBe(3_800_000_000);
+    expect(resolveModelParamCount({ id: 'x/curated', size: '0.6B' })).toBe(600_000_000);
   });
 
   test('returns undefined for unknown / unparseable', () => {
-    expect(resolveParamCount({ id: 'x/mystery', size: 'Unknown' })).toBeUndefined();
-    expect(resolveParamCount({ id: 'org/model' })).toBeUndefined();
+    expect(resolveModelParamCount({ id: 'x/mystery', size: 'Unknown' })).toBeUndefined();
+    expect(resolveModelParamCount({ id: 'org/model' })).toBeUndefined();
   });
 });
 

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  resolveParamCount,
+  bytesPerWeightFor,
+  estimatePerChatTokensPerSec,
+  estimateConcurrentCapacity,
+} from './gpuPerformance';
+import type { ModelArchitecture } from '@airunway/shared';
+
+describe('resolveParamCount', () => {
+  test('prefers explicit parameterCount', () => {
+    expect(resolveParamCount({ parameterCount: 8_000_000_000, id: 'x/y-3B' })).toBe(8_000_000_000);
+  });
+
+  test('falls back to parameters', () => {
+    expect(resolveParamCount({ parameters: 7_000_000_000, id: 'x/y' })).toBe(7_000_000_000);
+  });
+
+  test('parses from model id', () => {
+    expect(resolveParamCount({ id: 'meta-llama/Meta-Llama-3-70B' })).toBe(70_000_000_000);
+  });
+
+  test('parses from size string', () => {
+    expect(resolveParamCount({ id: 'x/curated', size: '3.8B' })).toBe(3_800_000_000);
+    expect(resolveParamCount({ id: 'x/curated', size: '0.6B' })).toBe(600_000_000);
+  });
+
+  test('returns undefined for unknown / unparseable', () => {
+    expect(resolveParamCount({ id: 'x/mystery', size: 'Unknown' })).toBeUndefined();
+    expect(resolveParamCount({ id: 'org/model' })).toBeUndefined();
+  });
+});
+
+describe('bytesPerWeightFor', () => {
+  test('maps fp8/int8 to 1 byte', () => {
+    expect(bytesPerWeightFor('fp8')).toBe(1);
+    expect(bytesPerWeightFor('int8')).toBe(1);
+  });
+
+  test('defaults to 2 bytes', () => {
+    expect(bytesPerWeightFor('bf16')).toBe(2);
+    expect(bytesPerWeightFor('fp16')).toBe(2);
+    expect(bytesPerWeightFor(undefined)).toBe(2);
+  });
+});
+
+describe('estimatePerChatTokensPerSec', () => {
+  test('Llama-3-70B FP8 on H100 (~38 tok/s)', () => {
+    const tps = estimatePerChatTokensPerSec({
+      paramCount: 70_000_000_000,
+      bytesPerWeight: 1,
+      memBandwidthGBs: 3350,
+    });
+    expect(tps).toBeGreaterThan(20);
+    expect(tps).toBeLessThan(60);
+  });
+
+  test('smaller model is faster', () => {
+    const big = estimatePerChatTokensPerSec({ paramCount: 70e9, bytesPerWeight: 2, memBandwidthGBs: 3350 });
+    const small = estimatePerChatTokensPerSec({ paramCount: 8e9, bytesPerWeight: 2, memBandwidthGBs: 3350 });
+    expect(small).toBeGreaterThan(big);
+  });
+});
+
+describe('estimateConcurrentCapacity', () => {
+  // Llama-3-70B architecture (GQA): 80 layers, 8 KV heads, head dim 128.
+  const llama70bArch: ModelArchitecture = { numLayers: 80, numKvHeads: 8, headDim: 128 };
+
+  test('Llama-3-70B FP8 on 4xH100-80GB / 4K context lands in expected bands', () => {
+    const perChat = estimatePerChatTokensPerSec({
+      paramCount: 70e9,
+      bytesPerWeight: 1,
+      memBandwidthGBs: 3350,
+    });
+    const result = estimateConcurrentCapacity({
+      paramCount: 70e9,
+      arch: llama70bArch,
+      perGpuMemoryGb: 80,
+      tpSize: 4,
+      contextLen: 4096,
+      bytesPerWeight: 1,
+      perChatTokensPerSec: perChat,
+    });
+    expect(result).toBeDefined();
+    expect(result!.concurrentSequences).toBeGreaterThan(250);
+    expect(result!.concurrentSequences).toBeLessThan(450);
+    expect(result!.aggregateTokensPerSec).toBeGreaterThan(10_000);
+    expect(result!.aggregateTokensPerSec).toBeLessThan(25_000);
+  });
+
+  test('returns undefined when architecture is incomplete', () => {
+    const result = estimateConcurrentCapacity({
+      paramCount: 70e9,
+      arch: { numLayers: 80 }, // missing kv heads / head dim
+      perGpuMemoryGb: 80,
+      tpSize: 4,
+      contextLen: 4096,
+      bytesPerWeight: 1,
+      perChatTokensPerSec: 40,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('longer context reduces concurrency', () => {
+    const base = {
+      paramCount: 70e9,
+      arch: llama70bArch,
+      perGpuMemoryGb: 80,
+      tpSize: 4,
+      bytesPerWeight: 1,
+      perChatTokensPerSec: 40,
+    };
+    const short = estimateConcurrentCapacity({ ...base, contextLen: 4096 })!;
+    const long = estimateConcurrentCapacity({ ...base, contextLen: 32768 })!;
+    expect(long.concurrentSequences).toBeLessThan(short.concurrentSequences);
+  });
+
+  test('zero capacity when weights exceed VRAM', () => {
+    const result = estimateConcurrentCapacity({
+      paramCount: 70e9,
+      arch: llama70bArch,
+      perGpuMemoryGb: 24, // single small GPU, tp=1: 70GB weights don't fit
+      tpSize: 1,
+      contextLen: 4096,
+      bytesPerWeight: 2,
+      perChatTokensPerSec: 10,
+    });
+    expect(result!.concurrentSequences).toBe(0);
+  });
+});

--- a/backend/src/services/gpuPerformance.test.ts
+++ b/backend/src/services/gpuPerformance.test.ts
@@ -5,7 +5,9 @@ import {
   deriveTpSizeToFitWeights,
   estimatePerChatTokensPerSec,
   estimateConcurrentCapacity,
+  tpDecodeEfficiency,
   TP_DECODE_EFFICIENCY,
+  TP_DECODE_EFFICIENCY_LARGE,
 } from './gpuPerformance';
 import { resolveModelParamCount } from '@airunway/shared';
 import { gpuSupportsFp8 } from './costEstimation';
@@ -251,6 +253,36 @@ describe('estimatePerChatTokensPerSec', () => {
       tpSize: 1,
     });
     expect(explicit).toBe(omitted);
+  });
+
+  test('tpDecodeEfficiency steps down with TP group size', () => {
+    // TP1: no cross-GPU all-reduce on the decode path.
+    expect(tpDecodeEfficiency(1)).toBe(1);
+    // TP2–4: single NVLink-domain mid tier.
+    expect(tpDecodeEfficiency(2)).toBe(TP_DECODE_EFFICIENCY);
+    expect(tpDecodeEfficiency(4)).toBe(TP_DECODE_EFFICIENCY);
+    // TP>4: crosses domains / nodes → larger haircut.
+    expect(tpDecodeEfficiency(8)).toBe(TP_DECODE_EFFICIENCY_LARGE);
+    expect(tpDecodeEfficiency(16)).toBe(TP_DECODE_EFFICIENCY_LARGE);
+    // Lower tier is the optimistic bound.
+    expect(TP_DECODE_EFFICIENCY).toBeGreaterThan(TP_DECODE_EFFICIENCY_LARGE);
+  });
+
+  test('large TP groups (>4) use the reduced decode efficiency tier', () => {
+    const single = estimatePerChatTokensPerSec({
+      paramCount: 70e9,
+      bytesPerWeight: 2,
+      memBandwidthGBs: 3350,
+      tpSize: 1,
+    });
+    const octa = estimatePerChatTokensPerSec({
+      paramCount: 70e9,
+      bytesPerWeight: 2,
+      memBandwidthGBs: 3350,
+      tpSize: 8,
+    });
+    // TP8 scales by 8 × TP_DECODE_EFFICIENCY_LARGE, not the mid-tier 0.85.
+    expect(octa / single).toBeCloseTo(8 * TP_DECODE_EFFICIENCY_LARGE, 5);
   });
 });
 

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -115,6 +115,64 @@ export function estimatePerChatTokensPerSec(input: PerChatInput): number {
   return (bandwidthBytesPerSec / modelBytesDecimal) * efficiency;
 }
 
+export interface DeriveTpSizeInput {
+  /** Full model parameter count (not per-GPU). */
+  paramCount: number;
+  /** Bytes per weight for the chosen quantization (see bytesPerWeightFor). */
+  bytesPerWeight: number;
+  /** Per-GPU VRAM in GiB for the target GPU. */
+  perGpuMemoryGb: number;
+  /** Upper bound on GPUs per replica (per-node GPU count of the pool). */
+  maxContiguous: number;
+  /** Per-GPU activation/workspace reserve held back from VRAM (GiB). */
+  headroomGib?: number;
+}
+
+/**
+ * Smallest tensor-parallel size (GPUs per replica) whose per-GPU weight shard
+ * leaves positive room for a KV cache, bounded by `maxContiguous`.
+ *
+ * Callers that know the intended TP size (the deployment form, curated cards
+ * with `minGpus`) should pass it through explicitly. This is for the paths that
+ * have no TP hint — notably HuggingFace search cards, whose model objects carry
+ * no `minGpus` — so that a 70B model is estimated at a TP size that actually
+ * fits (e.g. tp=2 on 80 GB) instead of defaulting to tp=1 and spuriously
+ * reporting "does not fit". The fit test mirrors `estimateConcurrentCapacity`
+ * exactly (`perGpuHBM - weights/tp - headroom > 0`) so the derived size agrees
+ * with the concurrency math that follows.
+ *
+ * TP is doubled (1 → 2 → 4 → 8 …) rather than incremented because real
+ * tensor-parallel groups are powers of two. Returns at least 1, and never more
+ * than `maxContiguous`, even when the weights still don't fit at that cap (the
+ * downstream estimate then legitimately reports "does not fit").
+ */
+export function deriveTpSizeToFitWeights(input: DeriveTpSizeInput): number {
+  const {
+    paramCount,
+    bytesPerWeight,
+    perGpuMemoryGb,
+    maxContiguous,
+    headroomGib = DECODE_HEADROOM_GIB,
+  } = input;
+
+  const cap = Math.max(1, Math.floor(maxContiguous || 1));
+  if (paramCount <= 0 || bytesPerWeight <= 0 || perGpuMemoryGb <= 0) {
+    return 1;
+  }
+
+  const usablePerGpuBytes = perGpuMemoryGb * BYTES_PER_GIB - headroomGib * BYTES_PER_GIB;
+  // Even an empty (weightless) shard wouldn't fit the headroom reserve — no TP
+  // size helps, so estimate at the cap and let the caller surface "does not fit".
+  if (usablePerGpuBytes <= 0) return cap;
+
+  const totalWeightBytes = paramCount * bytesPerWeight;
+  let tp = 1;
+  while (tp < cap && totalWeightBytes / tp >= usablePerGpuBytes) {
+    tp *= 2;
+  }
+  return Math.min(tp, cap);
+}
+
 export interface ConcurrentCapacityInput {
   paramCount: number;
   arch: ModelArchitecture;

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -29,6 +29,12 @@ export const MEM_BW_EFFICIENCY = 0.8;
  * across `tpSize` GPUs whose HBM bandwidth aggregates, so single-stream decode
  * speeds up ~`tpSize×` — minus a per-GPU haircut for all-reduce / interconnect
  * overhead. Aggregate effective bandwidth ≈ `tpSize × perGpuBW × this`.
+ *
+ * Caveat: this is a flat factor, independent of `tpSize` and interconnect. Real
+ * single-stream TP decode is latency/communication bound, so the per-GPU haircut
+ * grows with larger TP groups (and is worse across PCIe / multi-node than NVLink).
+ * 0.85 is therefore optimistic for big TP groups; treat it as a rough upper bound,
+ * consistent with the estimator's overall heuristic, disclaimer-backed nature.
  */
 export const TP_DECODE_EFFICIENCY = 0.85;
 

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -1,5 +1,4 @@
-import type { Model, ModelArchitecture } from '@airunway/shared';
-import { parseParameterCountFromName } from './modelCompatibility';
+import type { ModelArchitecture } from '@airunway/shared';
 
 /**
  * Offline inference-throughput estimator.
@@ -65,31 +64,6 @@ export function bytesPerKvFor(dtype?: string): number {
     default:
       return 2;
   }
-}
-
-/**
- * Resolve a numeric parameter count for a model, trying the most accurate
- * source first and falling back to parsing the name / size string.
- * Returns undefined for unknown / unparseable models (e.g. MoE strings).
- */
-export function resolveParamCount(
-  model: Pick<Model, 'parameterCount' | 'parameters' | 'id' | 'size'>
-): number | undefined {
-  if (typeof model.parameterCount === 'number' && model.parameterCount > 0) {
-    return model.parameterCount;
-  }
-  if (typeof model.parameters === 'number' && model.parameters > 0) {
-    return model.parameters;
-  }
-  if (model.id) {
-    const fromId = parseParameterCountFromName(model.id);
-    if (fromId) return fromId;
-  }
-  if (model.size) {
-    const fromSize = parseParameterCountFromName(model.size);
-    if (fromSize) return fromSize;
-  }
-  return undefined;
 }
 
 export interface PerChatInput {

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -28,11 +28,35 @@ export const MEM_BW_EFFICIENCY = 0.8;
 /** Per-GPU activation + workspace reserve (GiB) held back from the KV budget. */
 export const DECODE_HEADROOM_GIB = 5;
 
-/** Quantization → bytes per weight. KV bytes default to the same precision. */
+/** Quantization → bytes per weight. */
 export type Quantization = 'fp8' | 'int8' | 'fp16' | 'bf16';
 
 export function bytesPerWeightFor(quantization?: string): number {
   switch ((quantization || '').toLowerCase()) {
+    case 'fp8':
+    case 'int8':
+      return 1;
+    case 'fp16':
+    case 'bf16':
+    default:
+      return 2;
+  }
+}
+
+/**
+ * KV-cache precision. Deliberately independent of weight quantization — common
+ * serving defaults keep an fp16/bf16 KV cache even when weights are fp8/int8,
+ * unless KV-cache quantization is explicitly enabled.
+ */
+export type KvCacheDtype = 'fp8' | 'int8' | 'fp16' | 'bf16';
+
+/**
+ * Bytes per KV value for a given KV-cache dtype. Defaults to 2 (fp16/bf16) and
+ * is NOT tied to weight quantization — callers must pass the KV dtype explicitly
+ * to opt into a 1-byte KV cache.
+ */
+export function bytesPerKvFor(dtype?: string): number {
+  switch ((dtype || '').toLowerCase()) {
     case 'fp8':
     case 'int8':
       return 1;
@@ -100,9 +124,17 @@ export interface ConcurrentCapacityInput {
   tpSize: number;
   contextLen: number;
   bytesPerWeight: number;
-  /** Bytes per KV value; defaults to bytesPerWeight. */
+  /**
+   * Bytes per KV value. Independent of weight quantization; defaults to 2
+   * (fp16/bf16). Pass 1 only when an FP8/INT8 KV cache is explicitly requested
+   * (and supported by the target hardware).
+   */
   bytesPerKv?: number;
   headroomGib?: number;
+  /**
+   * Single-stream decode speed (tokens/sec). Used to derive the aggregate
+   * tokens/sec figure (aggregate = concurrentSequences × perChatTokensPerSec).
+   */
   perChatTokensPerSec: number;
 }
 
@@ -119,6 +151,10 @@ export interface ConcurrentCapacityResult {
  *   concurrent  = KV_budget / KV_per_seq
  *   aggregate   = concurrent × perChatTokensPerSec
  *
+ * Aggregate throughput is the number of concurrent sequences scaled by the
+ * single-stream decode rate. The single-stream `perChatTokensPerSec` is also
+ * reported separately as the "per-user speed".
+ *
  * Returns undefined when architecture details are insufficient to size the KV
  * cache, so the caller can fall back to a per-chat-only (low-confidence) result.
  */
@@ -132,7 +168,7 @@ export function estimateConcurrentCapacity(
     tpSize,
     contextLen,
     bytesPerWeight,
-    bytesPerKv = bytesPerWeight,
+    bytesPerKv = 2,
     headroomGib = DECODE_HEADROOM_GIB,
     perChatTokensPerSec,
   } = input;
@@ -159,6 +195,7 @@ export function estimateConcurrentCapacity(
   if (kvBytesPerSeq <= 0) return undefined;
 
   const concurrentSequences = Math.floor(kvBudgetTotalBytes / kvBytesPerSeq);
+  // Aggregate throughput: concurrency scaled by the single-stream decode rate.
   const aggregateTokensPerSec = Math.round(concurrentSequences * perChatTokensPerSec);
 
   return { concurrentSequences, aggregateTokensPerSec };

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -24,6 +24,14 @@ const BYTES_PER_GIB = 1024 * 1024 * 1024;
  */
 export const MEM_BW_EFFICIENCY = 0.8;
 
+/**
+ * Tensor-parallel decode scaling efficiency. Under TP the weights are sharded
+ * across `tpSize` GPUs whose HBM bandwidth aggregates, so single-stream decode
+ * speeds up ~`tpSize×` — minus a per-GPU haircut for all-reduce / interconnect
+ * overhead. Aggregate effective bandwidth ≈ `tpSize × perGpuBW × this`.
+ */
+export const TP_DECODE_EFFICIENCY = 0.85;
+
 /** Per-GPU activation + workspace reserve (GiB) held back from the KV budget. */
 export const DECODE_HEADROOM_GIB = 5;
 
@@ -70,23 +78,39 @@ export interface PerChatInput {
   paramCount: number;
   bytesPerWeight: number;
   memBandwidthGBs: number;
+  /**
+   * Tensor-parallel size (GPUs per replica). Defaults to 1. With TP > 1 the
+   * weights shard across `tpSize` GPUs whose HBM bandwidth aggregates, so the
+   * effective decode bandwidth scales by `tpSize × TP_DECODE_EFFICIENCY`.
+   */
+  tpSize?: number;
   efficiency?: number;
 }
 
 /**
  * Single-stream decode speed (tokens/sec). Each generated token requires
  * streaming the full set of model weights from HBM, so speed ≈ bandwidth /
- * model_bytes. This is the conservative single-GPU heuristic and intentionally
- * does NOT credit tensor-parallel speedup (it answers "how fast for one user").
+ * model_bytes. Under tensor parallelism the weights shard across `tpSize` GPUs
+ * whose HBM bandwidth aggregates, so single-stream decode scales ~`tpSize×`
+ * (minus TP_DECODE_EFFICIENCY for interconnect overhead); tpSize=1 reduces to
+ * the exact single-GPU figure.
  *
  * Note the one decimal/binary boundary: memory bandwidth is decimal GB/s
  * (vendor spec) and model bytes are decimal (paramCount × bytesPerWeight), so
  * they divide cleanly without GiB conversion.
  */
 export function estimatePerChatTokensPerSec(input: PerChatInput): number {
-  const { paramCount, bytesPerWeight, memBandwidthGBs, efficiency = MEM_BW_EFFICIENCY } = input;
+  const {
+    paramCount,
+    bytesPerWeight,
+    memBandwidthGBs,
+    tpSize = 1,
+    efficiency = MEM_BW_EFFICIENCY,
+  } = input;
   const modelBytesDecimal = paramCount * bytesPerWeight; // decimal bytes
-  const bandwidthBytesPerSec = memBandwidthGBs * 1e9; // decimal GB/s -> bytes/s
+  // TP aggregates per-GPU bandwidth; tpSize=1 keeps the exact single-GPU number.
+  const tpScale = tpSize > 1 ? tpSize * TP_DECODE_EFFICIENCY : 1;
+  const bandwidthBytesPerSec = memBandwidthGBs * 1e9 * tpScale; // decimal GB/s -> bytes/s
   if (modelBytesDecimal <= 0) return 0;
   return (bandwidthBytesPerSec / modelBytesDecimal) * efficiency;
 }

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -28,15 +28,45 @@ export const MEM_BW_EFFICIENCY = 0.8;
  * Tensor-parallel decode scaling efficiency. Under TP the weights are sharded
  * across `tpSize` GPUs whose HBM bandwidth aggregates, so single-stream decode
  * speeds up ~`tpSize×` — minus a per-GPU haircut for all-reduce / interconnect
- * overhead. Aggregate effective bandwidth ≈ `tpSize × perGpuBW × this`.
+ * overhead. Aggregate effective bandwidth ≈ `tpSize × perGpuBW × efficiency`.
  *
- * Caveat: this is a flat factor, independent of `tpSize` and interconnect. Real
- * single-stream TP decode is latency/communication bound, so the per-GPU haircut
- * grows with larger TP groups (and is worse across PCIe / multi-node than NVLink).
- * 0.85 is therefore optimistic for big TP groups; treat it as a rough upper bound,
- * consistent with the estimator's overall heuristic, disclaimer-backed nature.
+ * Real single-stream TP decode is latency/communication bound, so the per-GPU
+ * haircut grows with larger TP groups (and is worse across PCIe / multi-node
+ * than NVLink). We therefore step the factor down with group size rather than
+ * applying a single flat value (see `tpDecodeEfficiency`): small groups stay on
+ * one NVLink domain, while big groups cross domains / nodes and lose more to
+ * communication. These remain coarse heuristics, consistent with the
+ * estimator's overall disclaimer-backed nature.
+ *
+ * `TP_DECODE_EFFICIENCY` is the mid-tier value (TP 2–4, a typical single NVLink
+ * domain). Larger groups use `TP_DECODE_EFFICIENCY_LARGE`.
  */
 export const TP_DECODE_EFFICIENCY = 0.85;
+
+/**
+ * Decode efficiency for large TP groups (more than 4 GPUs per replica). Beyond a
+ * typical 4-GPU NVLink domain the all-reduce traffic increasingly crosses slower
+ * links (multi-domain NVSwitch, PCIe, or multi-node fabric), so the realised
+ * per-GPU bandwidth fraction drops further. 0.75 is a deliberately rough
+ * step-down for the TP≥8 regime.
+ */
+export const TP_DECODE_EFFICIENCY_LARGE = 0.75;
+
+/**
+ * Per-GPU decode efficiency fraction for a given tensor-parallel size. Stepped
+ * by group size to approximate the growing communication haircut:
+ *   - TP 1     → 1.0  (no cross-GPU all-reduce on the decode path)
+ *   - TP 2–4   → TP_DECODE_EFFICIENCY (0.85; typically one NVLink domain)
+ *   - TP > 4   → TP_DECODE_EFFICIENCY_LARGE (0.75; crosses domains / nodes)
+ *
+ * The cutover at 4 mirrors common 4-GPU NVLink partitioning; the values are
+ * heuristic upper bounds, not measured constants.
+ */
+export function tpDecodeEfficiency(tpSize: number): number {
+  if (tpSize <= 1) return 1;
+  if (tpSize <= 4) return TP_DECODE_EFFICIENCY;
+  return TP_DECODE_EFFICIENCY_LARGE;
+}
 
 /** Per-GPU activation + workspace reserve (GiB) held back from the KV budget. */
 export const DECODE_HEADROOM_GIB = 5;
@@ -87,7 +117,7 @@ export interface PerChatInput {
   /**
    * Tensor-parallel size (GPUs per replica). Defaults to 1. With TP > 1 the
    * weights shard across `tpSize` GPUs whose HBM bandwidth aggregates, so the
-   * effective decode bandwidth scales by `tpSize × TP_DECODE_EFFICIENCY`.
+   * effective decode bandwidth scales by `tpSize × tpDecodeEfficiency(tpSize)`.
    */
   tpSize?: number;
   efficiency?: number;
@@ -98,8 +128,8 @@ export interface PerChatInput {
  * streaming the full set of model weights from HBM, so speed ≈ bandwidth /
  * model_bytes. Under tensor parallelism the weights shard across `tpSize` GPUs
  * whose HBM bandwidth aggregates, so single-stream decode scales ~`tpSize×`
- * (minus TP_DECODE_EFFICIENCY for interconnect overhead); tpSize=1 reduces to
- * the exact single-GPU figure.
+ * (minus the per-group `tpDecodeEfficiency` haircut for interconnect overhead);
+ * tpSize=1 reduces to the exact single-GPU figure.
  *
  * Note the one decimal/binary boundary: memory bandwidth is decimal GB/s
  * (vendor spec) and model bytes are decimal (paramCount × bytesPerWeight), so
@@ -115,7 +145,8 @@ export function estimatePerChatTokensPerSec(input: PerChatInput): number {
   } = input;
   const modelBytesDecimal = paramCount * bytesPerWeight; // decimal bytes
   // TP aggregates per-GPU bandwidth; tpSize=1 keeps the exact single-GPU number.
-  const tpScale = tpSize > 1 ? tpSize * TP_DECODE_EFFICIENCY : 1;
+  // The per-GPU efficiency steps down with group size (see tpDecodeEfficiency).
+  const tpScale = tpSize > 1 ? tpSize * tpDecodeEfficiency(tpSize) : 1;
   const bandwidthBytesPerSec = memBandwidthGBs * 1e9 * tpScale; // decimal GB/s -> bytes/s
   if (modelBytesDecimal <= 0) return 0;
   return (bandwidthBytesPerSec / modelBytesDecimal) * efficiency;

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -1,0 +1,165 @@
+import type { Model, ModelArchitecture } from '@airunway/shared';
+import { parseParameterCountFromName } from './modelCompatibility';
+
+/**
+ * Offline inference-throughput estimator.
+ *
+ * Produces two rough numbers (see issue #139) without running any inference:
+ *  1. per-chat tokens/sec — single-stream decode speed, memory-bandwidth bound
+ *     (≈ 1/TPOT). "How snappy does chat feel?"
+ *  2. concurrent capacity / aggregate tokens/sec — KV-cache-budget gated, per
+ *     replica. "How many requests can this serve at once?"
+ *
+ * These are deliberately simple heuristics; real throughput depends on the
+ * serving engine, batch scheduler, prompt lengths, and quantization. All
+ * numbers are presented in the UI as estimates with a methodology disclaimer.
+ */
+
+/** 1 GiB in bytes — matches gpuValidation.ts so memory math stays consistent. */
+const BYTES_PER_GIB = 1024 * 1024 * 1024;
+
+/**
+ * Fraction of theoretical memory bandwidth realised in practice. Decode kernels
+ * never hit peak HBM bandwidth; ~0.8 is a common rule-of-thumb fudge factor,
+ * mirroring OVERHEAD_MULTIPLIER in gpuValidation.ts.
+ */
+export const MEM_BW_EFFICIENCY = 0.8;
+
+/** Per-GPU activation + workspace reserve (GiB) held back from the KV budget. */
+export const DECODE_HEADROOM_GIB = 5;
+
+/** Quantization → bytes per weight. KV bytes default to the same precision. */
+export type Quantization = 'fp8' | 'int8' | 'fp16' | 'bf16';
+
+export function bytesPerWeightFor(quantization?: string): number {
+  switch ((quantization || '').toLowerCase()) {
+    case 'fp8':
+    case 'int8':
+      return 1;
+    case 'fp16':
+    case 'bf16':
+    default:
+      return 2;
+  }
+}
+
+/**
+ * Resolve a numeric parameter count for a model, trying the most accurate
+ * source first and falling back to parsing the name / size string.
+ * Returns undefined for unknown / unparseable models (e.g. MoE strings).
+ */
+export function resolveParamCount(
+  model: Pick<Model, 'parameterCount' | 'parameters' | 'id' | 'size'>
+): number | undefined {
+  if (typeof model.parameterCount === 'number' && model.parameterCount > 0) {
+    return model.parameterCount;
+  }
+  if (typeof model.parameters === 'number' && model.parameters > 0) {
+    return model.parameters;
+  }
+  if (model.id) {
+    const fromId = parseParameterCountFromName(model.id);
+    if (fromId) return fromId;
+  }
+  if (model.size) {
+    const fromSize = parseParameterCountFromName(model.size);
+    if (fromSize) return fromSize;
+  }
+  return undefined;
+}
+
+export interface PerChatInput {
+  paramCount: number;
+  bytesPerWeight: number;
+  memBandwidthGBs: number;
+  efficiency?: number;
+}
+
+/**
+ * Single-stream decode speed (tokens/sec). Each generated token requires
+ * streaming the full set of model weights from HBM, so speed ≈ bandwidth /
+ * model_bytes. This is the conservative single-GPU heuristic and intentionally
+ * does NOT credit tensor-parallel speedup (it answers "how fast for one user").
+ *
+ * Note the one decimal/binary boundary: memory bandwidth is decimal GB/s
+ * (vendor spec) and model bytes are decimal (paramCount × bytesPerWeight), so
+ * they divide cleanly without GiB conversion.
+ */
+export function estimatePerChatTokensPerSec(input: PerChatInput): number {
+  const { paramCount, bytesPerWeight, memBandwidthGBs, efficiency = MEM_BW_EFFICIENCY } = input;
+  const modelBytesDecimal = paramCount * bytesPerWeight; // decimal bytes
+  const bandwidthBytesPerSec = memBandwidthGBs * 1e9; // decimal GB/s -> bytes/s
+  if (modelBytesDecimal <= 0) return 0;
+  return (bandwidthBytesPerSec / modelBytesDecimal) * efficiency;
+}
+
+export interface ConcurrentCapacityInput {
+  paramCount: number;
+  arch: ModelArchitecture;
+  perGpuMemoryGb: number;
+  tpSize: number;
+  contextLen: number;
+  bytesPerWeight: number;
+  /** Bytes per KV value; defaults to bytesPerWeight. */
+  bytesPerKv?: number;
+  headroomGib?: number;
+  perChatTokensPerSec: number;
+}
+
+export interface ConcurrentCapacityResult {
+  concurrentSequences: number;
+  aggregateTokensPerSec: number;
+}
+
+/**
+ * KV-cache-budget-gated concurrent capacity, per replica (per TP group).
+ *
+ *   KV_budget   = (perGpuHBM - weightsPerGpu - headroom) × TP   [GiB-bytes]
+ *   KV_per_seq  = contextLen × 2 × layers × kvHeads × headDim × bytesPerKv
+ *   concurrent  = KV_budget / KV_per_seq
+ *   aggregate   = concurrent × perChatTokensPerSec
+ *
+ * Returns undefined when architecture details are insufficient to size the KV
+ * cache, so the caller can fall back to a per-chat-only (low-confidence) result.
+ */
+export function estimateConcurrentCapacity(
+  input: ConcurrentCapacityInput
+): ConcurrentCapacityResult | undefined {
+  const {
+    paramCount,
+    arch,
+    perGpuMemoryGb,
+    tpSize,
+    contextLen,
+    bytesPerWeight,
+    bytesPerKv = bytesPerWeight,
+    headroomGib = DECODE_HEADROOM_GIB,
+    perChatTokensPerSec,
+  } = input;
+
+  const { numLayers, numKvHeads, headDim } = arch;
+  if (!numLayers || !numKvHeads || !headDim || tpSize <= 0 || contextLen <= 0) {
+    return undefined;
+  }
+
+  // All memory math in GiB-bytes for consistency with gpuValidation.ts.
+  const perGpuHbmBytes = perGpuMemoryGb * BYTES_PER_GIB;
+  const headroomBytes = headroomGib * BYTES_PER_GIB;
+  const weightsPerGpuBytes = (paramCount * bytesPerWeight) / tpSize;
+
+  const kvBudgetPerGpuBytes = perGpuHbmBytes - weightsPerGpuBytes - headroomBytes;
+  if (kvBudgetPerGpuBytes <= 0) {
+    // Weights + headroom already exceed VRAM; no room for KV cache.
+    return { concurrentSequences: 0, aggregateTokensPerSec: 0 };
+  }
+  const kvBudgetTotalBytes = kvBudgetPerGpuBytes * tpSize;
+
+  const kvBytesPerToken = 2 * numLayers * numKvHeads * headDim * bytesPerKv;
+  const kvBytesPerSeq = contextLen * kvBytesPerToken;
+  if (kvBytesPerSeq <= 0) return undefined;
+
+  const concurrentSequences = Math.floor(kvBudgetTotalBytes / kvBytesPerSeq);
+  const aggregateTokensPerSec = Math.round(concurrentSequences * perChatTokensPerSec);
+
+  return { concurrentSequences, aggregateTokensPerSec };
+}

--- a/backend/src/services/gpuPerformance.ts
+++ b/backend/src/services/gpuPerformance.ts
@@ -38,7 +38,7 @@ export const DECODE_HEADROOM_GIB = 5;
 /** Quantization → bytes per weight. */
 export type Quantization = 'fp8' | 'int8' | 'fp16' | 'bf16';
 
-export function bytesPerWeightFor(quantization?: string): number {
+export function bytesPerWeightFor(quantization?: Quantization): number {
   switch ((quantization || '').toLowerCase()) {
     case 'fp8':
     case 'int8':
@@ -62,7 +62,7 @@ export type KvCacheDtype = 'fp8' | 'int8' | 'fp16' | 'bf16';
  * is NOT tied to weight quantization — callers must pass the KV dtype explicitly
  * to opt into a 1-byte KV cache.
  */
-export function bytesPerKvFor(dtype?: string): number {
+export function bytesPerKvFor(dtype?: KvCacheDtype): number {
   switch ((dtype || '').toLowerCase()) {
     case 'fp8':
     case 'int8':

--- a/backend/src/services/huggingface.test.ts
+++ b/backend/src/services/huggingface.test.ts
@@ -234,4 +234,74 @@ describe('HuggingFaceService', () => {
       ).rejects.toThrow();
     });
   });
+
+  describe('getModelArchitecture', () => {
+    const configJson = JSON.stringify({
+      num_hidden_layers: 80,
+      num_attention_heads: 64,
+      num_key_value_heads: 8,
+      head_dim: 128,
+      max_position_embeddings: 8192,
+      torch_dtype: 'bfloat16',
+    });
+
+    test('parses architecture from config.json', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(configJson, { status: 200 }))
+      );
+
+      const arch = await huggingFaceService.getModelArchitecture('meta-llama/Meta-Llama-3-70B');
+
+      expect(arch).toEqual({
+        numLayers: 80,
+        numKvHeads: 8,
+        headDim: 128,
+        maxPositionEmbeddings: 8192,
+        torchDtype: 'bfloat16',
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('serves a cached result without re-fetching while fresh', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(configJson, { status: 200 }))
+      );
+
+      await huggingFaceService.getModelArchitecture('org/model');
+      await huggingFaceService.getModelArchitecture('org/model');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('drops the expired entry and re-fetches after the TTL', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(configJson, { status: 200 }))
+      );
+
+      const realNow = Date.now;
+      const base = realNow();
+      try {
+        // First call caches with expiresAt = base + 1h.
+        Date.now = () => base;
+        await huggingFaceService.getModelArchitecture('org/model');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // Advance past the 1-hour TTL: entry is expired, must re-fetch.
+        Date.now = () => base + 60 * 60 * 1000 + 1;
+        await huggingFaceService.getModelArchitecture('org/model');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      } finally {
+        Date.now = realNow;
+      }
+    });
+
+    test('returns undefined on a non-ok response', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response('not found', { status: 404 }))
+      );
+
+      const arch = await huggingFaceService.getModelArchitecture('org/missing');
+      expect(arch).toBeUndefined();
+    });
+  });
 });

--- a/backend/src/services/huggingface.test.ts
+++ b/backend/src/services/huggingface.test.ts
@@ -263,6 +263,85 @@ describe('HuggingFaceService', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    test('reads transformer dimensions from a nested text_config (multimodal)', async () => {
+      // Many image-text-to-text / multimodal configs describe the composite
+      // model at the top level and nest the language-model dimensions under
+      // text_config. Those fields must be read from the nested object so the
+      // estimate stays high-confidence instead of degrading to per-chat-only.
+      const multimodalConfig = JSON.stringify({
+        model_type: 'llava',
+        torch_dtype: 'float16',
+        vision_config: { hidden_size: 1024 },
+        text_config: {
+          num_hidden_layers: 32,
+          num_attention_heads: 32,
+          num_key_value_heads: 8,
+          hidden_size: 4096,
+          max_position_embeddings: 4096,
+          torch_dtype: 'bfloat16',
+        },
+      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(multimodalConfig, { status: 200 }))
+      );
+
+      const arch = await huggingFaceService.getModelArchitecture('org/multimodal-text');
+
+      expect(arch).toEqual({
+        numLayers: 32,
+        numKvHeads: 8,
+        // head_dim derived from nested hidden_size / num_attention_heads.
+        headDim: 128,
+        maxPositionEmbeddings: 4096,
+        // Nested torch_dtype wins over the top-level one.
+        torchDtype: 'bfloat16',
+      });
+    });
+
+    test('prefers top-level transformer fields over a nested text_config', async () => {
+      // A plain decoder LLM that also happens to carry a nested sub-config must
+      // still read its dimensions from the top level (it's the real model).
+      const config = JSON.stringify({
+        num_hidden_layers: 80,
+        num_attention_heads: 64,
+        num_key_value_heads: 8,
+        head_dim: 128,
+        max_position_embeddings: 8192,
+        torch_dtype: 'bfloat16',
+        text_config: { num_hidden_layers: 4, num_attention_heads: 4 },
+      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(config, { status: 200 }))
+      );
+
+      const arch = await huggingFaceService.getModelArchitecture('org/decoder-with-subconfig');
+
+      expect(arch?.numLayers).toBe(80);
+      expect(arch?.numKvHeads).toBe(8);
+    });
+
+    test('reads from llm_config when text_config is absent', async () => {
+      const config = JSON.stringify({
+        model_type: 'internvl',
+        llm_config: {
+          num_hidden_layers: 48,
+          num_attention_heads: 32,
+          num_key_value_heads: 4,
+          head_dim: 128,
+          max_position_embeddings: 16384,
+        },
+      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(config, { status: 200 }))
+      );
+
+      const arch = await huggingFaceService.getModelArchitecture('org/internvl');
+
+      expect(arch?.numLayers).toBe(48);
+      expect(arch?.numKvHeads).toBe(4);
+      expect(arch?.maxPositionEmbeddings).toBe(16384);
+    });
+
     test('serves a cached result without re-fetching while fresh', async () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve(new Response(configJson, { status: 200 }))

--- a/backend/src/services/huggingface.test.ts
+++ b/backend/src/services/huggingface.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { isValidHfRepoId, encodeHfRepoPath } from './huggingface';
 
 // Store original fetch
 const originalFetch = global.fetch;
@@ -302,6 +303,93 @@ describe('HuggingFaceService', () => {
 
       const arch = await huggingFaceService.getModelArchitecture('org/missing');
       expect(arch).toBeUndefined();
+    });
+
+    test('rejects a malformed model id without fetching', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(configJson, { status: 200 }))
+      );
+
+      for (const bad of ['../../etc/passwd', 'a/b/c', 'foo bar', '.', '..', 'owner/', 'owner/name?x=1']) {
+        const arch = await huggingFaceService.getModelArchitecture(bad);
+        expect(arch).toBeUndefined();
+      }
+      // Security: no token-bearing request is ever issued for an invalid id.
+      expect(mockFetch).toHaveBeenCalledTimes(0);
+    });
+
+    test('encodes the model id when building the config.json URL', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(configJson, { status: 200 }))
+      );
+
+      await huggingFaceService.getModelArchitecture('meta-llama/Meta-Llama-3-70B');
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://huggingface.co/meta-llama/Meta-Llama-3-70B/resolve/main/config.json');
+    });
+  });
+
+  describe('getGgufFiles', () => {
+    test('throws on a malformed model id without fetching', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify({ siblings: [] }), { status: 200 }))
+      );
+
+      await expect(huggingFaceService.getGgufFiles('../../etc/passwd')).rejects.toThrow(
+        'Invalid Hugging Face model id'
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(0);
+    });
+
+    test('encodes the model id when building the api URL', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ siblings: [{ rfilename: 'model.Q4_K_M.gguf' }] }), {
+            status: 200,
+          })
+        )
+      );
+
+      const files = await huggingFaceService.getGgufFiles('unsloth/Qwen3-4B-GGUF');
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://huggingface.co/api/models/unsloth/Qwen3-4B-GGUF');
+      expect(files).toEqual(['model.Q4_K_M.gguf']);
+    });
+  });
+
+  describe('isValidHfRepoId', () => {
+    test('accepts canonical single- and two-segment ids', () => {
+      for (const ok of ['gpt2', 'meta-llama/Meta-Llama-3-70B', 'unsloth/Qwen3-4B-GGUF', 'a_b.c-d/e.f_g-h']) {
+        expect(isValidHfRepoId(ok)).toBe(true);
+      }
+    });
+
+    test('rejects traversal, extra segments, and unsafe characters', () => {
+      for (const bad of [
+        '',
+        '.',
+        '..',
+        'owner/',
+        '/name',
+        'a/b/c',
+        '../../etc/passwd',
+        'foo bar',
+        'owner/name?x=1',
+        'owner/name#frag',
+        'owner/na me',
+        'a'.repeat(97) + '/b',
+      ]) {
+        expect(isValidHfRepoId(bad)).toBe(false);
+      }
+    });
+  });
+
+  describe('encodeHfRepoPath', () => {
+    test('percent-encodes each segment but preserves the slash', () => {
+      expect(encodeHfRepoPath('owner/name')).toBe('owner/name');
+      expect(encodeHfRepoPath('gpt2')).toBe('gpt2');
     });
   });
 });

--- a/backend/src/services/huggingface.test.ts
+++ b/backend/src/services/huggingface.test.ts
@@ -296,6 +296,40 @@ describe('HuggingFaceService', () => {
       }
     });
 
+    test('evicts the least-recently-used entry past the size cap', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(configJson, { status: 200 }))
+      );
+
+      // ARCH_CACHE_MAX_ENTRIES is 500. Fill the cache to the cap, then touch the
+      // first key so it is no longer the least-recently-used, then insert one
+      // more distinct key to trigger a single eviction.
+      const CAP = 500;
+      for (let i = 0; i < CAP; i++) {
+        await huggingFaceService.getModelArchitecture(`org/model-${i}`);
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(CAP);
+
+      // Re-access model-0 (currently the oldest): served from cache (no fetch)
+      // and promoted to most-recently-used.
+      await huggingFaceService.getModelArchitecture('org/model-0');
+      expect(mockFetch).toHaveBeenCalledTimes(CAP);
+
+      // Insert a brand-new key, pushing the cache over the cap. The LRU victim is
+      // now model-1 (model-0 was just promoted), so model-1 must re-fetch while
+      // model-0 stays cached.
+      await huggingFaceService.getModelArchitecture('org/overflow');
+      expect(mockFetch).toHaveBeenCalledTimes(CAP + 1);
+
+      // model-0 was promoted → still cached (no new fetch).
+      await huggingFaceService.getModelArchitecture('org/model-0');
+      expect(mockFetch).toHaveBeenCalledTimes(CAP + 1);
+
+      // model-1 was evicted → must re-fetch.
+      await huggingFaceService.getModelArchitecture('org/model-1');
+      expect(mockFetch).toHaveBeenCalledTimes(CAP + 2);
+    });
+
     test('returns undefined on a non-ok response', async () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve(new Response('not found', { status: 404 }))

--- a/backend/src/services/huggingface.ts
+++ b/backend/src/services/huggingface.ts
@@ -307,8 +307,13 @@ class HuggingFaceService {
   async getModelArchitecture(modelId: string, hfToken?: string): Promise<ModelArchitecture | undefined> {
     const cacheKey = architectureCacheKey(modelId, hfToken);
     const cached = architectureCache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) {
-      return cached.value;
+    if (cached) {
+      if (cached.expiresAt > Date.now()) {
+        return cached.value;
+      }
+      // Drop the stale entry so the cache stays bounded by "used within TTL"
+      // rather than growing unbounded across many distinct modelIds/tokens.
+      architectureCache.delete(cacheKey);
     }
 
     const url = `${HF_BASE_URL}/${modelId}/resolve/main/config.json`;

--- a/backend/src/services/huggingface.ts
+++ b/backend/src/services/huggingface.ts
@@ -17,6 +17,44 @@ const HF_WHOAMI_URL = 'https://huggingface.co/api/whoami-v2';
 const HF_MODELS_URL = 'https://huggingface.co/api/models';
 const HF_BASE_URL = 'https://huggingface.co';
 
+/** Max characters per repo-id segment (HF's own repo-name limit is 96). */
+const HF_REPO_SEGMENT_MAX = 96;
+
+/**
+ * Validate a HuggingFace repo id (`owner/name`, or a canonical single-segment id
+ * like `gpt2`) before it is interpolated into an outbound URL.
+ *
+ * Security: `modelId` arrives from untrusted query/path input and is sent to
+ * huggingface.co with the caller's `Authorization` token. Without this guard a
+ * crafted value (`../../other`, extra `/segments`, `name?x=1`, whitespace) could
+ * steer that authenticated request to an unintended path. We therefore allow
+ * only 1–2 non-empty segments of safe characters and reject `.`/`..` traversal.
+ */
+export function isValidHfRepoId(modelId: string): boolean {
+  if (typeof modelId !== 'string') return false;
+  const segments = modelId.split('/');
+  if (segments.length < 1 || segments.length > 2) return false;
+  return segments.every(
+    (seg) =>
+      seg.length > 0 &&
+      seg.length <= HF_REPO_SEGMENT_MAX &&
+      seg !== '.' &&
+      seg !== '..' &&
+      /^[A-Za-z0-9._-]+$/.test(seg)
+  );
+}
+
+/**
+ * Percent-encode each path segment of a repo id before interpolation. Mirrors
+ * the per-segment encoder in aikit.ts (`buildHuggingFaceUrl`). Callers should
+ * still validate with `isValidHfRepoId` first — this is defense in depth so even
+ * a validated id can never inject path/query syntax.
+ */
+export function encodeHfRepoPath(modelId: string): string {
+  return modelId.split('/').map(encodeURIComponent).join('/');
+}
+
+
 /**
  * Cache for model architecture (config.json) lookups.
  *
@@ -268,7 +306,14 @@ class HuggingFaceService {
   async getGgufFiles(modelId: string, accessToken?: string): Promise<string[]> {
     logger.debug({ modelId }, 'Fetching GGUF files from HuggingFace repo');
 
-    const url = `https://huggingface.co/api/models/${modelId}`;
+    // Reject malformed ids before issuing a token-bearing request (see
+    // isValidHfRepoId). Throwing keeps this method's existing throw-on-failure
+    // contract; callers already surface errors.
+    if (!isValidHfRepoId(modelId)) {
+      throw new Error('Invalid Hugging Face model id');
+    }
+
+    const url = `https://huggingface.co/api/models/${encodeHfRepoPath(modelId)}`;
     const headers: Record<string, string> = {};
     if (accessToken) {
       headers['Authorization'] = `Bearer ${accessToken}`;
@@ -305,6 +350,14 @@ class HuggingFaceService {
    * @param hfToken - Optional HF access token for gated/private models
    */
   async getModelArchitecture(modelId: string, hfToken?: string): Promise<ModelArchitecture | undefined> {
+    // Reject malformed ids before any cache work or token-bearing fetch. The
+    // method's contract is graceful degradation (undefined → bandwidth-only
+    // estimate), so an invalid id is treated the same as a lookup miss.
+    if (!isValidHfRepoId(modelId)) {
+      logger.debug({ modelId }, 'Rejecting invalid HuggingFace model id');
+      return undefined;
+    }
+
     const cacheKey = architectureCacheKey(modelId, hfToken);
     const cached = architectureCache.get(cacheKey);
     if (cached) {
@@ -316,7 +369,7 @@ class HuggingFaceService {
       architectureCache.delete(cacheKey);
     }
 
-    const url = `${HF_BASE_URL}/${modelId}/resolve/main/config.json`;
+    const url = `${HF_BASE_URL}/${encodeHfRepoPath(modelId)}/resolve/main/config.json`;
     const headers: Record<string, string> = {};
     if (hfToken) {
       headers['Authorization'] = `Bearer ${hfToken}`;

--- a/backend/src/services/huggingface.ts
+++ b/backend/src/services/huggingface.ts
@@ -83,7 +83,12 @@ function architectureCacheKey(modelId: string, hfToken?: string): string {
 }
 
 /** Shape of the subset of HuggingFace config.json fields we read. */
-interface HfConfigJson {
+/**
+ * The transformer dimensions we read from a HuggingFace `config.json`. For a
+ * plain decoder LLM these live at the top level; for many multimodal /
+ * image-text-to-text models they live in a nested sub-config (see below).
+ */
+interface HfTransformerConfig {
   num_hidden_layers?: number;
   num_attention_heads?: number;
   num_key_value_heads?: number;
@@ -91,6 +96,45 @@ interface HfConfigJson {
   hidden_size?: number;
   max_position_embeddings?: number;
   torch_dtype?: string;
+}
+
+interface HfConfigJson extends HfTransformerConfig {
+  // Composite/multimodal configs (LLaVA, InternVL, Llama-4, Gemma-3, Mllama, …)
+  // nest the language-model dimensions under a sub-config rather than at the top
+  // level. Checked in priority order by resolveTransformerConfig().
+  text_config?: HfTransformerConfig;
+  llm_config?: HfTransformerConfig;
+  language_config?: HfTransformerConfig;
+}
+
+/**
+ * Nested config keys that hold the language-model transformer dimensions on
+ * composite/multimodal models, in priority order.
+ */
+const NESTED_TEXT_CONFIG_KEYS = ['text_config', 'llm_config', 'language_config'] as const;
+
+/**
+ * Resolve the sub-config carrying the language-model transformer dimensions.
+ *
+ * Plain decoder LLMs keep `num_hidden_layers` & friends at the top level; many
+ * multimodal / image-text-to-text configs nest them under `text_config`,
+ * `llm_config`, or `language_config` while the top level only describes the
+ * composite model. Prefer the top-level fields when present (normal decoder),
+ * else the first nested sub-config that looks like a transformer (has
+ * `num_hidden_layers`). Falls back to the top-level object when nothing
+ * qualifies, preserving the prior degrade-to-low-confidence behavior.
+ */
+function resolveTransformerConfig(config: HfConfigJson): HfTransformerConfig {
+  if (config.num_hidden_layers != null) {
+    return config;
+  }
+  for (const key of NESTED_TEXT_CONFIG_KEYS) {
+    const nested = config[key];
+    if (nested && typeof nested === 'object' && nested.num_hidden_layers != null) {
+      return nested;
+    }
+  }
+  return config;
 }
 
 /**
@@ -400,21 +444,26 @@ class HuggingFaceService {
       return undefined;
     }
 
+    // For multimodal/composite models the transformer dimensions live in a
+    // nested sub-config (text_config / llm_config / language_config) rather than
+    // at the top level; resolve to whichever object actually holds them.
+    const tf = resolveTransformerConfig(config);
+
     // num_key_value_heads is absent on MHA models; fall back to attention heads.
-    const numKvHeads = config.num_key_value_heads ?? config.num_attention_heads;
+    const numKvHeads = tf.num_key_value_heads ?? tf.num_attention_heads;
     // head_dim is often omitted; derive from hidden_size / num_attention_heads.
     const headDim =
-      config.head_dim ??
-      (config.hidden_size && config.num_attention_heads
-        ? config.hidden_size / config.num_attention_heads
+      tf.head_dim ??
+      (tf.hidden_size && tf.num_attention_heads
+        ? tf.hidden_size / tf.num_attention_heads
         : undefined);
 
     const arch: ModelArchitecture = {
-      numLayers: config.num_hidden_layers,
+      numLayers: tf.num_hidden_layers,
       numKvHeads,
       headDim,
-      maxPositionEmbeddings: config.max_position_embeddings,
-      torchDtype: config.torch_dtype,
+      maxPositionEmbeddings: tf.max_position_embeddings,
+      torchDtype: tf.torch_dtype ?? config.torch_dtype,
     };
 
     // Cache successful lookups only.

--- a/backend/src/services/huggingface.ts
+++ b/backend/src/services/huggingface.ts
@@ -62,8 +62,16 @@ export function encodeHfRepoPath(modelId: string): string {
  * responses are keyed by `modelId + ':' + sha256(token)` so one user's gated
  * config can never be served to a caller with a different (or no) token.
  * Only successful lookups are cached, with a short TTL since `main` can move.
+ *
+ * Bounding: entries are TTL-expired lazily on re-access, but a single fetch of
+ * many distinct modelId/token keys would otherwise keep them all resident for
+ * the full TTL. An LRU size cap (`ARCH_CACHE_MAX_ENTRIES`) bounds the map under
+ * wide-scan or adversarial traffic: the least-recently-used entry is evicted
+ * once the cap is exceeded. The Map's insertion order is the recency order —
+ * fresh hits re-insert to move themselves to the newest position.
  */
 const ARCH_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const ARCH_CACHE_MAX_ENTRIES = 500;
 const architectureCache = new Map<string, { value: ModelArchitecture; expiresAt: number }>();
 
 function architectureCacheKey(modelId: string, hfToken?: string): string {
@@ -362,6 +370,10 @@ class HuggingFaceService {
     const cached = architectureCache.get(cacheKey);
     if (cached) {
       if (cached.expiresAt > Date.now()) {
+        // Bump recency: delete + re-insert moves this key to the newest
+        // position so the LRU eviction below sheds genuinely cold entries.
+        architectureCache.delete(cacheKey);
+        architectureCache.set(cacheKey, cached);
         return cached.value;
       }
       // Drop the stale entry so the cache stays bounded by "used within TTL"
@@ -407,6 +419,14 @@ class HuggingFaceService {
 
     // Cache successful lookups only.
     architectureCache.set(cacheKey, { value: arch, expiresAt: Date.now() + ARCH_CACHE_TTL_MS });
+    // Evict the least-recently-used entry (the Map's oldest insertion) when the
+    // size cap is exceeded, bounding memory under wide-scan/adversarial traffic.
+    if (architectureCache.size > ARCH_CACHE_MAX_ENTRIES) {
+      const oldestKey = architectureCache.keys().next().value;
+      if (oldestKey !== undefined) {
+        architectureCache.delete(oldestKey);
+      }
+    }
     return arch;
   }
 }

--- a/backend/src/services/huggingface.ts
+++ b/backend/src/services/huggingface.ts
@@ -1,5 +1,6 @@
 import logger from '../lib/logger';
-import type { HfUserInfo, HfTokenExchangeResponse, HfApiModelResult, HfModelSearchResult, HfSearchParams, HfModelSearchResponse } from '@airunway/shared';
+import { createHash } from 'node:crypto';
+import type { HfUserInfo, HfTokenExchangeResponse, HfApiModelResult, HfModelSearchResult, HfSearchParams, HfModelSearchResponse, ModelArchitecture } from '@airunway/shared';
 import { filterCompatibleModels } from './modelCompatibility';
 
 /**
@@ -15,6 +16,36 @@ const HF_TOKEN_URL = 'https://huggingface.co/oauth/token';
 const HF_WHOAMI_URL = 'https://huggingface.co/api/whoami-v2';
 const HF_MODELS_URL = 'https://huggingface.co/api/models';
 const HF_BASE_URL = 'https://huggingface.co';
+
+/**
+ * Cache for model architecture (config.json) lookups.
+ *
+ * Security: public (no-token) responses are keyed by modelId alone. Tokened
+ * responses are keyed by `modelId + ':' + sha256(token)` so one user's gated
+ * config can never be served to a caller with a different (or no) token.
+ * Only successful lookups are cached, with a short TTL since `main` can move.
+ */
+const ARCH_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const architectureCache = new Map<string, { value: ModelArchitecture; expiresAt: number }>();
+
+function architectureCacheKey(modelId: string, hfToken?: string): string {
+  if (!hfToken) {
+    return modelId;
+  }
+  const tokenHash = createHash('sha256').update(hfToken).digest('hex');
+  return `${modelId}:${tokenHash}`;
+}
+
+/** Shape of the subset of HuggingFace config.json fields we read. */
+interface HfConfigJson {
+  num_hidden_layers?: number;
+  num_attention_heads?: number;
+  num_key_value_heads?: number;
+  head_dim?: number;
+  hidden_size?: number;
+  max_position_embeddings?: number;
+  torch_dtype?: string;
+}
 
 /**
  * HuggingFace OAuth Service
@@ -261,6 +292,64 @@ class HuggingFaceService {
 
     logger.debug({ modelId, count: ggufFiles.length }, 'Found GGUF files');
     return ggufFiles;
+  }
+
+  /**
+   * Fetch transformer architecture details from a model's config.json.
+   *
+   * Used to size the KV cache when estimating concurrent serving capacity.
+   * Returns `undefined` on any failure (network, 404, gated without token,
+   * unparseable) so callers degrade gracefully to a bandwidth-only estimate.
+   *
+   * @param modelId - HuggingFace model ID (e.g. 'meta-llama/Meta-Llama-3-70B')
+   * @param hfToken - Optional HF access token for gated/private models
+   */
+  async getModelArchitecture(modelId: string, hfToken?: string): Promise<ModelArchitecture | undefined> {
+    const cacheKey = architectureCacheKey(modelId, hfToken);
+    const cached = architectureCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    const url = `${HF_BASE_URL}/${modelId}/resolve/main/config.json`;
+    const headers: Record<string, string> = {};
+    if (hfToken) {
+      headers['Authorization'] = `Bearer ${hfToken}`;
+    }
+
+    let config: HfConfigJson;
+    try {
+      const response = await fetch(url, { headers });
+      if (!response.ok) {
+        logger.debug({ status: response.status, modelId }, 'Failed to fetch model config.json');
+        return undefined;
+      }
+      config = (await response.json()) as HfConfigJson;
+    } catch (error) {
+      logger.debug({ error, modelId }, 'Error fetching model config.json');
+      return undefined;
+    }
+
+    // num_key_value_heads is absent on MHA models; fall back to attention heads.
+    const numKvHeads = config.num_key_value_heads ?? config.num_attention_heads;
+    // head_dim is often omitted; derive from hidden_size / num_attention_heads.
+    const headDim =
+      config.head_dim ??
+      (config.hidden_size && config.num_attention_heads
+        ? config.hidden_size / config.num_attention_heads
+        : undefined);
+
+    const arch: ModelArchitecture = {
+      numLayers: config.num_hidden_layers,
+      numKvHeads,
+      headDim,
+      maxPositionEmbeddings: config.max_position_embeddings,
+      torchDtype: config.torch_dtype,
+    };
+
+    // Cache successful lookups only.
+    architectureCache.set(cacheKey, { value: arch, expiresAt: Date.now() + ARCH_CACHE_TTL_MS });
+    return arch;
   }
 }
 

--- a/backend/src/services/modelCompatibility.test.ts
+++ b/backend/src/services/modelCompatibility.test.ts
@@ -7,9 +7,9 @@ import {
   extractParameterCount,
   processHfModel,
   filterCompatibleModels,
-  parseParameterCountFromName,
   getEngineArchitectures,
 } from './modelCompatibility';
+import { parseParameterCountFromName } from '@airunway/shared';
 import type { Engine, HfApiModelResult } from '@airunway/shared';
 
 describe('inferArchitectureFromModelId', () => {

--- a/backend/src/services/modelCompatibility.ts
+++ b/backend/src/services/modelCompatibility.ts
@@ -1,4 +1,5 @@
 import type { Engine, HfApiModelResult, HfModelSearchResult } from '@airunway/shared';
+import { parseParameterCountFromName } from '@airunway/shared';
 import { estimateGpuMemory, formatGpuMemory } from './gpuValidation';
 
 /**
@@ -521,40 +522,6 @@ export function getIncompatibilityReason(
   
   if (!supportedEngines || supportedEngines.length === 0) {
     return `Architecture "${architectures[0]}" is not supported by any engine`;
-  }
-  
-  return undefined;
-}
-
-/**
- * Parse parameter count from model name/ID
- * Handles common naming conventions like "8B", "70B", "1.5B", "0.6B", "405B", "7b", etc.
- * 
- * @param modelId - Model ID or name (e.g., "meta-llama/Llama-3.1-8B-Instruct")
- * @returns Parameter count or undefined if not parseable
- */
-export function parseParameterCountFromName(modelId: string): number | undefined {
-  // Match patterns like "8B", "70B", "1.5B", "0.6B", "405b", "7B", "1B" etc.
-  // Must be preceded by a word boundary, hyphen, or underscore
-  // Case insensitive
-  const match = modelId.match(/(?:^|[-_./])(\d+(?:\.\d+)?)\s*[Bb](?:$|[-_./]|illion)?/);
-  
-  if (match) {
-    const billions = parseFloat(match[1]);
-    if (!isNaN(billions) && billions > 0 && billions < 10000) {
-      // Convert billions to actual parameter count
-      return billions * 1_000_000_000;
-    }
-  }
-  
-  // Also try matching "M" for millions (e.g., "125M", "350M")
-  const millionMatch = modelId.match(/(?:^|[-_./])(\d+(?:\.\d+)?)\s*[Mm](?:$|[-_./]|illion)?/);
-  
-  if (millionMatch) {
-    const millions = parseFloat(millionMatch[1]);
-    if (!isNaN(millions) && millions > 0 && millions < 10000) {
-      return millions * 1_000_000;
-    }
   }
   
   return undefined;

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,8 @@
         "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.9.1",
+        "@typescript-eslint/eslint-plugin": "^8.60.0",
+        "@typescript-eslint/parser": "^8.60.0",
         "eslint": "^10.4.0",
         "pino-pretty": "^13.1.3",
         "typescript": "6.0.3",
@@ -1658,7 +1660,7 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
-    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
@@ -2776,6 +2778,8 @@
 
     "@eslint/eslintrc/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
 
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "@eslint/eslintrc/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
@@ -2954,8 +2958,6 @@
 
     "@types/react-window/@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
 
-    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
     "@vitest/coverage-istanbul/magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
 
     "@vitest/coverage-istanbul/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
@@ -3015,6 +3017,8 @@
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "elliptic/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -3264,6 +3268,8 @@
 
     "@headlamp-k8s/eslint-config/eslint/file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
+    "@headlamp-k8s/eslint-config/eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "@headlamp-k8s/eslint-config/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "@headlamp-k8s/pluginctl/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -3297,6 +3303,8 @@
     "@kinvolk/headlamp-plugin/eslint/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
 
     "@kinvolk/headlamp-plugin/eslint/file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "@kinvolk/headlamp-plugin/eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "@kinvolk/headlamp-plugin/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -3486,6 +3494,8 @@
 
     "eslint-plugin-import/eslint/file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
+    "eslint-plugin-import/eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "eslint-plugin-import/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "eslint-plugin-import/tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
@@ -3500,6 +3510,8 @@
 
     "eslint-plugin-jsx-a11y/eslint/file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
 
+    "eslint-plugin-jsx-a11y/eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "eslint-plugin-react/eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
@@ -3513,6 +3525,8 @@
     "eslint-plugin-react/eslint/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
 
     "eslint-plugin-react/eslint/file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "eslint-plugin-react/eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,54 @@
+// Flat ESLint config (ESLint v9+). Replaces the old .eslintrc + `--ext` flow,
+// which ESLint v9 removed. TypeScript is linted via the typescript-eslint
+// plugin's `flat/recommended` preset, which bundles the parser, the plugin, and
+// a non-type-checked rule set (fast, low false-positive noise).
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  // Ignore build output and config files (mirrors the previous `eslint src`
+  // scope — only application source is linted).
+  {
+    ignores: ['dist/**', 'node_modules/**', '*.config.*', 'coverage/**'],
+  },
+
+  // typescript-eslint's flat/recommended turns off core rules that clash with
+  // TS (e.g. no-undef), wires up the parser, and enables the recommended rules.
+  ...tseslint.configs['flat/recommended'],
+
+  // React-specific rules + JSX parsing for the application source.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsparser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+
+      // Pre-existing debt: this codebase predates any ESLint config (the v8→v10
+      // bump first introduced one) and the react-hooks v4→v7 bump enabled new
+      // React-Compiler rules. `recommended` therefore surfaces ~26 historical
+      // violations — none in newly-written code. Demote them to warnings so lint
+      // is green and CI-usable today while still surfacing the backlog for
+      // incremental burndown. Promote back to "error" once each is cleared.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-empty-object-type': 'warn',
+      'react-hooks/set-state-in-effect': 'warn',
+      'react-hooks/purity': 'warn',
+      'react-hooks/preserve-manual-memoization': 'warn',
+    },
+  },
+];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bunx --bun vite",
     "build": "tsc && bunx --bun vite build",
-    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint src --report-unused-disable-directives",
     "preview": "bunx --bun vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/frontend/src/components/deployments/DeploymentForm.test.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.test.tsx
@@ -149,6 +149,69 @@ describe('DeploymentForm', () => {
     expect(screen.getByRole('button', { name: /Deploy Model/i })).toBeEnabled()
   })
 
+  it('warns but does not block deploying when the throughput estimate says the model does not fit', () => {
+    render(
+      <MemoryRouter>
+        <DeploymentForm
+          model={createModel({ supportedEngines: ['vllm'] })}
+          detailedCapacity={createCapacity()}
+          runtimes={[
+            createRuntime({
+              id: 'vllm',
+              name: 'vLLM',
+              installed: true,
+              healthy: true,
+              requiresCRD: false,
+            }),
+          ]}
+          doesNotFit
+          doesNotFitReason="This model is estimated not to fit on this cluster's GPU (A10) at 1 GPU per replica."
+        />
+      </MemoryRouter>
+    )
+
+    const vllmCard = screen
+      .getByText('High-throughput inference with the native vLLM provider')
+      .closest('[role="radio"]') as HTMLElement
+    fireEvent.click(vllmCard)
+
+    // The warning is surfaced...
+    expect(
+      screen.getByText(/estimated not to fit on this cluster's GPU \(A10\)/i)
+    ).toBeInTheDocument()
+    // ...but Deploy stays enabled (the user may pick more GPUs per replica).
+    expect(screen.getByRole('button', { name: /Deploy Model/i })).toBeEnabled()
+  })
+
+  it('hides the does-not-fit warning when FP8 is already blocking deployment', () => {
+    render(
+      <MemoryRouter>
+        <DeploymentForm
+          model={createModel({ supportedEngines: ['vllm'] })}
+          detailedCapacity={createCapacity()}
+          runtimes={[
+            createRuntime({
+              id: 'vllm',
+              name: 'vLLM',
+              installed: true,
+              healthy: true,
+              requiresCRD: false,
+            }),
+          ]}
+          doesNotFit
+          doesNotFitReason="This model is estimated not to fit."
+          fp8Blocked
+          fp8BlockReason="FP8 is only supported on H100/H200 GPUs."
+        />
+      </MemoryRouter>
+    )
+
+    // The blocking FP8 message wins; the does-not-fit warning is suppressed to
+    // avoid stacking two conflicting messages.
+    expect(screen.getByText(/FP8 is only supported on H100\/H200 GPUs/i)).toBeInTheDocument()
+    expect(screen.queryByText(/estimated not to fit/i)).not.toBeInTheDocument()
+  })
+
   it('treats a CRD-less vLLM provider that is not ready as registered but unavailable', async () => {
     render(
       <MemoryRouter>

--- a/frontend/src/components/deployments/DeploymentForm.test.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DetailedClusterCapacity, Model, RuntimeStatus } from '@/lib/api'
-import { DeploymentForm } from './DeploymentForm'
+import { DeploymentForm, setFp8PrecisionEngineArgs } from './DeploymentForm'
 
 const mutateAsync = vi.fn()
 const toast = vi.fn()
@@ -321,5 +321,65 @@ describe('DeploymentForm', () => {
       expect(toggle).toHaveAttribute('aria-checked', 'true')
       expect(latestManifestConfig()?.gatewayEnabled).toBe(true)
     })
+  })
+})
+
+describe('setFp8PrecisionEngineArgs', () => {
+  it('preserves a user-set non-fp8 quantization when weight precision is not FP8', () => {
+    // Regression: the precision dropdowns must not clobber an awq/gptq value the
+    // user typed into the advanced engine-args editor.
+    const result = setFp8PrecisionEngineArgs(
+      { quantization: 'awq' },
+      { weightFp8: false, kvFp8: false }
+    )
+    expect(result).toEqual({ quantization: 'awq' })
+  })
+
+  it('strips a quantization value it owns (fp8) when weight precision is not FP8', () => {
+    const result = setFp8PrecisionEngineArgs(
+      { quantization: 'fp8' },
+      { weightFp8: false, kvFp8: false }
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it('sets quantization to fp8 when weight precision is FP8, overriding a prior awq', () => {
+    const result = setFp8PrecisionEngineArgs(
+      { quantization: 'awq' },
+      { weightFp8: true, kvFp8: false }
+    )
+    expect(result).toEqual({ quantization: 'fp8' })
+  })
+
+  it('preserves a user-set non-fp8 kv-cache-dtype when KV precision is not FP8', () => {
+    const result = setFp8PrecisionEngineArgs(
+      { 'kv-cache-dtype': 'int8' },
+      { weightFp8: false, kvFp8: false }
+    )
+    expect(result).toEqual({ 'kv-cache-dtype': 'int8' })
+  })
+
+  it('strips a kv-cache-dtype value it owns (fp8) when KV precision is not FP8', () => {
+    const result = setFp8PrecisionEngineArgs(
+      { 'kv-cache-dtype': 'fp8' },
+      { weightFp8: false, kvFp8: false }
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it('sets kv-cache-dtype to fp8 when KV precision is FP8, overriding a prior int8', () => {
+    const result = setFp8PrecisionEngineArgs(
+      { 'kv-cache-dtype': 'int8' },
+      { weightFp8: false, kvFp8: true }
+    )
+    expect(result).toEqual({ 'kv-cache-dtype': 'fp8' })
+  })
+
+  it('leaves unrelated engine args untouched', () => {
+    const result = setFp8PrecisionEngineArgs(
+      { 'max-model-len': '8192', quantization: 'gptq' },
+      { weightFp8: false, kvFp8: false }
+    )
+    expect(result).toEqual({ 'max-model-len': '8192', quantization: 'gptq' })
   })
 })

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -84,6 +84,18 @@ interface DeploymentFormProps {
   detailedCapacity?: DetailedClusterCapacity
   autoscaler?: AutoscalerDetectionResult
   runtimes?: RuntimeStatus[]
+  /** Weight precision chosen on the Deploy page (FP8 emits an engine arg). */
+  weightQuant?: 'fp16' | 'fp8'
+  /** KV-cache precision chosen on the Deploy page (FP8 emits an engine arg). */
+  kvCacheDtype?: 'fp16' | 'fp8'
+  /**
+   * True when FP8 was selected but the target GPU has no FP8 datapath
+   * (non-Hopper). Disables the Deploy button so we never submit a flag the
+   * engine can't honor.
+   */
+  fp8Blocked?: boolean
+  /** Human-readable reason shown when fp8Blocked is true. */
+  fp8BlockReason?: string
 }
 
 // Subset of Engine type for traditional GPU inference engines (excludes llamacpp which is KAITO-only)
@@ -96,6 +108,13 @@ type GgufRunMode = 'build' | 'direct'
 
 const TENSOR_PARALLEL_SIZE_ARG = 'tensor-parallel-size'
 const PIPELINE_PARALLEL_SIZE_ARG = 'pipeline-parallel-size'
+// FP8 precision engine flags (vLLM / SGLang). Only emitted when FP8 is selected
+// on FP8-capable hardware; FP16/BF16 is the engine default and needs no flag.
+const QUANTIZATION_ARG = 'quantization'
+const KV_CACHE_DTYPE_ARG = 'kv-cache-dtype'
+// Engines that accept the generic --quantization / --kv-cache-dtype flags.
+// TRT-LLM uses a different mechanism and KAITO ignores generic engine args.
+const FP8_ARG_ENGINES: TraditionalEngine[] = ['vllm', 'sglang']
 
 // Runtime metadata for display
 const RUNTIME_INFO: Record<RuntimeId, { name: string; description: string; defaultNamespace: string }> = {
@@ -211,7 +230,34 @@ function setDynamoParallelismEngineArgs(
   return Object.keys(nextEngineArgs).length > 0 ? nextEngineArgs : undefined;
 }
 
-export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }: DeploymentFormProps) {
+/**
+ * Merge or strip the FP8 precision engine args (`quantization`,
+ * `kv-cache-dtype`) without clobbering other args. Sets a key to `fp8` when the
+ * corresponding precision is FP8 and the engine supports the flag; otherwise
+ * removes it (FP16/BF16 is the engine default and needs no flag).
+ */
+function setFp8PrecisionEngineArgs(
+  engineArgs: Record<string, unknown> | undefined,
+  opts: { weightFp8: boolean; kvFp8: boolean }
+): Record<string, unknown> | undefined {
+  const nextEngineArgs = { ...(engineArgs || {}) };
+
+  if (opts.weightFp8) {
+    nextEngineArgs[QUANTIZATION_ARG] = 'fp8';
+  } else {
+    delete nextEngineArgs[QUANTIZATION_ARG];
+  }
+
+  if (opts.kvFp8) {
+    nextEngineArgs[KV_CACHE_DTYPE_ARG] = 'fp8';
+  } else {
+    delete nextEngineArgs[KV_CACHE_DTYPE_ARG];
+  }
+
+  return Object.keys(nextEngineArgs).length > 0 ? nextEngineArgs : undefined;
+}
+
+export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes, weightQuant = 'fp16', kvCacheDtype = 'fp16', fp8Blocked = false, fp8BlockReason }: DeploymentFormProps) {
   const navigate = useNavigate()
   const { toast } = useToast()
   const createDeployment = useCreateDeployment()
@@ -474,6 +520,27 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
     config.mode,
     topologyManagedByAIConfig,
   ])
+
+  // Apply (or strip) FP8 precision engine args based on the Deploy page's
+  // precision dropdowns. Only emitted for engines that accept the generic flags
+  // (vLLM / SGLang) and never when FP8 is blocked on non-Hopper hardware.
+  useEffect(() => {
+    const engineSupportsFp8Args = FP8_ARG_ENGINES.includes(config.engine as TraditionalEngine)
+    const weightFp8 = weightQuant === 'fp8' && engineSupportsFp8Args && !fp8Blocked
+    const kvFp8 = kvCacheDtype === 'fp8' && engineSupportsFp8Args && !fp8Blocked
+
+    setConfig(prev => {
+      const nextEngineArgs = setFp8PrecisionEngineArgs(prev.engineArgs, { weightFp8, kvFp8 })
+      const prevQuant = prev.engineArgs?.[QUANTIZATION_ARG]
+      const prevKv = prev.engineArgs?.[KV_CACHE_DTYPE_ARG]
+      const nextQuant = nextEngineArgs?.[QUANTIZATION_ARG]
+      const nextKv = nextEngineArgs?.[KV_CACHE_DTYPE_ARG]
+      if (prevQuant === nextQuant && prevKv === nextKv) {
+        return prev
+      }
+      return { ...prev, engineArgs: nextEngineArgs }
+    })
+  }, [weightQuant, kvCacheDtype, fp8Blocked, config.engine])
 
   // Auto-select matching premade model when navigating with a KAITO model from Models page
   useEffect(() => {
@@ -863,6 +930,10 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
   const getButtonContent = () => {
     if (needsHfAuth) {
       return 'HuggingFace Auth Required'
+    }
+
+    if (fp8Blocked) {
+      return 'FP8 Not Supported on This GPU'
     }
 
     if (!isRuntimeInstalled) {
@@ -1911,7 +1982,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
         </Button>
         <Button
           type="submit"
-          disabled={createDeployment.isProcessing || needsHfAuth || !isRuntimeInstalled || !isKaitoConfigValid}
+          disabled={createDeployment.isProcessing || needsHfAuth || !isRuntimeInstalled || !isKaitoConfigValid || fp8Blocked}
           loading={createDeployment.isProcessing}
           className={cn(
             "flex-1 h-14 rounded-2xl bg-primary text-primary-foreground font-bold shadow-glow-button gap-2",
@@ -1921,6 +1992,11 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes }
           {getButtonContent()}
         </Button>
       </div>
+      {fp8Blocked && (
+        <p className="text-sm text-destructive text-center">
+          {fp8BlockReason || 'FP8 is only supported on H100/H200 GPUs. Choose FP16/BF16 to deploy.'}
+        </p>
+      )}
     </form>
     </>
   )

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -2009,7 +2009,7 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes, 
       </div>
       {fp8Blocked && (
         <p className="text-sm text-destructive text-center">
-          {fp8BlockReason || 'FP8 is only supported on H100/H200 GPUs. Choose FP16/BF16 to deploy.'}
+          {fp8BlockReason || 'FP8 is only supported on L40S/L4 and H100/H200 GPUs. Choose FP16/BF16 to deploy.'}
         </p>
       )}
       {/* Non-blocking "does not fit" warning. Deploy stays enabled: the estimate

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -89,9 +89,8 @@ interface DeploymentFormProps {
   /** KV-cache precision chosen on the Deploy page (FP8 emits an engine arg). */
   kvCacheDtype?: 'fp16' | 'fp8'
   /**
-   * True when FP8 was selected but the target GPU has no FP8 datapath
-   * (non-Hopper). Disables the Deploy button so we never submit a flag the
-   * engine can't honor.
+   * True when FP8 was selected but the target GPU has no FP8 datapath. Disables
+   * the Deploy button so we never submit a flag the engine can't honor.
    */
   fp8Blocked?: boolean
   /** Human-readable reason shown when fp8Blocked is true. */
@@ -538,7 +537,8 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes, 
 
   // Apply (or strip) FP8 precision engine args based on the Deploy page's
   // precision dropdowns. Only emitted for engines that accept the generic flags
-  // (vLLM / SGLang) and never when FP8 is blocked on non-Hopper hardware.
+  // (vLLM / SGLang) and never when FP8 is blocked on hardware without an FP8
+  // datapath.
   useEffect(() => {
     const engineSupportsFp8Args = FP8_ARG_ENGINES.includes(config.engine as TraditionalEngine)
     const weightFp8 = weightQuant === 'fp8' && engineSupportsFp8Args && !fp8Blocked

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -234,9 +234,12 @@ function setDynamoParallelismEngineArgs(
  * Merge or strip the FP8 precision engine args (`quantization`,
  * `kv-cache-dtype`) without clobbering other args. Sets a key to `fp8` when the
  * corresponding precision is FP8 and the engine supports the flag; otherwise
- * removes it (FP16/BF16 is the engine default and needs no flag).
+ * removes ONLY a value this control owns (`fp8`). A user-provided non-fp8 value
+ * (e.g. `awq`/`gptq` typed into the advanced engine-args editor) is preserved,
+ * since FP16/BF16 is merely the engine default and shouldn't override an
+ * explicit user choice.
  */
-function setFp8PrecisionEngineArgs(
+export function setFp8PrecisionEngineArgs(
   engineArgs: Record<string, unknown> | undefined,
   opts: { weightFp8: boolean; kvFp8: boolean }
 ): Record<string, unknown> | undefined {
@@ -244,13 +247,15 @@ function setFp8PrecisionEngineArgs(
 
   if (opts.weightFp8) {
     nextEngineArgs[QUANTIZATION_ARG] = 'fp8';
-  } else {
+  } else if (nextEngineArgs[QUANTIZATION_ARG] === 'fp8') {
+    // Only strip the value WE set. A user-provided non-fp8 quantization
+    // (e.g. awq, gptq) from the advanced engine-args editor is preserved.
     delete nextEngineArgs[QUANTIZATION_ARG];
   }
 
   if (opts.kvFp8) {
     nextEngineArgs[KV_CACHE_DTYPE_ARG] = 'fp8';
-  } else {
+  } else if (nextEngineArgs[KV_CACHE_DTYPE_ARG] === 'fp8') {
     delete nextEngineArgs[KV_CACHE_DTYPE_ARG];
   }
 

--- a/frontend/src/components/deployments/DeploymentForm.tsx
+++ b/frontend/src/components/deployments/DeploymentForm.tsx
@@ -96,6 +96,16 @@ interface DeploymentFormProps {
   fp8Blocked?: boolean
   /** Human-readable reason shown when fp8Blocked is true. */
   fp8BlockReason?: string
+  /**
+   * True when the throughput estimate determined (with high confidence) that the
+   * model does not fit on the cluster's GPU at the estimated topology. Surfaced
+   * as a non-blocking warning near the Deploy button — it does NOT disable
+   * deploying, since the user may select more GPUs per replica than the estimate
+   * assumed.
+   */
+  doesNotFit?: boolean
+  /** Human-readable reason shown when doesNotFit is true. */
+  doesNotFitReason?: string
 }
 
 // Subset of Engine type for traditional GPU inference engines (excludes llamacpp which is KAITO-only)
@@ -262,7 +272,7 @@ export function setFp8PrecisionEngineArgs(
   return Object.keys(nextEngineArgs).length > 0 ? nextEngineArgs : undefined;
 }
 
-export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes, weightQuant = 'fp16', kvCacheDtype = 'fp16', fp8Blocked = false, fp8BlockReason }: DeploymentFormProps) {
+export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes, weightQuant = 'fp16', kvCacheDtype = 'fp16', fp8Blocked = false, fp8BlockReason, doesNotFit = false, doesNotFitReason }: DeploymentFormProps) {
   const navigate = useNavigate()
   const { toast } = useToast()
   const createDeployment = useCreateDeployment()
@@ -2000,6 +2010,15 @@ export function DeploymentForm({ model, detailedCapacity, autoscaler, runtimes, 
       {fp8Blocked && (
         <p className="text-sm text-destructive text-center">
           {fp8BlockReason || 'FP8 is only supported on H100/H200 GPUs. Choose FP16/BF16 to deploy.'}
+        </p>
+      )}
+      {/* Non-blocking "does not fit" warning. Deploy stays enabled: the estimate
+          assumes a fixed GPUs-per-replica, but the user may select more here, so
+          we caution rather than block. Hidden when fp8Blocked already explains a
+          blocking reason. */}
+      {doesNotFit && !fp8Blocked && (
+        <p className="text-sm text-yellow-500/90 text-center">
+          {doesNotFitReason || "This model is estimated not to fit on this cluster's GPUs at the selected precision. Try more GPUs per replica, a smaller model, or FP8 precision."}
         </p>
       )}
     </form>

--- a/frontend/src/components/models/HfModelCard.tsx
+++ b/frontend/src/components/models/HfModelCard.tsx
@@ -15,8 +15,8 @@ interface HfModelCardProps {
   gpuCapacityGb?: number;
   gpuCount?: number;
   gpuCapacityLabel?: string;
-  /** GPU model name (e.g. "H100-80GB") used for the throughput estimate. */
-  gpuModel?: string;
+  /** Whether the cluster has any GPU pool to estimate on (backend picks which). */
+  gpuPresent?: boolean;
 }
 
 /**
@@ -32,7 +32,7 @@ function formatCount(count: number): string {
   return count.toString();
 }
 
-export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: HfModelCardProps) {
+export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuPresent }: HfModelCardProps) {
   const navigate = useNavigate();
 
   const handleDeploy = () => {
@@ -44,7 +44,7 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, 
   const { ref: inViewRef, inView } = useInView<HTMLDivElement>();
   const throughputParams = buildThroughputParamsForGpu(
     { id: model.id, parameterCount: model.parameterCount },
-    gpuModel
+    gpuPresent
   );
   const { data: throughput, isLoading: throughputLoading } = useGpuThroughput(
     throughputParams ?? {},

--- a/frontend/src/components/models/HfModelCard.tsx
+++ b/frontend/src/components/models/HfModelCard.tsx
@@ -2,15 +2,21 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { GpuFitIndicator } from './GpuFitIndicator';
+import { ThroughputEstimate } from './ThroughputEstimate';
 import type { HfModelSearchResult } from '@airunway/shared';
 import { Download, Heart, Lock } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useGpuThroughput } from '@/hooks/useGpuOperator';
+import { useInView } from '@/hooks/useInView';
+import { buildThroughputParamsForGpu } from '@/lib/gpu-throughput-params';
 
 interface HfModelCardProps {
   model: HfModelSearchResult;
   gpuCapacityGb?: number;
   gpuCount?: number;
   gpuCapacityLabel?: string;
+  /** GPU model name (e.g. "H100-80GB") used for the throughput estimate. */
+  gpuModel?: string;
 }
 
 /**
@@ -26,7 +32,7 @@ function formatCount(count: number): string {
   return count.toString();
 }
 
-export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: HfModelCardProps) {
+export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: HfModelCardProps) {
   const navigate = useNavigate();
 
   const handleDeploy = () => {
@@ -34,8 +40,20 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }
     navigate(`/deploy/${encodeURIComponent(model.id)}?source=hf`);
   };
 
+  // Lazy throughput estimate: only fetch once the card scrolls into view.
+  const { ref: inViewRef, inView } = useInView<HTMLDivElement>();
+  const throughputParams = buildThroughputParamsForGpu(
+    { id: model.id, parameterCount: model.parameterCount },
+    gpuModel
+  );
+  const { data: throughput, isLoading: throughputLoading } = useGpuThroughput(
+    throughputParams ?? {},
+    { enabled: inView && !!throughputParams }
+  );
+
   return (
     <div
+      ref={inViewRef}
       className={cn(
         "flex flex-col rounded-2xl p-5 group",
         "bg-white/[0.03] border border-white/5",
@@ -82,6 +100,12 @@ export function HfModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }
             capacityLabel={gpuCapacityLabel}
           />
         </div>
+
+        {throughputParams && (throughputLoading || throughput) && (
+          <div className="mb-3">
+            <ThroughputEstimate estimate={throughput} isLoading={throughputLoading} />
+          </div>
+        )}
 
         {/* Supported engines */}
         <div className="flex flex-wrap gap-1">

--- a/frontend/src/components/models/HfModelSearch.tsx
+++ b/frontend/src/components/models/HfModelSearch.tsx
@@ -14,10 +14,10 @@ interface HfModelSearchProps {
   gpuCapacityGb?: number;
   gpuCount?: number;
   gpuCapacityLabel?: string;
-  gpuModel?: string;
+  gpuPresent?: boolean;
 }
 
-export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: HfModelSearchProps) {
+export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuPresent }: HfModelSearchProps) {
   const [query, setQuery] = useState('');
   const [offset, setOffset] = useState(0);
   const limit = 20;
@@ -137,7 +137,7 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapaci
                 gpuCapacityGb={maxGpuMemoryGb}
                 gpuCount={effectiveGpuCount}
                 gpuCapacityLabel={effectiveCapacityLabel}
-                gpuModel={gpuModel}
+                gpuPresent={gpuPresent}
               />
             ))}
           </div>

--- a/frontend/src/components/models/HfModelSearch.tsx
+++ b/frontend/src/components/models/HfModelSearch.tsx
@@ -14,9 +14,10 @@ interface HfModelSearchProps {
   gpuCapacityGb?: number;
   gpuCount?: number;
   gpuCapacityLabel?: string;
+  gpuModel?: string;
 }
 
-export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapacityLabel }: HfModelSearchProps) {
+export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: HfModelSearchProps) {
   const [query, setQuery] = useState('');
   const [offset, setOffset] = useState(0);
   const limit = 20;
@@ -136,6 +137,7 @@ export function HfModelSearch({ onLoginClick, gpuCapacityGb, gpuCount, gpuCapaci
                 gpuCapacityGb={maxGpuMemoryGb}
                 gpuCount={effectiveGpuCount}
                 gpuCapacityLabel={effectiveCapacityLabel}
+                gpuModel={gpuModel}
               />
             ))}
           </div>

--- a/frontend/src/components/models/ModelCard.tsx
+++ b/frontend/src/components/models/ModelCard.tsx
@@ -15,8 +15,8 @@ interface ModelCardProps {
   gpuCapacityGb?: number
   gpuCount?: number
   gpuCapacityLabel?: string
-  /** GPU model name (e.g. "H100-80GB") used for the throughput estimate. */
-  gpuModel?: string
+  /** Whether the cluster has any GPU pool to estimate on (backend picks which). */
+  gpuPresent?: boolean
 }
 
 /**
@@ -60,7 +60,7 @@ function estimateGgufRamGb(sizeStr?: string): number | undefined {
   return Math.ceil(billions * 0.6 + 2)
 }
 
-export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: ModelCardProps) {
+export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuPresent }: ModelCardProps) {
   const navigate = useNavigate()
 
   const handleDeploy = () => {
@@ -74,7 +74,7 @@ export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, gp
   // Lazy throughput estimate: only fetch once the card scrolls into view, and
   // skip CPU-only models (no GPU throughput to estimate).
   const { ref: inViewRef, inView } = useInView<HTMLDivElement>()
-  const throughputParams = !isCpuModel ? buildThroughputParamsForGpu(model, gpuModel) : undefined
+  const throughputParams = !isCpuModel ? buildThroughputParamsForGpu(model, gpuPresent) : undefined
   const { data: throughput, isLoading: throughputLoading } = useGpuThroughput(
     throughputParams ?? {},
     { enabled: inView && !!throughputParams }

--- a/frontend/src/components/models/ModelCard.tsx
+++ b/frontend/src/components/models/ModelCard.tsx
@@ -2,15 +2,21 @@ import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { GpuFitIndicator } from './GpuFitIndicator'
+import { ThroughputEstimate } from './ThroughputEstimate'
 import { type Model } from '@/lib/api'
 import { Cpu, HardDrive, Layers } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useGpuThroughput } from '@/hooks/useGpuOperator'
+import { useInView } from '@/hooks/useInView'
+import { buildThroughputParamsForGpu } from '@/lib/gpu-throughput-params'
 
 interface ModelCardProps {
   model: Model
   gpuCapacityGb?: number
   gpuCount?: number
   gpuCapacityLabel?: string
+  /** GPU model name (e.g. "H100-80GB") used for the throughput estimate. */
+  gpuModel?: string
 }
 
 /**
@@ -54,7 +60,7 @@ function estimateGgufRamGb(sizeStr?: string): number | undefined {
   return Math.ceil(billions * 0.6 + 2)
 }
 
-export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: ModelCardProps) {
+export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: ModelCardProps) {
   const navigate = useNavigate()
 
   const handleDeploy = () => {
@@ -65,8 +71,18 @@ export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: 
   const estimatedGpuMemoryGb = model.estimatedGpuMemoryGb ?? parseGpuMemoryGb(model.minGpuMemory)
   const estimatedCpuRamGb = isCpuModel ? estimateGgufRamGb(model.size) : undefined
 
+  // Lazy throughput estimate: only fetch once the card scrolls into view, and
+  // skip CPU-only models (no GPU throughput to estimate).
+  const { ref: inViewRef, inView } = useInView<HTMLDivElement>()
+  const throughputParams = !isCpuModel ? buildThroughputParamsForGpu(model, gpuModel) : undefined
+  const { data: throughput, isLoading: throughputLoading } = useGpuThroughput(
+    throughputParams ?? {},
+    { enabled: inView && !!throughputParams }
+  )
+
   return (
     <div
+      ref={inViewRef}
       className={cn(
         "flex flex-col h-full group rounded-2xl p-5",
         "bg-white/[0.03] border border-white/5",
@@ -121,6 +137,10 @@ export function ModelCard({ model, gpuCapacityGb, gpuCount, gpuCapacityLabel }: 
             <HardDrive className="h-4 w-4 shrink-0" />
             <span>{model.conversational ? 'Chat' : formatTaskLabel(model.task)}</span>
           </div>
+
+          {throughputParams && (throughputLoading || throughput) && (
+            <ThroughputEstimate estimate={throughput} isLoading={throughputLoading} />
+          )}
         </div>
 
         <div className="flex flex-wrap gap-1.5 mt-4">

--- a/frontend/src/components/models/ModelGrid.tsx
+++ b/frontend/src/components/models/ModelGrid.tsx
@@ -8,10 +8,10 @@ interface ModelGridProps {
   gpuCapacityGb?: number
   gpuCount?: number
   gpuCapacityLabel?: string
-  gpuModel?: string
+  gpuPresent?: boolean
 }
 
-export function ModelGrid({ models, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: ModelGridProps) {
+export function ModelGrid({ models, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuPresent }: ModelGridProps) {
   const navigate = useNavigate()
 
   if (models.length === 0) {
@@ -43,7 +43,7 @@ export function ModelGrid({ models, gpuCapacityGb, gpuCount, gpuCapacityLabel, g
             gpuCapacityGb={gpuCapacityGb}
             gpuCount={gpuCount}
             gpuCapacityLabel={gpuCapacityLabel}
-            gpuModel={gpuModel}
+            gpuPresent={gpuPresent}
           />
         </div>
       ))}

--- a/frontend/src/components/models/ModelGrid.tsx
+++ b/frontend/src/components/models/ModelGrid.tsx
@@ -8,9 +8,10 @@ interface ModelGridProps {
   gpuCapacityGb?: number
   gpuCount?: number
   gpuCapacityLabel?: string
+  gpuModel?: string
 }
 
-export function ModelGrid({ models, gpuCapacityGb, gpuCount, gpuCapacityLabel }: ModelGridProps) {
+export function ModelGrid({ models, gpuCapacityGb, gpuCount, gpuCapacityLabel, gpuModel }: ModelGridProps) {
   const navigate = useNavigate()
 
   if (models.length === 0) {
@@ -42,6 +43,7 @@ export function ModelGrid({ models, gpuCapacityGb, gpuCount, gpuCapacityLabel }:
             gpuCapacityGb={gpuCapacityGb}
             gpuCount={gpuCount}
             gpuCapacityLabel={gpuCapacityLabel}
+            gpuModel={gpuModel}
           />
         </div>
       ))}

--- a/frontend/src/components/models/ThroughputEstimate.test.tsx
+++ b/frontend/src/components/models/ThroughputEstimate.test.tsx
@@ -21,6 +21,8 @@ describe('ThroughputEstimate', () => {
     render(<ThroughputEstimate estimate={base} />);
     expect(screen.getByText(/~40 tok\/s per chat/)).toBeInTheDocument();
     expect(screen.getByText(/~360 concurrent/)).toBeInTheDocument();
+    // Aggregate total (concurrency × per-chat rate) is shown in the visible label.
+    expect(screen.getByText(/~14k tok\/s total/)).toBeInTheDocument();
   });
 
   it('shows only per-chat speed when low confidence', () => {

--- a/frontend/src/components/models/ThroughputEstimate.test.tsx
+++ b/frontend/src/components/models/ThroughputEstimate.test.tsx
@@ -33,6 +33,23 @@ describe('ThroughputEstimate', () => {
     expect(screen.queryByText(/concurrent/)).not.toBeInTheDocument();
   });
 
+  it('shows a does-not-fit warning when the model has no room for KV cache', () => {
+    render(
+      <ThroughputEstimate
+        estimate={{
+          ...base,
+          concurrentSequences: 0,
+          aggregateTokensPerSec: 0,
+          doesNotFit: true,
+        }}
+      />
+    );
+    expect(screen.getByText(/Does not fit/)).toBeInTheDocument();
+    // The misleading per-chat / concurrency numbers must not be shown.
+    expect(screen.queryByText(/tok\/s per chat/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/concurrent/)).not.toBeInTheDocument();
+  });
+
   it('renders a loading state', () => {
     render(<ThroughputEstimate isLoading />);
     expect(screen.getByText(/Estimating speed/)).toBeInTheDocument();

--- a/frontend/src/components/models/ThroughputEstimate.test.tsx
+++ b/frontend/src/components/models/ThroughputEstimate.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ThroughputEstimate } from './ThroughputEstimate';
+import type { GpuThroughputEstimate } from '@airunway/shared';
+
+const base: GpuThroughputEstimate = {
+  perChatTokensPerSec: 40,
+  concurrentSequences: 360,
+  aggregateTokensPerSec: 14400,
+  gpuModel: 'H100-80GB',
+  perGpuMemoryGb: 80,
+  memBandwidthGBs: 3350,
+  tpSize: 4,
+  contextLen: 4096,
+  capacityLabel: '4x80 GB',
+  lowConfidence: false,
+};
+
+describe('ThroughputEstimate', () => {
+  it('shows both per-chat speed and concurrency when confident', () => {
+    render(<ThroughputEstimate estimate={base} />);
+    expect(screen.getByText(/~40 tok\/s per chat/)).toBeInTheDocument();
+    expect(screen.getByText(/~360 concurrent/)).toBeInTheDocument();
+  });
+
+  it('shows only per-chat speed when low confidence', () => {
+    render(
+      <ThroughputEstimate
+        estimate={{ ...base, lowConfidence: true, concurrentSequences: undefined, aggregateTokensPerSec: undefined }}
+      />
+    );
+    expect(screen.getByText('~40 tok/s per chat')).toBeInTheDocument();
+    expect(screen.queryByText(/concurrent/)).not.toBeInTheDocument();
+  });
+
+  it('renders a loading state', () => {
+    render(<ThroughputEstimate isLoading />);
+    expect(screen.getByText(/Estimating speed/)).toBeInTheDocument();
+  });
+
+  it('renders nothing without an estimate', () => {
+    const { container } = render(<ThroughputEstimate />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when per-chat speed is zero', () => {
+    const { container } = render(
+      <ThroughputEstimate estimate={{ ...base, perChatTokensPerSec: 0 }} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/models/ThroughputEstimate.tsx
+++ b/frontend/src/components/models/ThroughputEstimate.tsx
@@ -83,9 +83,13 @@ export function ThroughputEstimate({ estimate, isLoading, className }: Throughpu
   const hasConcurrency =
     !lowConfidence && typeof concurrentSequences === 'number' && concurrentSequences > 0;
 
-  const label = hasConcurrency
-    ? `~${Math.round(perChatTokensPerSec)} tok/s per chat · ~${formatCount(concurrentSequences!)} concurrent`
-    : `~${Math.round(perChatTokensPerSec)} tok/s per chat`;
+  const hasAggregate = hasConcurrency && typeof aggregateTokensPerSec === 'number' && aggregateTokensPerSec > 0;
+
+  const label = hasAggregate
+    ? `~${Math.round(perChatTokensPerSec)} tok/s per chat · ~${formatCount(concurrentSequences!)} concurrent · ~${formatCount(aggregateTokensPerSec!)} tok/s total`
+    : hasConcurrency
+      ? `~${Math.round(perChatTokensPerSec)} tok/s per chat · ~${formatCount(concurrentSequences!)} concurrent`
+      : `~${Math.round(perChatTokensPerSec)} tok/s per chat`;
 
   const tooltip = hasConcurrency
     ? `Rough estimate on ${gpuModel} (assuming ${tpSize} GPU${tpSize > 1 ? 's' : ''} per replica at ${contextLen.toLocaleString()} token context): about ${Math.round(perChatTokensPerSec)} tokens/sec for a single chat, and roughly ${concurrentSequences!.toLocaleString()} requests at once (~${aggregateTokensPerSec?.toLocaleString()} tokens/sec total). Based on memory-bandwidth and KV-cache heuristics — actual speed varies with batch size, prompt length, and quantization.`

--- a/frontend/src/components/models/ThroughputEstimate.tsx
+++ b/frontend/src/components/models/ThroughputEstimate.tsx
@@ -9,7 +9,7 @@ interface ThroughputEstimateProps {
   className?: string;
 }
 
-/** Compact number formatting: 18234 -> "18.2k". */
+/** Compact number formatting: 1234 -> "1.2k", 18234 -> "18k". */
 function formatCount(n: number): string {
   if (n >= 1000) {
     return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;

--- a/frontend/src/components/models/ThroughputEstimate.tsx
+++ b/frontend/src/components/models/ThroughputEstimate.tsx
@@ -1,5 +1,5 @@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { Zap } from 'lucide-react';
+import { AlertTriangle, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { GpuThroughputEstimate } from '@airunway/shared';
 
@@ -49,7 +49,36 @@ export function ThroughputEstimate({ estimate, isLoading, className }: Throughpu
     tpSize,
     contextLen,
     lowConfidence,
+    doesNotFit,
   } = estimate;
+
+  // High-confidence "does not fit": model weights plus reserved headroom exceed
+  // the GPU's VRAM, leaving no room for KV cache. Surface this explicitly rather
+  // than showing a misleading per-chat speed.
+  if (!lowConfidence && doesNotFit) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className={cn(
+                'flex items-center gap-2 text-sm text-destructive',
+                className
+              )}
+            >
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              <span className="truncate">Does not fit — no room for KV cache</span>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="max-w-xs">
+              {`This model does not fit on ${gpuModel} (assuming ${tpSize} GPU${tpSize > 1 ? 's' : ''} per replica): the model weights plus reserved memory headroom exceed the available VRAM, leaving no room for the KV cache. It cannot be served on this GPU/topology — try a larger GPU, more GPUs per replica, or a smaller / more heavily quantized model.`}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
   const hasConcurrency =
     !lowConfidence && typeof concurrentSequences === 'number' && concurrentSequences > 0;

--- a/frontend/src/components/models/ThroughputEstimate.tsx
+++ b/frontend/src/components/models/ThroughputEstimate.tsx
@@ -1,0 +1,85 @@
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Zap } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { GpuThroughputEstimate } from '@airunway/shared';
+
+interface ThroughputEstimateProps {
+  estimate?: GpuThroughputEstimate;
+  isLoading?: boolean;
+  className?: string;
+}
+
+/** Compact number formatting: 18234 -> "18.2k". */
+function formatCount(n: number): string {
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  }
+  return `${Math.round(n)}`;
+}
+
+/**
+ * Shows a rough inference-speed estimate for a model on the cluster's GPUs.
+ *
+ * Two numbers (see issue #139):
+ *  - per-chat token speed (single-stream decode, "how snappy chat feels")
+ *  - concurrent requests + aggregate tokens/sec (KV-cache-budget gated)
+ *
+ * Both are estimates — no inference is run. When architecture data is missing
+ * (lowConfidence) only the per-chat number is shown.
+ */
+export function ThroughputEstimate({ estimate, isLoading, className }: ThroughputEstimateProps) {
+  if (isLoading) {
+    return (
+      <span className={cn('flex items-center gap-2 text-sm text-muted-foreground', className)}>
+        <Zap className="h-4 w-4" />
+        Estimating speed…
+      </span>
+    );
+  }
+
+  if (!estimate || estimate.perChatTokensPerSec <= 0) {
+    return null;
+  }
+
+  const {
+    perChatTokensPerSec,
+    concurrentSequences,
+    aggregateTokensPerSec,
+    gpuModel,
+    tpSize,
+    contextLen,
+    lowConfidence,
+  } = estimate;
+
+  const hasConcurrency =
+    !lowConfidence && typeof concurrentSequences === 'number' && concurrentSequences > 0;
+
+  const label = hasConcurrency
+    ? `~${Math.round(perChatTokensPerSec)} tok/s per chat · ~${formatCount(concurrentSequences!)} concurrent`
+    : `~${Math.round(perChatTokensPerSec)} tok/s per chat`;
+
+  const tooltip = hasConcurrency
+    ? `Rough estimate on ${gpuModel} (assuming ${tpSize} GPU${tpSize > 1 ? 's' : ''} per replica at ${contextLen.toLocaleString()} token context): about ${Math.round(perChatTokensPerSec)} tokens/sec for a single chat, and roughly ${concurrentSequences!.toLocaleString()} requests at once (~${aggregateTokensPerSec?.toLocaleString()} tokens/sec total). Based on memory-bandwidth and KV-cache heuristics — actual speed varies with batch size, prompt length, and quantization.`
+    : `Rough single-chat speed estimate on ${gpuModel}: about ${Math.round(perChatTokensPerSec)} tokens/sec. Concurrent-capacity estimate unavailable (model architecture details could not be read). Actual speed varies with batch size, prompt length, and quantization.`;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              'flex items-center gap-2 text-sm text-muted-foreground',
+              className
+            )}
+          >
+            <Zap className="h-4 w-4 shrink-0" />
+            <span className="truncate">{label}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="max-w-xs">{tooltip}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/hooks/useGpuOperator.test.tsx
+++ b/frontend/src/hooks/useGpuOperator.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+// Mock the API module so getThroughput is a controllable spy: this lets us
+// reject with a specific HTTP status and count how many times the query fires,
+// without hitting MSW or the network.
+vi.mock('@/lib/api', () => ({
+  gpuOperatorApi: {
+    getThroughput: vi.fn(),
+  },
+}))
+
+import { useGpuThroughput } from './useGpuOperator'
+import { gpuOperatorApi } from '@/lib/api'
+
+const getThroughputMock = vi.mocked(gpuOperatorApi.getThroughput)
+
+/**
+ * Wrapper whose QueryClient has retries ENABLED (unlike the shared test-utils
+ * client, which disables them globally). This is essential: it proves the
+ * per-query `retry` override in useGpuThroughput actually takes effect rather
+ * than being masked by a retry-disabled default.
+ */
+function createRetryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 5, // a clearly-retrying default that our per-query override must beat
+        retryDelay: 0, // no backoff so retry-exercising tests stay fast
+        gcTime: 0,
+      },
+    },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+/** Build an error shaped like the api client's ApiError (status on `statusCode`). */
+function apiError(statusCode: number, message = 'error') {
+  return Object.assign(new Error(message), { name: 'ApiError', statusCode })
+}
+
+describe('useGpuThroughput retry policy', () => {
+  beforeEach(() => {
+    getThroughputMock.mockReset()
+  })
+
+  it('does not retry when the backend returns 404 (no known GPU spec)', async () => {
+    getThroughputMock.mockRejectedValue(
+      apiError(404, 'No GPU node pool with known specs found in the cluster.')
+    )
+
+    const { result } = renderHook(
+      () => useGpuThroughput({ paramCount: 70_000_000_000 }),
+      { wrapper: createRetryWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    // Exactly one request: the 4xx is deterministic, so no retries fire even
+    // though the QueryClient default would otherwise retry 5×.
+    expect(getThroughputMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry on other 4xx client errors (e.g. 400)', async () => {
+    getThroughputMock.mockRejectedValue(apiError(400, 'Invalid query params'))
+
+    const { result } = renderHook(
+      () => useGpuThroughput({ paramCount: 70_000_000_000 }),
+      { wrapper: createRetryWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(getThroughputMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('still retries transient 5xx server errors (bounded budget)', async () => {
+    getThroughputMock.mockRejectedValue(apiError(503, 'Service Unavailable'))
+
+    const { result } = renderHook(
+      () => useGpuThroughput({ paramCount: 70_000_000_000 }),
+      { wrapper: createRetryWrapper() }
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    // More than one call proves 5xx is retried (unlike 4xx); the small upper
+    // bound proves our `failureCount < 2` budget is applied rather than the
+    // QueryClient's retry:5 default.
+    const calls = getThroughputMock.mock.calls.length
+    expect(calls).toBeGreaterThan(1)
+    expect(calls).toBeLessThanOrEqual(3)
+  })
+})

--- a/frontend/src/hooks/useGpuOperator.ts
+++ b/frontend/src/hooks/useGpuOperator.ts
@@ -25,6 +25,7 @@ export interface ThroughputParams {
   paramCount?: number
   contextLen?: number
   quantization?: 'fp8' | 'int8' | 'fp16' | 'bf16'
+  kvCacheDtype?: 'fp8' | 'int8' | 'fp16' | 'bf16'
   gpuModel?: string
   tpSize?: number
 }
@@ -43,8 +44,11 @@ export function useGpuThroughput(params: ThroughputParams, options?: { enabled?:
   // model yields a high-confidence result with a token but a low-confidence one
   // without, and the two must not share a cache entry.
   const authState = hfToken ? 'auth' : 'anon'
+  // gpuModel is no longer sent by callers (the backend selects the GPU), so the
+  // enable-gate keys off paramCount only. Callers still pass `enabled: false`
+  // (or omit params entirely) when there's no GPU pool to estimate on.
   const enabled =
-    (options?.enabled ?? true) && !!params.gpuModel && !!params.paramCount
+    (options?.enabled ?? true) && !!params.paramCount
 
   return useQuery<GpuThroughputEstimate>({
     queryKey: [
@@ -56,6 +60,7 @@ export function useGpuThroughput(params: ThroughputParams, options?: { enabled?:
       params.contextLen,
       params.tpSize,
       params.quantization,
+      params.kvCacheDtype,
     ],
     queryFn: () => gpuOperatorApi.getThroughput(params, hfToken ?? undefined),
     enabled,

--- a/frontend/src/hooks/useGpuOperator.ts
+++ b/frontend/src/hooks/useGpuOperator.ts
@@ -35,7 +35,8 @@ export interface ThroughputParams {
  *
  * Pass `enabled: false` to defer the fetch (e.g. until a catalog card scrolls
  * into view) — this avoids firing an HF config.json lookup for every rendered
- * card. The query is also disabled until a GPU model and param count are known.
+ * card. The query is also disabled until `paramCount` is known; the GPU model
+ * is chosen server-side, so callers no longer need to supply one.
  */
 export function useGpuThroughput(params: ThroughputParams, options?: { enabled?: boolean }) {
   const hfToken = getHfAccessToken()

--- a/frontend/src/hooks/useGpuOperator.ts
+++ b/frontend/src/hooks/useGpuOperator.ts
@@ -65,6 +65,16 @@ export function useGpuThroughput(params: ThroughputParams, options?: { enabled?:
     queryFn: () => gpuOperatorApi.getThroughput(params, hfToken ?? undefined),
     enabled,
     staleTime: 5 * 60 * 1000, // estimates are stable; cache for 5 minutes
+    // A 404 means no cluster GPU pool maps to a known spec — a deterministic
+    // "no estimate" state, not a transient error. Don't retry any client error
+    // (4xx); keep a small retry budget for transient server/network failures.
+    retry: (failureCount, error) => {
+      const statusCode = (error as { statusCode?: number }).statusCode
+      if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 500) {
+        return false
+      }
+      return failureCount < 2
+    },
   })
 }
 

--- a/frontend/src/hooks/useGpuOperator.ts
+++ b/frontend/src/hooks/useGpuOperator.ts
@@ -38,12 +38,18 @@ export interface ThroughputParams {
  */
 export function useGpuThroughput(params: ThroughputParams, options?: { enabled?: boolean }) {
   const hfToken = getHfAccessToken()
+  // Discriminate the cache by auth state (never the token itself) so that
+  // switching between logged-in and logged-out recomputes the estimate: a gated
+  // model yields a high-confidence result with a token but a low-confidence one
+  // without, and the two must not share a cache entry.
+  const authState = hfToken ? 'auth' : 'anon'
   const enabled =
     (options?.enabled ?? true) && !!params.gpuModel && !!params.paramCount
 
   return useQuery<GpuThroughputEstimate>({
     queryKey: [
       'gpu-throughput',
+      authState,
       params.modelId,
       params.gpuModel,
       params.paramCount,

--- a/frontend/src/hooks/useGpuOperator.ts
+++ b/frontend/src/hooks/useGpuOperator.ts
@@ -1,5 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { gpuOperatorApi, type GPUOperatorStatus, type GPUOperatorInstallResult, type ClusterGpuCapacity } from '@/lib/api'
+import type { GpuThroughputEstimate } from '@airunway/shared'
+import { getHfAccessToken } from './useHuggingFace'
 
 export function useGpuOperatorStatus() {
   return useQuery<GPUOperatorStatus>({
@@ -15,6 +17,43 @@ export function useGpuCapacity() {
     queryFn: () => gpuOperatorApi.getCapacity(),
     refetchInterval: 30000, // Refetch every 30 seconds
     staleTime: 10000, // Consider data stale after 10 seconds
+  })
+}
+
+export interface ThroughputParams {
+  modelId?: string
+  paramCount?: number
+  contextLen?: number
+  quantization?: 'fp8' | 'int8' | 'fp16' | 'bf16'
+  gpuModel?: string
+  tpSize?: number
+}
+
+/**
+ * Estimate inference throughput for a model on the cluster's GPUs.
+ *
+ * Pass `enabled: false` to defer the fetch (e.g. until a catalog card scrolls
+ * into view) — this avoids firing an HF config.json lookup for every rendered
+ * card. The query is also disabled until a GPU model and param count are known.
+ */
+export function useGpuThroughput(params: ThroughputParams, options?: { enabled?: boolean }) {
+  const hfToken = getHfAccessToken()
+  const enabled =
+    (options?.enabled ?? true) && !!params.gpuModel && !!params.paramCount
+
+  return useQuery<GpuThroughputEstimate>({
+    queryKey: [
+      'gpu-throughput',
+      params.modelId,
+      params.gpuModel,
+      params.paramCount,
+      params.contextLen,
+      params.tpSize,
+      params.quantization,
+    ],
+    queryFn: () => gpuOperatorApi.getThroughput(params, hfToken ?? undefined),
+    enabled,
+    staleTime: 5 * 60 * 1000, // estimates are stable; cache for 5 minutes
   })
 }
 

--- a/frontend/src/hooks/useInView.ts
+++ b/frontend/src/hooks/useInView.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type RefObject } from 'react'
 
 /**
  * Returns a ref to attach to an element and a boolean that flips to true the
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from 'react'
  */
 export function useInView<T extends Element = HTMLDivElement>(
   options?: IntersectionObserverInit
-): { ref: React.RefObject<T | null>; inView: boolean } {
+): { ref: RefObject<T | null>; inView: boolean } {
   const ref = useRef<T>(null)
   const [inView, setInView] = useState(false)
 

--- a/frontend/src/hooks/useInView.ts
+++ b/frontend/src/hooks/useInView.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react'
  * Returns a ref to attach to an element and a boolean that flips to true the
  * first time the element scrolls into the viewport. Used to defer expensive
  * per-card work (e.g. throughput estimates that fetch HF config.json) until a
- * card is actually visible. Once seen, it stays true (no fl/unflickering).
+ * card is actually visible. Once seen, it stays true (no flickering).
  */
 export function useInView<T extends Element = HTMLDivElement>(
   options?: IntersectionObserverInit

--- a/frontend/src/hooks/useInView.ts
+++ b/frontend/src/hooks/useInView.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Returns a ref to attach to an element and a boolean that flips to true the
+ * first time the element scrolls into the viewport. Used to defer expensive
+ * per-card work (e.g. throughput estimates that fetch HF config.json) until a
+ * card is actually visible. Once seen, it stays true (no fl/unflickering).
+ */
+export function useInView<T extends Element = HTMLDivElement>(
+  options?: IntersectionObserverInit
+): { ref: React.RefObject<T>; inView: boolean } {
+  const ref = useRef<T>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element || inView) return
+    if (typeof IntersectionObserver === 'undefined') {
+      // Fallback for environments without IntersectionObserver (e.g. jsdom).
+      setInView(true)
+      return
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        setInView(true)
+        observer.disconnect()
+      }
+    }, options ?? { rootMargin: '100px' })
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [inView, options])
+
+  return { ref, inView }
+}

--- a/frontend/src/hooks/useInView.ts
+++ b/frontend/src/hooks/useInView.ts
@@ -8,7 +8,7 @@ import { useEffect, useRef, useState } from 'react'
  */
 export function useInView<T extends Element = HTMLDivElement>(
   options?: IntersectionObserverInit
-): { ref: React.RefObject<T>; inView: boolean } {
+): { ref: React.RefObject<T | null>; inView: boolean } {
   const ref = useRef<T>(null)
   const [inView, setInView] = useState(false)
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -529,6 +529,7 @@ export const gpuOperatorApi = {
       paramCount?: number;
       contextLen?: number;
       quantization?: 'fp8' | 'int8' | 'fp16' | 'bf16';
+      kvCacheDtype?: 'fp8' | 'int8' | 'fp16' | 'bf16';
       gpuModel?: string;
       tpSize?: number;
     },
@@ -539,6 +540,7 @@ export const gpuOperatorApi = {
     if (params.paramCount) search.set('paramCount', String(params.paramCount));
     if (params.contextLen) search.set('contextLen', String(params.contextLen));
     if (params.quantization) search.set('quantization', params.quantization);
+    if (params.kvCacheDtype) search.set('kvCacheDtype', params.kvCacheDtype);
     if (params.gpuModel) search.set('gpuModel', params.gpuModel);
     if (params.tpSize) search.set('tpSize', String(params.tpSize));
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -115,6 +115,7 @@ export type {
   AutoscalerDetectionResult,
   AutoscalerStatusInfo,
   DetailedClusterCapacity,
+  GpuThroughputEstimate,
   NodePoolInfo,
   PodFailureReason,
   PodLogsOptions,
@@ -159,6 +160,7 @@ import type {
   AutoscalerDetectionResult,
   AutoscalerStatusInfo,
   DetailedClusterCapacity,
+  GpuThroughputEstimate,
   PodFailureReason,
   RuntimesStatusResponse,
   PodLogsResponse,
@@ -519,6 +521,35 @@ export const gpuOperatorApi = {
   getCapacity: () => request<ClusterGpuCapacity>('/installation/gpu-capacity'),
 
   getDetailedCapacity: () => request<DetailedClusterCapacity>('/installation/gpu-capacity/detailed'),
+
+  /** Estimate inference throughput (per-chat speed + concurrent capacity) for a model on the cluster's GPUs */
+  getThroughput: (
+    params: {
+      modelId?: string;
+      paramCount?: number;
+      contextLen?: number;
+      quantization?: 'fp8' | 'int8' | 'fp16' | 'bf16';
+      gpuModel?: string;
+      tpSize?: number;
+    },
+    hfToken?: string
+  ) => {
+    const search = new URLSearchParams();
+    if (params.modelId) search.set('modelId', params.modelId);
+    if (params.paramCount) search.set('paramCount', String(params.paramCount));
+    if (params.contextLen) search.set('contextLen', String(params.contextLen));
+    if (params.quantization) search.set('quantization', params.quantization);
+    if (params.gpuModel) search.set('gpuModel', params.gpuModel);
+    if (params.tpSize) search.set('tpSize', String(params.tpSize));
+
+    const headers: Record<string, string> = {};
+    if (hfToken) {
+      headers['X-HF-Token'] = hfToken;
+    }
+    return request<GpuThroughputEstimate>(`/installation/gpu-throughput?${search.toString()}`, {
+      headers,
+    });
+  },
 };
 
 // ============================================================================

--- a/frontend/src/lib/gpu-throughput-params.ts
+++ b/frontend/src/lib/gpu-throughput-params.ts
@@ -34,17 +34,6 @@ export function hasEstimableGpu(capacity?: DetailedClusterCapacity): boolean {
   return (capacity?.nodePools ?? []).some((p) => p.gpuModel);
 }
 
-/**
- * @deprecated Prefer `hasEstimableGpu`. Retained for the catalog pages that pass
- * a `gpuModel` prop down to cards; the value is now used only as a presence
- * signal and is not forwarded to the backend estimate.
- */
-export function pickGpuModel(capacity?: DetailedClusterCapacity): string | undefined {
-  const pools = (capacity?.nodePools ?? []).filter((p) => p.gpuModel);
-  if (pools.length === 0) return undefined;
-  return pools.reduce((best, p) => (p.gpuCount > best.gpuCount ? p : best)).gpuModel;
-}
-
 /** Optional precision overrides for the throughput estimate. */
 export interface QuantOverrides {
   /** Weight quantization (affects model memory footprint + decode speed). */
@@ -71,7 +60,7 @@ export interface QuantOverrides {
 export function buildThroughputParamsForGpu(
   model: Partial<Pick<Model, 'size' | 'parameterCount' | 'parameters' | 'contextLength' | 'minGpus'>> &
     Pick<Model, 'id'>,
-  gpuPresent?: string | boolean,
+  gpuPresent?: boolean,
   overrides?: QuantOverrides
 ): ThroughputParams | undefined {
   const paramCount = resolveModelParamCount(model);

--- a/frontend/src/lib/gpu-throughput-params.ts
+++ b/frontend/src/lib/gpu-throughput-params.ts
@@ -23,36 +23,69 @@ export function resolveModelParamCount(
   return undefined;
 }
 
-/** Pick the GPU model to estimate on: the pool with the most GPUs (most likely target). */
+/**
+ * Whether the cluster has any GPU pool we could estimate on. Used purely as a
+ * presence gate — the backend (`selectGpuForEstimate`) is the single source of
+ * truth for *which* GPU the estimate runs on, so we deliberately do not forward
+ * a concrete choice from here (avoids frontend/backend selection drift on mixed
+ * clusters, e.g. 8xL4 + 1xH100).
+ */
+export function hasEstimableGpu(capacity?: DetailedClusterCapacity): boolean {
+  return (capacity?.nodePools ?? []).some((p) => p.gpuModel);
+}
+
+/**
+ * @deprecated Prefer `hasEstimableGpu`. Retained for the catalog pages that pass
+ * a `gpuModel` prop down to cards; the value is now used only as a presence
+ * signal and is not forwarded to the backend estimate.
+ */
 export function pickGpuModel(capacity?: DetailedClusterCapacity): string | undefined {
   const pools = (capacity?.nodePools ?? []).filter((p) => p.gpuModel);
   if (pools.length === 0) return undefined;
   return pools.reduce((best, p) => (p.gpuCount > best.gpuCount ? p : best)).gpuModel;
 }
 
+/** Optional precision overrides for the throughput estimate. */
+export interface QuantOverrides {
+  /** Weight quantization (affects model memory footprint + decode speed). */
+  quantization?: 'fp8' | 'int8' | 'fp16' | 'bf16';
+  /** KV-cache precision (independent of weights; affects concurrency). */
+  kvCacheDtype?: 'fp8' | 'int8' | 'fp16' | 'bf16';
+}
+
 /**
- * Build throughput-estimate query params for a model on a specific GPU model.
+ * Build throughput-estimate query params for a model.
  * Returns undefined when there's nothing useful to ask for (no GPU, no params).
+ *
+ * `gpuPresent` only gates *whether* to estimate; the backend chooses which GPU
+ * (highest-VRAM pool) so this never forwards a concrete gpuModel — keeping a
+ * single source of truth for GPU selection.
  *
  * tpSize defaults to the model's minimum GPUs (bounded server-side); the Deploy
  * summary card and catalog cards use this default since they're outside the
  * deployment form where an explicit GPU-per-replica count would be chosen.
+ *
+ * `overrides` lets the Deploy page pass user-selected weight / KV-cache
+ * precision; catalog cards omit it and use server defaults (fp16 / fp16 KV).
  */
 export function buildThroughputParamsForGpu(
   model: Partial<Pick<Model, 'size' | 'parameterCount' | 'parameters' | 'contextLength' | 'minGpus'>> &
     Pick<Model, 'id'>,
-  gpuModel?: string
+  gpuPresent?: string | boolean,
+  overrides?: QuantOverrides
 ): ThroughputParams | undefined {
   const paramCount = resolveModelParamCount(model);
-  if (!paramCount || !gpuModel) {
+  if (!paramCount || !gpuPresent) {
     return undefined;
   }
   return {
     modelId: model.id,
     paramCount,
     contextLen: model.contextLength,
-    gpuModel,
+    // gpuModel intentionally omitted — backend selects the highest-VRAM pool.
     tpSize: model.minGpus && model.minGpus > 0 ? model.minGpus : undefined,
+    quantization: overrides?.quantization,
+    kvCacheDtype: overrides?.kvCacheDtype,
   };
 }
 
@@ -61,7 +94,8 @@ export function buildThroughputParamsForGpu(
  */
 export function buildThroughputParams(
   model: Pick<Model, 'id' | 'size' | 'parameterCount' | 'parameters' | 'contextLength' | 'minGpus'>,
-  capacity?: DetailedClusterCapacity
+  capacity?: DetailedClusterCapacity,
+  overrides?: QuantOverrides
 ): ThroughputParams | undefined {
-  return buildThroughputParamsForGpu(model, pickGpuModel(capacity));
+  return buildThroughputParamsForGpu(model, hasEstimableGpu(capacity), overrides);
 }

--- a/frontend/src/lib/gpu-throughput-params.ts
+++ b/frontend/src/lib/gpu-throughput-params.ts
@@ -1,27 +1,6 @@
 import type { DetailedClusterCapacity, Model } from '@airunway/shared';
+import { resolveModelParamCount } from '@airunway/shared';
 import type { ThroughputParams } from '@/hooks/useGpuOperator';
-
-/** Parse a parameter count (absolute) from a model's fields or size string. */
-export function resolveModelParamCount(
-  model: Partial<Pick<Model, 'parameterCount' | 'parameters' | 'size'>> & Pick<Model, 'id'>
-): number | undefined {
-  if (typeof model.parameterCount === 'number' && model.parameterCount > 0) {
-    return model.parameterCount;
-  }
-  if (typeof model.parameters === 'number' && model.parameters > 0) {
-    return model.parameters;
-  }
-  const text = `${model.size ?? ''} ${model.id ?? ''}`;
-  const bMatch = text.match(/(?:^|[-_./\s])(\d+(?:\.\d+)?)\s*B(?:$|[-_./\s])/i);
-  if (bMatch) {
-    return parseFloat(bMatch[1]) * 1_000_000_000;
-  }
-  const mMatch = text.match(/(?:^|[-_./\s])(\d+(?:\.\d+)?)\s*M(?:$|[-_./\s])/i);
-  if (mMatch) {
-    return parseFloat(mMatch[1]) * 1_000_000;
-  }
-  return undefined;
-}
 
 /**
  * Whether the cluster has any GPU pool we could estimate on. Used purely as a

--- a/frontend/src/lib/gpu-throughput-params.ts
+++ b/frontend/src/lib/gpu-throughput-params.ts
@@ -1,0 +1,67 @@
+import type { DetailedClusterCapacity, Model } from '@airunway/shared';
+import type { ThroughputParams } from '@/hooks/useGpuOperator';
+
+/** Parse a parameter count (absolute) from a model's fields or size string. */
+export function resolveModelParamCount(
+  model: Partial<Pick<Model, 'parameterCount' | 'parameters' | 'size'>> & Pick<Model, 'id'>
+): number | undefined {
+  if (typeof model.parameterCount === 'number' && model.parameterCount > 0) {
+    return model.parameterCount;
+  }
+  if (typeof model.parameters === 'number' && model.parameters > 0) {
+    return model.parameters;
+  }
+  const text = `${model.size ?? ''} ${model.id ?? ''}`;
+  const bMatch = text.match(/(?:^|[-_./\s])(\d+(?:\.\d+)?)\s*B(?:$|[-_./\s])/i);
+  if (bMatch) {
+    return parseFloat(bMatch[1]) * 1_000_000_000;
+  }
+  const mMatch = text.match(/(?:^|[-_./\s])(\d+(?:\.\d+)?)\s*M(?:$|[-_./\s])/i);
+  if (mMatch) {
+    return parseFloat(mMatch[1]) * 1_000_000;
+  }
+  return undefined;
+}
+
+/** Pick the GPU model to estimate on: the pool with the most GPUs (most likely target). */
+export function pickGpuModel(capacity?: DetailedClusterCapacity): string | undefined {
+  const pools = (capacity?.nodePools ?? []).filter((p) => p.gpuModel);
+  if (pools.length === 0) return undefined;
+  return pools.reduce((best, p) => (p.gpuCount > best.gpuCount ? p : best)).gpuModel;
+}
+
+/**
+ * Build throughput-estimate query params for a model on a specific GPU model.
+ * Returns undefined when there's nothing useful to ask for (no GPU, no params).
+ *
+ * tpSize defaults to the model's minimum GPUs (bounded server-side); the Deploy
+ * summary card and catalog cards use this default since they're outside the
+ * deployment form where an explicit GPU-per-replica count would be chosen.
+ */
+export function buildThroughputParamsForGpu(
+  model: Partial<Pick<Model, 'size' | 'parameterCount' | 'parameters' | 'contextLength' | 'minGpus'>> &
+    Pick<Model, 'id'>,
+  gpuModel?: string
+): ThroughputParams | undefined {
+  const paramCount = resolveModelParamCount(model);
+  if (!paramCount || !gpuModel) {
+    return undefined;
+  }
+  return {
+    modelId: model.id,
+    paramCount,
+    contextLen: model.contextLength,
+    gpuModel,
+    tpSize: model.minGpus && model.minGpus > 0 ? model.minGpus : undefined,
+  };
+}
+
+/**
+ * Convenience for the Deploy page, which has detailed capacity (with node pools).
+ */
+export function buildThroughputParams(
+  model: Pick<Model, 'id' | 'size' | 'parameterCount' | 'parameters' | 'contextLength' | 'minGpus'>,
+  capacity?: DetailedClusterCapacity
+): ThroughputParams | undefined {
+  return buildThroughputParamsForGpu(model, pickGpuModel(capacity));
+}

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -1,16 +1,56 @@
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
+import { useState } from 'react'
 import { useModel, useHfModel } from '@/hooks/useModels'
 import { useAutoscalerDetection, useDetailedCapacity } from '@/hooks/useAutoscaler'
 import { useRuntimesStatus } from '@/hooks/useRuntimes'
 import { DeploymentForm } from '@/components/deployments/DeploymentForm'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Loader2, ArrowLeft, Cpu, HardDrive, Layers, ExternalLink } from 'lucide-react'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Loader2, ArrowLeft, Cpu, HardDrive, Layers, ExternalLink, Info } from 'lucide-react'
 import { GpuFitIndicator } from '@/components/models/GpuFitIndicator'
 import { ThroughputEstimate } from '@/components/models/ThroughputEstimate'
 import { getGpuFitCapacityDisplay } from '@/lib/gpu-fit-capacity'
 import { buildThroughputParams } from '@/lib/gpu-throughput-params'
 import { useGpuThroughput } from '@/hooks/useGpuOperator'
+
+type WeightQuant = 'fp16' | 'fp8'
+type KvQuant = 'fp16' | 'fp8'
+
+const WEIGHT_QUANT_LABELS: Record<WeightQuant, string> = {
+  fp16: 'FP16 / BF16 (Default)',
+  fp8: 'FP8',
+}
+
+const KV_QUANT_LABELS: Record<KvQuant, string> = {
+  fp16: 'FP16 / BF16 (Default)',
+  fp8: 'FP8',
+}
+
+// Lightweight info tooltip (native title + hover popover), matching the pattern
+// used elsewhere in the deployment UI.
+function InfoHint({ text }: { text: string }) {
+  return (
+    <span className="relative group/hint inline-flex">
+      <button
+        type="button"
+        tabIndex={0}
+        aria-label={text}
+        title={text}
+        className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <Info className="h-3.5 w-3.5" />
+      </button>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-max max-w-xs rounded-lg border border-white/10 bg-[#0F1419]/95 backdrop-blur-md px-3 py-1.5 text-sm text-popover-foreground shadow-md opacity-0 transition-opacity group-hover/hint:opacity-100 group-focus-within/hint:opacity-100 z-50"
+      >
+        {text}
+      </span>
+    </span>
+  )
+}
 
 export function DeployPage() {
   const { modelId } = useParams<{ modelId: string }>()
@@ -18,6 +58,12 @@ export function DeployPage() {
   const navigate = useNavigate()
   const decodedModelId = modelId ? decodeURIComponent(modelId) : undefined
   const isHfSource = searchParams.get('source') === 'hf'
+
+  // Precision controls for the throughput estimate. Weight precision and
+  // KV-cache precision are independent knobs (KV cache often stays fp16/bf16
+  // even when weights are quantized).
+  const [weightQuant, setWeightQuant] = useState<WeightQuant>('fp16')
+  const [kvCacheDtype, setKvCacheDtype] = useState<KvQuant>('fp16')
 
   // Use appropriate hook based on source
   const localModelQuery = useModel(isHfSource ? undefined : decodedModelId)
@@ -30,11 +76,29 @@ export function DeployPage() {
   const gpuFitCapacity = getGpuFitCapacityDisplay(detailedCapacity)
 
   // Estimated inference throughput for this model on the cluster's GPUs.
-  const throughputParams = model ? buildThroughputParams(model, detailedCapacity) : undefined
+  const throughputParams = model
+    ? buildThroughputParams(model, detailedCapacity, { quantization: weightQuant, kvCacheDtype })
+    : undefined
   const { data: throughput, isLoading: throughputLoading } = useGpuThroughput(
     throughputParams ?? {},
     { enabled: !!throughputParams }
   )
+
+  // The backend downgrades an FP8 KV cache to FP16 on GPUs without a native FP8
+  // datapath (only Hopper / H100 / H200 support it). Surface that to the user.
+  const kvDowngraded =
+    kvCacheDtype === 'fp8' &&
+    !!throughput?.kvCacheDtype &&
+    throughput.kvCacheDtype !== 'fp8'
+
+  // Block deploying with FP8 on hardware that has no FP8 datapath (non-Hopper).
+  // The estimate response carries the resolved GPU's FP8 capability so we don't
+  // re-implement the GPU→generation mapping client-side.
+  const fp8Selected = weightQuant === 'fp8' || kvCacheDtype === 'fp8'
+  const fp8Blocked = fp8Selected && throughput?.fp8Supported === false
+  const fp8BlockReason = fp8Blocked
+    ? `FP8 is only supported on H100/H200 GPUs. This cluster's GPU${throughput?.gpuModel ? ` (${throughput.gpuModel})` : ''} can't run FP8 — choose FP16 / BF16 to deploy.`
+    : undefined
 
   // Wait for both model and runtimes to load before showing the form
   // This ensures the runtime selector is visible when the form renders
@@ -133,10 +197,6 @@ export function DeployPage() {
             <HardDrive className="h-4 w-4" />
             <span>{model.conversational ? 'Chat' : model.task === 'image-text-to-text' ? 'Multimodal' : 'Text Generation'}</span>
           </div>
-
-          {throughputParams && (throughputLoading || throughput) && (
-            <ThroughputEstimate estimate={throughput} isLoading={throughputLoading} />
-          )}
         </div>
 
         <div className="flex flex-wrap gap-2 mt-4">
@@ -148,6 +208,78 @@ export function DeployPage() {
         </div>
       </div>
 
+      {/* Performance & Precision: precision controls + speed estimate live here.
+          Changing any control recomputes the estimate. FP8 selections also feed
+          the real deployment (engine args) — see DeploymentForm. */}
+      {throughputParams && (
+        <div className="glass-panel animate-slide-up" style={{ animationDelay: '75ms', animationFillMode: 'both' }}>
+          <h2 className="text-lg font-semibold mb-1">Performance &amp; Precision</h2>
+          <p className="text-sm text-muted-foreground mb-4">
+            Estimated speed for this model on your cluster's GPUs. Adjust precision to
+            explore the tradeoffs — FP8 choices are applied to the deployment.
+          </p>
+
+          <div className="flex flex-wrap items-start gap-4">
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <Label htmlFor="weight-quant">
+                  Model Weights Precision
+                </Label>
+                <InfoHint text="How compactly the model's weights are stored. Lower precision (FP8) uses less GPU memory and runs faster, but can slightly reduce answer quality. FP8 needs a recent GPU (H100/H200)." />
+              </div>
+              <Select value={weightQuant} onValueChange={(v) => setWeightQuant(v as WeightQuant)}>
+                <SelectTrigger id="weight-quant" className="h-8 w-44 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(WEIGHT_QUANT_LABELS) as WeightQuant[]).map((q) => (
+                    <SelectItem key={q} value={q}>
+                      {WEIGHT_QUANT_LABELS[q]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <Label htmlFor="kv-quant">
+                  KV Cache Precision
+                </Label>
+                <InfoHint text="Precision of the running conversation memory the model keeps while generating. Lower precision lets the GPU handle more simultaneous chats. FP8 needs a recent GPU (H100/H200)." />
+              </div>
+              <Select value={kvCacheDtype} onValueChange={(v) => setKvCacheDtype(v as KvQuant)}>
+                <SelectTrigger id="kv-quant" className="h-8 w-44 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(KV_QUANT_LABELS) as KvQuant[]).map((q) => (
+                    <SelectItem key={q} value={q}>
+                      {KV_QUANT_LABELS[q]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="mt-4 flex items-center gap-2 text-sm">
+            <ThroughputEstimate estimate={throughput} isLoading={throughputLoading} />
+          </div>
+
+          {kvDowngraded && (
+            <p className="mt-2 text-xs text-yellow-500/90">
+              FP8 KV cache isn’t supported on{throughput?.gpuModel ? ` ${throughput.gpuModel}` : ' this GPU'} — showing the estimate with standard precision instead.
+            </p>
+          )}
+          {fp8Blocked && (
+            <p className="mt-2 text-xs text-destructive">
+              {fp8BlockReason}
+            </p>
+          )}
+        </div>
+      )}
+
       {/* Deployment Form */}
       <div className="animate-slide-up" style={{ animationDelay: '100ms', animationFillMode: 'both' }}>
         <DeploymentForm
@@ -155,6 +287,10 @@ export function DeployPage() {
           detailedCapacity={detailedCapacity}
           autoscaler={autoscaler}
           runtimes={runtimesData?.runtimes}
+          weightQuant={weightQuant}
+          kvCacheDtype={kvCacheDtype}
+          fp8Blocked={fp8Blocked}
+          fp8BlockReason={fp8BlockReason}
         />
       </div>
     </div>

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -85,15 +85,16 @@ export function DeployPage() {
   )
 
   // The backend downgrades an FP8 KV cache to FP16 on GPUs without a native FP8
-  // datapath (only Hopper / H100 / H200 support it). Surface that to the user.
+  // datapath (only Ada Lovelace and Hopper — L40S/L4/H100/H200 — support it).
+  // Surface that to the user.
   const kvDowngraded =
     kvCacheDtype === 'fp8' &&
     !!throughput?.kvCacheDtype &&
     throughput.kvCacheDtype !== 'fp8'
 
-  // Block deploying with FP8 on hardware that has no FP8 datapath (non-Hopper).
-  // The estimate response carries the resolved GPU's FP8 capability so we don't
-  // re-implement the GPU→generation mapping client-side.
+  // Block deploying with FP8 on hardware that has no FP8 datapath. The estimate
+  // response carries the resolved GPU's FP8 capability so we don't re-implement
+  // the GPU→generation mapping client-side.
   const fp8Selected = weightQuant === 'fp8' || kvCacheDtype === 'fp8'
   const fp8Blocked = fp8Selected && throughput?.fp8Supported === false
   const fp8BlockReason = fp8Blocked

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -98,7 +98,7 @@ export function DeployPage() {
   const fp8Selected = weightQuant === 'fp8' || kvCacheDtype === 'fp8'
   const fp8Blocked = fp8Selected && throughput?.fp8Supported === false
   const fp8BlockReason = fp8Blocked
-    ? `FP8 is only supported on H100/H200 GPUs. This cluster's GPU${throughput?.gpuModel ? ` (${throughput.gpuModel})` : ''} can't run FP8 — choose FP16 / BF16 to deploy.`
+    ? `FP8 is only supported on L40S/L4 and H100/H200 GPUs. This cluster's GPU${throughput?.gpuModel ? ` (${throughput.gpuModel})` : ''} can't run FP8 — choose FP16 / BF16 to deploy.`
     : undefined
 
   // FP8 selected but we couldn't confirm GPU support: the estimate has settled
@@ -245,7 +245,7 @@ export function DeployPage() {
                 <Label htmlFor="weight-quant">
                   Model Weights Precision
                 </Label>
-                <InfoHint text="How compactly the model's weights are stored. Lower precision (FP8) uses less GPU memory and runs faster, but can slightly reduce answer quality. FP8 needs a recent GPU (H100/H200)." />
+                <InfoHint text="How compactly the model's weights are stored. Lower precision (FP8) uses less GPU memory and runs faster, but can slightly reduce answer quality. FP8 needs a recent GPU (L40S/L4 or H100/H200)." />
               </div>
               <Select value={weightQuant} onValueChange={(v) => setWeightQuant(v as WeightQuant)}>
                 <SelectTrigger id="weight-quant" className="h-8 w-44 text-sm">
@@ -266,7 +266,7 @@ export function DeployPage() {
                 <Label htmlFor="kv-quant">
                   KV Cache Precision
                 </Label>
-                <InfoHint text="Precision of the running conversation memory the model keeps while generating. Lower precision lets the GPU handle more simultaneous chats. FP8 needs a recent GPU (H100/H200)." />
+                <InfoHint text="Precision of the running conversation memory the model keeps while generating. Lower precision lets the GPU handle more simultaneous chats. FP8 needs a recent GPU (L40S/L4 or H100/H200)." />
               </div>
               <Select value={kvCacheDtype} onValueChange={(v) => setKvCacheDtype(v as KvQuant)}>
                 <SelectTrigger id="kv-quant" className="h-8 w-44 text-sm">

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -7,7 +7,10 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Loader2, ArrowLeft, Cpu, HardDrive, Layers, ExternalLink } from 'lucide-react'
 import { GpuFitIndicator } from '@/components/models/GpuFitIndicator'
+import { ThroughputEstimate } from '@/components/models/ThroughputEstimate'
 import { getGpuFitCapacityDisplay } from '@/lib/gpu-fit-capacity'
+import { buildThroughputParams } from '@/lib/gpu-throughput-params'
+import { useGpuThroughput } from '@/hooks/useGpuOperator'
 
 export function DeployPage() {
   const { modelId } = useParams<{ modelId: string }>()
@@ -25,6 +28,13 @@ export function DeployPage() {
   const { data: autoscaler } = useAutoscalerDetection()
   const { data: runtimesData, isLoading: runtimesLoading } = useRuntimesStatus()
   const gpuFitCapacity = getGpuFitCapacityDisplay(detailedCapacity)
+
+  // Estimated inference throughput for this model on the cluster's GPUs.
+  const throughputParams = model ? buildThroughputParams(model, detailedCapacity) : undefined
+  const { data: throughput, isLoading: throughputLoading } = useGpuThroughput(
+    throughputParams ?? {},
+    { enabled: !!throughputParams }
+  )
 
   // Wait for both model and runtimes to load before showing the form
   // This ensures the runtime selector is visible when the form renders
@@ -123,6 +133,10 @@ export function DeployPage() {
             <HardDrive className="h-4 w-4" />
             <span>{model.conversational ? 'Chat' : model.task === 'image-text-to-text' ? 'Multimodal' : 'Text Generation'}</span>
           </div>
+
+          {throughputParams && (throughputLoading || throughput) && (
+            <ThroughputEstimate estimate={throughput} isLoading={throughputLoading} />
+          )}
         </div>
 
         <div className="flex flex-wrap gap-2 mt-4">

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -109,6 +109,16 @@ export function DeployPage() {
   const fp8CapabilityUnknown =
     fp8Selected && !throughputLoading && throughput?.fp8Supported === undefined
 
+  // High-confidence "model does not fit": the backend had real architecture
+  // details and the KV budget left no room for even one sequence on the
+  // estimate's assumed topology. We surface a non-blocking warning (the user may
+  // still pick more GPUs-per-replica in the form than the estimate assumed, which
+  // can make it fit) rather than disabling Deploy outright.
+  const doesNotFit = !!throughput?.doesNotFit && !throughput?.lowConfidence
+  const doesNotFitReason = doesNotFit
+    ? `This model is estimated not to fit on this cluster's GPU${throughput?.gpuModel ? ` (${throughput.gpuModel})` : ''} at ${throughput?.tpSize ?? 1} GPU${(throughput?.tpSize ?? 1) > 1 ? 's' : ''} per replica — the model weights plus reserved memory leave no room for the conversation cache. Increasing GPUs per replica below, choosing a smaller model, or using FP8 precision may help.`
+    : undefined
+
   // Wait for both model and runtimes to load before showing the form
   // This ensures the runtime selector is visible when the form renders
   if (modelLoading || runtimesLoading) {
@@ -306,6 +316,8 @@ export function DeployPage() {
           kvCacheDtype={kvCacheDtype}
           fp8Blocked={fp8Blocked}
           fp8BlockReason={fp8BlockReason}
+          doesNotFit={doesNotFit}
+          doesNotFitReason={doesNotFitReason}
         />
       </div>
     </div>

--- a/frontend/src/pages/DeployPage.tsx
+++ b/frontend/src/pages/DeployPage.tsx
@@ -100,6 +100,15 @@ export function DeployPage() {
     ? `FP8 is only supported on H100/H200 GPUs. This cluster's GPU${throughput?.gpuModel ? ` (${throughput.gpuModel})` : ''} can't run FP8 — choose FP16 / BF16 to deploy.`
     : undefined
 
+  // FP8 selected but we couldn't confirm GPU support: the estimate has settled
+  // (not in-flight) yet carries no fp8Supported signal — e.g. it errored or
+  // 404'd (no GPU pool with known specs). We don't block (the hardware may
+  // support FP8 even if we lack specs), but we warn so an unsupported flag isn't
+  // sent silently. Mutually exclusive with fp8Blocked (false → blocked;
+  // undefined → unknown; true → fine).
+  const fp8CapabilityUnknown =
+    fp8Selected && !throughputLoading && throughput?.fp8Supported === undefined
+
   // Wait for both model and runtimes to load before showing the form
   // This ensures the runtime selector is visible when the form renders
   if (modelLoading || runtimesLoading) {
@@ -275,6 +284,12 @@ export function DeployPage() {
           {fp8Blocked && (
             <p className="mt-2 text-xs text-destructive">
               {fp8BlockReason}
+            </p>
+          )}
+          {fp8CapabilityUnknown && (
+            <p className="mt-2 text-xs text-yellow-500/90">
+              We couldn’t verify FP8 support for this cluster’s GPUs. FP8 will still be applied —
+              if the hardware doesn’t support it, the model may fail to start. Choose FP16 / BF16 if unsure.
             </p>
           )}
         </div>

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -10,7 +10,7 @@ import { BookMarked, Search, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { Engine } from '@airunway/shared'
 import { getGpuFitCapacityDisplay } from '@/lib/gpu-fit-capacity'
-import { pickGpuModel } from '@/lib/gpu-throughput-params'
+import { hasEstimableGpu } from '@/lib/gpu-throughput-params'
 
 type Tab = 'curated' | 'huggingface'
 
@@ -22,7 +22,7 @@ export function ModelsPage() {
   const [selectedEngines, setSelectedEngines] = useState<Engine[]>([])
   const [activeTab, setActiveTab] = useState<Tab>('curated')
   const gpuFitCapacity = getGpuFitCapacityDisplay(gpuCapacity)
-  const gpuModel = pickGpuModel(detailedCapacity)
+  const gpuPresent = hasEstimableGpu(detailedCapacity)
 
   const filteredModels = useMemo(() => {
     if (!models) return []
@@ -146,7 +146,7 @@ export function ModelsPage() {
             gpuCapacityGb={gpuCapacity?.totalMemoryGb}
             gpuCount={gpuFitCapacity.gpuCount}
             gpuCapacityLabel={gpuFitCapacity.capacityLabel}
-            gpuModel={gpuModel}
+            gpuPresent={gpuPresent}
           />
         </>
       )}
@@ -157,7 +157,7 @@ export function ModelsPage() {
           gpuCapacityGb={gpuCapacity?.totalMemoryGb}
           gpuCount={gpuFitCapacity.gpuCount}
           gpuCapacityLabel={gpuFitCapacity.capacityLabel}
-          gpuModel={gpuModel}
+          gpuPresent={gpuPresent}
         />
       )}
     </div>

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useModels } from '@/hooks/useModels'
 import { useGpuCapacity } from '@/hooks/useGpuOperator'
+import { useDetailedCapacity } from '@/hooks/useAutoscaler'
 import { ModelGrid } from '@/components/models/ModelGrid'
 import { ModelSearch } from '@/components/models/ModelSearch'
 import { HfModelSearch } from '@/components/models/HfModelSearch'
@@ -9,16 +10,19 @@ import { BookMarked, Search, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { Engine } from '@airunway/shared'
 import { getGpuFitCapacityDisplay } from '@/lib/gpu-fit-capacity'
+import { pickGpuModel } from '@/lib/gpu-throughput-params'
 
 type Tab = 'curated' | 'huggingface'
 
 export function ModelsPage() {
   const { data: models, isLoading, error } = useModels()
   const { data: gpuCapacity } = useGpuCapacity()
+  const { data: detailedCapacity } = useDetailedCapacity()
   const [search, setSearch] = useState('')
   const [selectedEngines, setSelectedEngines] = useState<Engine[]>([])
   const [activeTab, setActiveTab] = useState<Tab>('curated')
   const gpuFitCapacity = getGpuFitCapacityDisplay(gpuCapacity)
+  const gpuModel = pickGpuModel(detailedCapacity)
 
   const filteredModels = useMemo(() => {
     if (!models) return []
@@ -142,6 +146,7 @@ export function ModelsPage() {
             gpuCapacityGb={gpuCapacity?.totalMemoryGb}
             gpuCount={gpuFitCapacity.gpuCount}
             gpuCapacityLabel={gpuFitCapacity.capacityLabel}
+            gpuModel={gpuModel}
           />
         </>
       )}
@@ -152,6 +157,7 @@ export function ModelsPage() {
           gpuCapacityGb={gpuCapacity?.totalMemoryGb}
           gpuCount={gpuFitCapacity.gpuCount}
           gpuCapacityLabel={gpuFitCapacity.capacityLabel}
+          gpuModel={gpuModel}
         />
       )}
     </div>

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,4 +1,5 @@
 export * from './model';
+export * from './modelParams';
 export * from './deployment';
 export * from './settings';
 export * from './installation';

--- a/shared/types/installation.ts
+++ b/shared/types/installation.ts
@@ -128,6 +128,17 @@ export interface GpuThroughputEstimate {
   tpSize: number;
   /** Context length (tokens) assumed for KV sizing. */
   contextLen: number;
+  /**
+   * Effective KV-cache dtype used for the concurrency estimate, after hardware
+   * gating. May differ from the requested dtype (e.g. fp8 downgraded to fp16 on
+   * non-Hopper GPUs). Independent of weight quantization.
+   */
+  kvCacheDtype?: 'fp16' | 'bf16' | 'fp8' | 'int8';
+  /**
+   * Whether the resolved GPU has a native FP8 datapath (Hopper, e.g. H100/H200).
+   * The UI uses this to block FP8 deployments on non-Hopper hardware.
+   */
+  fp8Supported?: boolean;
   /** Topology / capacity label, e.g. "4x80 GB". */
   capacityLabel?: string;
   /** True when architecture data was unavailable, so only perChat is meaningful. */

--- a/shared/types/installation.ts
+++ b/shared/types/installation.ts
@@ -131,12 +131,13 @@ export interface GpuThroughputEstimate {
   /**
    * Effective KV-cache dtype used for the concurrency estimate, after hardware
    * gating. May differ from the requested dtype (e.g. fp8 downgraded to fp16 on
-   * non-Hopper GPUs). Independent of weight quantization.
+   * GPUs without a native FP8 datapath). Independent of weight quantization.
    */
   kvCacheDtype?: 'fp16' | 'bf16' | 'fp8' | 'int8';
   /**
-   * Whether the resolved GPU has a native FP8 datapath (Hopper, e.g. H100/H200).
-   * The UI uses this to block FP8 deployments on non-Hopper hardware.
+   * Whether the resolved GPU has a native FP8 datapath (Ada Lovelace and Hopper,
+   * e.g. L40S/L4/H100/H200). The UI uses this to block FP8 deployments on
+   * hardware without an FP8 datapath.
    */
   fp8Supported?: boolean;
   /** Topology / capacity label, e.g. "4x80 GB". */

--- a/shared/types/installation.ts
+++ b/shared/types/installation.ts
@@ -132,6 +132,12 @@ export interface GpuThroughputEstimate {
   capacityLabel?: string;
   /** True when architecture data was unavailable, so only perChat is meaningful. */
   lowConfidence: boolean;
+  /**
+   * True (high-confidence) when model weights plus reserved headroom exceed the
+   * GPU's available VRAM, leaving no room for KV cache — the model does not fit
+   * and cannot be served on this GPU/topology. Distinct from lowConfidence.
+   */
+  doesNotFit?: boolean;
 }
 
 /**

--- a/shared/types/installation.ts
+++ b/shared/types/installation.ts
@@ -100,6 +100,41 @@ export interface ClusterGpuCapacity {
 }
 
 /**
+ * Estimated inference throughput for a model on the cluster's GPUs.
+ *
+ * Two distinct numbers (see issue #139):
+ *  - perChatTokensPerSec: single-stream decode speed (memory-bandwidth bound,
+ *    ~1/TPOT) — "how snappy does chat feel?"
+ *  - concurrentSequences / aggregateTokensPerSec: KV-cache-budget gated capacity
+ *    per replica — "how many requests can this serve at once?"
+ *
+ * Both are rough estimates (no inference is run). When architecture details are
+ * unavailable, only perChatTokensPerSec is populated and lowConfidence is true.
+ */
+export interface GpuThroughputEstimate {
+  /** Single-stream decode speed (tokens/sec per chat). */
+  perChatTokensPerSec: number;
+  /** Approx concurrent sequences per replica at the assumed context length. */
+  concurrentSequences?: number;
+  /** Aggregate tokens/sec per replica across concurrent sequences. */
+  aggregateTokensPerSec?: number;
+  /** Resolved GPU model the estimate was computed for. */
+  gpuModel: string;
+  /** Per-GPU VRAM (GB) used in the estimate. */
+  perGpuMemoryGb: number;
+  /** Per-GPU memory bandwidth (GB/s) used in the estimate. */
+  memBandwidthGBs: number;
+  /** Tensor-parallel size (GPUs per replica) assumed. */
+  tpSize: number;
+  /** Context length (tokens) assumed for KV sizing. */
+  contextLen: number;
+  /** Topology / capacity label, e.g. "4x80 GB". */
+  capacityLabel?: string;
+  /** True when architecture data was unavailable, so only perChat is meaningful. */
+  lowConfidence: boolean;
+}
+
+/**
  * Gateway CRD installation status
  */
 export interface GatewayCRDStatus {

--- a/shared/types/model.ts
+++ b/shared/types/model.ts
@@ -22,3 +22,16 @@ export interface Model {
   compatibilityWarnings?: string[]; // Warnings about model compatibility
   fromHfSearch?: boolean;        // Whether this model came from HF search (not curated list)
 }
+
+/**
+ * Transformer architecture details, read from a model's HuggingFace config.json.
+ * Used to size the KV cache when estimating concurrent serving capacity.
+ * All fields optional because config.json may be missing or incomplete.
+ */
+export interface ModelArchitecture {
+  numLayers?: number;            // num_hidden_layers
+  numKvHeads?: number;           // num_key_value_heads (falls back to num_attention_heads for MHA)
+  headDim?: number;              // head_dim (falls back to hidden_size / num_attention_heads)
+  maxPositionEmbeddings?: number; // max_position_embeddings (max context length)
+  torchDtype?: string;           // e.g. "bfloat16", "float16"
+}

--- a/shared/types/modelParams.ts
+++ b/shared/types/modelParams.ts
@@ -1,0 +1,77 @@
+import type { Model } from './model';
+
+/**
+ * Canonical model parameter-count parsing — shared by the backend (catalog
+ * search, throughput estimation) and the frontend (throughput-estimate query
+ * builder) so the two never drift. Previously each side carried its own inline
+ * regex; those copies disagreed on whitespace boundaries, the `illion`
+ * long-form suffix, and the sanity guard. This module is the single source of
+ * truth.
+ */
+
+/**
+ * Parse a parameter count from a model name / ID / size string.
+ * Handles common naming conventions like "8B", "70B", "1.5B", "0.6B", "405B",
+ * "7b", "125M", "350m", etc.
+ *
+ * @param modelId - Model ID, name, or size string (e.g. "meta-llama/Llama-3.1-8B-Instruct", "0.6B")
+ * @returns Absolute parameter count, or undefined if not parseable
+ */
+export function parseParameterCountFromName(modelId: string): number | undefined {
+  // Match patterns like "8B", "70B", "1.5B", "0.6B", "405b", "7B", "1B" etc.
+  // Must be preceded by start-of-string, hyphen, underscore, dot, or slash.
+  // Case insensitive.
+  const match = modelId.match(/(?:^|[-_./])(\d+(?:\.\d+)?)\s*[Bb](?:$|[-_./]|illion)?/);
+
+  if (match) {
+    const billions = parseFloat(match[1]);
+    if (!isNaN(billions) && billions > 0 && billions < 10000) {
+      // Convert billions to actual parameter count
+      return billions * 1_000_000_000;
+    }
+  }
+
+  // Also try matching "M" for millions (e.g., "125M", "350M")
+  const millionMatch = modelId.match(/(?:^|[-_./])(\d+(?:\.\d+)?)\s*[Mm](?:$|[-_./]|illion)?/);
+
+  if (millionMatch) {
+    const millions = parseFloat(millionMatch[1]);
+    if (!isNaN(millions) && millions > 0 && millions < 10000) {
+      return millions * 1_000_000;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve a numeric parameter count for a model, trying the most accurate
+ * source first and falling back to parsing the name / size string.
+ *
+ * Precedence: explicit numeric `parameterCount` → `parameters` → parse `id` →
+ * parse `size`. Returns undefined for unknown / unparseable models (e.g. MoE
+ * strings like "8x7B").
+ *
+ * The signature is deliberately lenient (only `id` is required) so callers that
+ * carry just an id + numeric count — e.g. HuggingFace search cards without a
+ * `size` field — typecheck without constructing a full Model.
+ */
+export function resolveModelParamCount(
+  model: Partial<Pick<Model, 'parameterCount' | 'parameters' | 'size'>> & Pick<Model, 'id'>
+): number | undefined {
+  if (typeof model.parameterCount === 'number' && model.parameterCount > 0) {
+    return model.parameterCount;
+  }
+  if (typeof model.parameters === 'number' && model.parameters > 0) {
+    return model.parameters;
+  }
+  if (model.id) {
+    const fromId = parseParameterCountFromName(model.id);
+    if (fromId) return fromId;
+  }
+  if (model.size) {
+    const fromSize = parseParameterCountFromName(model.size);
+    if (fromSize) return fromSize;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Description

Adds an **offline inference-throughput estimator** (issue #139) that surfaces two rough numbers per model without running any inference:

- **per-chat `tok/s`** — single-stream decode speed, memory-bandwidth bound ("how snappy chat feels")
- **concurrent capacity / aggregate `tok/s`** — KV-cache-budget gated, per replica ("how many requests at once")

The estimate is shown on catalog cards (deferred until the card scrolls into view) and on the Deploy page, where it sits in a new **Performance & Precision** section alongside weight- and KV-cache-precision controls. All values are presented as estimates with a methodology disclaimer. The branch also hardens the supporting backend (input validation, caching, GPU selection), unifies parameter-count parsing across the stack, and restores `bun run lint` by migrating both workspaces to ESLint flat config.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [x] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [x] 🔧 Build/CI configuration

## Related Issues

Fixes #139

## Changes Made

**Throughput estimator (backend)**

- Add `gpuPerformance.ts` with `estimatePerChatTokensPerSec` and `estimateConcurrentCapacity` heuristics, plus `deriveTpSizeToFitWeights`, `bytesPerWeightFor`, and `bytesPerKvFor` helpers
- Add `GET /installation/gpu-throughput` route: selects the GPU pool to estimate on, derives `tpSize` when the caller sends no `minGpus` hint, and degrades to a low-confidence per-chat-only result when architecture data is missing
- Add `getModelArchitecture` to `huggingface.ts` to read transformer dims from `config.json` (including nested `text_config`/`llm_config`/`language_config` for multimodal models), with a token-scoped, TTL'd, LRU-bounded cache (gated configs keyed by `sha256(token)` so they never leak across callers)
- Add per-GPU `memBandwidthGBs` specs and an `H200-141GB` entry to `costEstimation.ts`; gate FP8 to Hopper via `gpuSupportsFp8`

**Throughput estimator (frontend)**

- Add `ThroughputEstimate` component, `useGpuThroughput` hook, `gpuOperatorApi.getThroughput`, and `gpu-throughput-params` builders
- Add `useInView` so catalog cards defer the estimate fetch until visible
- Wire estimates into `ModelCard`, `HfModelCard`, `ModelGrid`, `HfModelSearch`, `ModelsPage`, and the Deploy summary card

**Deploy page precision controls**

- Add **Model Weights Precision** and **KV Cache Precision** dropdowns; feed FP8 into the deployment as `--quantization fp8` / `--kv-cache-dtype fp8` engine args for `vllm`/`sglang` only
- Decouple KV-cache precision from weight quantization (`bytesPerKvFor` defaults to 2 bytes)
- Gate FP8 to H100/H200: downgrade an FP8 KV cache to FP16 in the estimate, and disable Deploy with a reason on non-Hopper GPUs
- Surface a non-blocking **"model does not fit"** warning when the high-confidence estimate leaves no room for the KV cache (`Deploy` stays enabled, hidden when `fp8Blocked` already applies)

**Correctness & hardening**

- Factor tensor parallelism into per-chat speed: scale bandwidth by `tpSize × tpDecodeEfficiency(tpSize)`, stepped by group size (`1.0` for TP1, `0.85` for TP2-4, `0.75` for TP>4) so large groups crossing NVLink domains aren't over-estimated
- Bound `tpSize` to a pool's per-node GPU count via `perNodeGpuCount`; validate an explicit `gpuModel` against `capacity.nodePools` and fall back to the highest-VRAM pool
- Validate and `encodeURIComponent` `modelId` (`isValidHfRepoId` / `encodeHfRepoPath`) before any token-forwarding Hugging Face fetch, rejecting `../` traversal and stray segments
- Cap `paramCount` at 9T and the explicit `contextLen` at `MAX_CONTEXT_LEN` (32768); vary the react-query cache key by HF auth state (`auth`/`anon`) and stop retrying deterministic 4xx responses
- Correct estimates for unknown GPUs (skip / `404` instead of silently treating as `A10`) and accept non-HF custom `modelId`s (degrade to bandwidth-only instead of a hard `400`)

**Refactors**

- Unify model parameter-count parsing in `@airunway/shared` (`shared/types/modelParams.ts`: `parseParameterCountFromName`, `resolveModelParamCount`), removing divergent backend/frontend copies
- Type quant params with the exported `Quantization` / `KvCacheDtype` unions instead of `string`
- Drop dead `gpuModel` client-side selection plumbing (`pickGpuModel`), making the backend the single source of truth for GPU selection

**Build/CI**

- Migrate `backend` and `frontend` to ESLint flat config (`eslint.config.mjs`); add `@typescript-eslint/parser` + plugin to backend; drop the removed `--ext` flag so `bun run lint` works under ESLint v9+

## Testing

- [x] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [ ] Tested with a Kubernetes cluster

New/updated test suites: `gpuPerformance.test.ts`, `huggingface.test.ts`, `installation.test.ts`, `costEstimation.test.ts`, `modelCompatibility.test.ts` (backend); `DeploymentForm.test.tsx`, `ThroughputEstimate.test.tsx`, `useGpuOperator.test.tsx` (frontend). They cover the per-chat/concurrency heuristics, TP-size derivation and decode-efficiency tiers, `config.json` parsing (incl. nested multimodal configs), TTL + LRU cache eviction, `modelId` validation/encoding, query-param bounds, unknown-GPU `404`, FP8 gating, and the non-blocking "does not fit" warning.

### Manual Testing

Create a cluster with GPU nodepool and then check out this code and run the following:

```bash
bun install
bun run dev
```

Now go to http://localhost:5173/deploy/microsoft%2FPhi-4-mini-instruct and you can see the new section.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

<img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/99054a5c-e000-46ac-9654-44ea0c68a565" />

Look at the new Performance & Precision section.

## Additional Notes

- All numbers are deliberately simple heuristics and are labelled as estimates in the UI — real throughput depends on the serving engine, batch scheduler, prompt lengths, and quantization.
- The ESLint migration intentionally **demotes** the pre-existing `no-explicit-any` / `no-unused-vars` backlog (and the newly-enabled react-hooks compiler rules) to warnings so lint is green and CI-usable, leaving the historical backlog visible for incremental burndown rather than fixing it in this PR.
- One pre-existing `tsc` error in `frontend/src/hooks/useInView.ts` (`RefObject<T | null>`) surfaced during validation; it is unrelated to the estimator logic and can be addressed separately.
