### PR TITLE
fix(backend): honour kubeconfig CA under Bun's native fetch

### DIFF
--- a/backend/src/lib/kubeconfig.test.ts
+++ b/backend/src/lib/kubeconfig.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as k8s from '@kubernetes/client-node';
+import { kubeConfigToBunTls, BunTlsHttpLibrary, makeApiClient } from './kubeconfig';
+
+/**
+ * Regression guards for the Bun TLS shim (`kubeConfigToBunTls`,
+ * `BunTlsHttpLibrary`, `makeApiClient`). This is security-sensitive auth/TLS
+ * code: the most important assertion in this file is that the **default path
+ * never disables certificate verification** — see `does NOT set
+ * rejectUnauthorized on the default path`.
+ *
+ * Tests build real `KubeConfig` objects via `loadFromOptions` (no disk/network)
+ * rather than mocking SDK internals, so they keep working across SDK patch bumps.
+ */
+
+// PEM-shaped placeholders. `applyToHTTPSOptions` only base64-decodes the *Data
+// fields into Buffers and copies them; it does not parse/validate the contents.
+const CA_PEM = '-----BEGIN CERTIFICATE-----\nMIIBfakeCApem\n-----END CERTIFICATE-----\n';
+const CERT_PEM = '-----BEGIN CERTIFICATE-----\nMIIBfakeClientpem\n-----END CERTIFICATE-----\n';
+const KEY_PEM = '-----BEGIN PRIVATE KEY-----\nMIIBfakeKeypem\n-----END PRIVATE KEY-----\n';
+
+const b64 = (s: string) => Buffer.from(s).toString('base64');
+
+interface KcOpts {
+  skipTLSVerify?: boolean;
+  tlsServerName?: string;
+  token?: string;
+  withClientCert?: boolean;
+  caData?: string | null;
+}
+
+function makeKubeConfig(opts: KcOpts = {}): k8s.KubeConfig {
+  const kc = new k8s.KubeConfig();
+  const cluster: Record<string, unknown> = {
+    name: 'test-cluster',
+    server: 'https://api.example.test:443',
+    skipTLSVerify: !!opts.skipTLSVerify,
+  };
+  if (opts.caData !== null) cluster.caData = opts.caData ?? b64(CA_PEM);
+  if (opts.tlsServerName) cluster.tlsServerName = opts.tlsServerName;
+
+  const user: Record<string, unknown> = { name: 'test-user' };
+  if (opts.token) user.token = opts.token;
+  if (opts.withClientCert) {
+    user.certData = b64(CERT_PEM);
+    user.keyData = b64(KEY_PEM);
+  }
+
+  kc.loadFromOptions({
+    clusters: [cluster as any],
+    users: [user as any],
+    contexts: [{ name: 'test-ctx', cluster: 'test-cluster', user: 'test-user' }],
+    currentContext: 'test-ctx',
+  });
+  return kc;
+}
+
+describe('kubeConfigToBunTls', () => {
+  it('maps ca/cert/key into the Bun tls option', async () => {
+    const tls = await kubeConfigToBunTls(makeKubeConfig({ withClientCert: true }));
+    expect(tls).toBeDefined();
+    expect(Buffer.isBuffer(tls!.ca)).toBe(true);
+    expect(Buffer.isBuffer(tls!.cert)).toBe(true);
+    expect(Buffer.isBuffer(tls!.key)).toBe(true);
+    expect(tls!.ca!.toString()).toBe(CA_PEM);
+  });
+
+  it('maps the kubeconfig SNI (servername) to Bun camelCase serverName', async () => {
+    const tls = await kubeConfigToBunTls(makeKubeConfig({ token: 'tok', tlsServerName: 'sni.override.test' }));
+    expect(tls).toBeDefined();
+    expect(tls!.serverName).toBe('sni.override.test');
+  });
+
+  it('does NOT set serverName when the kubeconfig has no tls-server-name', async () => {
+    const tls = await kubeConfigToBunTls(makeKubeConfig({ token: 'tok' }));
+    // ca is still present, so tls is defined; serverName must be absent.
+    expect(tls).toBeDefined();
+    expect(tls!.serverName).toBeUndefined();
+  });
+
+  it('sets rejectUnauthorized=false when skipTLSVerify is true', async () => {
+    const tls = await kubeConfigToBunTls(makeKubeConfig({ token: 'tok', skipTLSVerify: true }));
+    expect(tls).toBeDefined();
+    expect(tls!.rejectUnauthorized).toBe(false);
+  });
+
+  // *** KEY SECURITY REGRESSION GUARD ***
+  it('does NOT set rejectUnauthorized on the default (verifying) path', async () => {
+    const tls = await kubeConfigToBunTls(makeKubeConfig({ token: 'tok' }));
+    expect(tls).toBeDefined();
+    // Must be absent (not `true`, not `false`) so Bun keeps verification ON.
+    expect(tls!.rejectUnauthorized).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(tls!, 'rejectUnauthorized')).toBe(false);
+  });
+
+  it('returns undefined when the kubeconfig configures no TLS material', async () => {
+    // No CA, no client cert, token auth, verification left on → nothing to map.
+    const tls = await kubeConfigToBunTls(makeKubeConfig({ token: 'tok', caData: null }));
+    expect(tls).toBeUndefined();
+  });
+});
+
+describe('BunTlsHttpLibrary.send', () => {
+  const realFetch = globalThis.fetch;
+  let calls: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    calls = [];
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function stubFetch(status = 200, body = '{"ok":true}') {
+    globalThis.fetch = (async (url: any, options: any) => {
+      calls.push({ url: String(url), options });
+      return new Response(body, { status, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+  }
+
+  function makeRequest(): k8s.RequestContext {
+    const req = new k8s.RequestContext('https://api.example.test:443/healthz', k8s.HttpMethod.GET);
+    // Mirror how the generated client applies auth before send() runs.
+    req.setHeaderParam('Authorization', 'Bearer test-token-123');
+    return req;
+  }
+
+  it('passes the mapped tls material to fetch', async () => {
+    stubFetch();
+    const lib = new BunTlsHttpLibrary(makeKubeConfig({ withClientCert: true, tlsServerName: 'sni.test' }));
+    await lib.send(makeRequest()).toPromise();
+
+    expect(calls).toHaveLength(1);
+    const tls = calls[0].options.tls;
+    expect(tls).toBeDefined();
+    expect(Buffer.isBuffer(tls.ca)).toBe(true);
+    expect(tls.serverName).toBe('sni.test');
+  });
+
+  it('preserves the Authorization header applied upstream (auth survives the override)', async () => {
+    stubFetch();
+    const lib = new BunTlsHttpLibrary(makeKubeConfig({ token: 'ignored' }));
+    await lib.send(makeRequest()).toPromise();
+
+    const headers = new Headers(calls[0].options.headers);
+    expect(headers.get('Authorization')).toBe('Bearer test-token-123');
+  });
+
+  it('omits tls entirely when the kubeconfig configures none', async () => {
+    stubFetch();
+    const lib = new BunTlsHttpLibrary(makeKubeConfig({ token: 'tok', caData: null }));
+    await lib.send(makeRequest()).toPromise();
+    expect(calls[0].options.tls).toBeUndefined();
+  });
+
+  it('returns a ResponseContext (not a thrown error) for a non-2xx response', async () => {
+    stubFetch(404, '{"kind":"Status","code":404}');
+    const lib = new BunTlsHttpLibrary(makeKubeConfig({ token: 'tok' }));
+    const res = await lib.send(makeRequest()).toPromise();
+
+    expect(res).toBeInstanceOf(k8s.ResponseContext);
+    expect(res.httpStatusCode).toBe(404);
+    expect(await res.body.text()).toContain('Status');
+  });
+
+  it('resolves the kubeconfig TLS material only once across multiple requests', async () => {
+    stubFetch();
+    const kc = makeKubeConfig({ withClientCert: true });
+    let applyCount = 0;
+    const orig = kc.applyToHTTPSOptions.bind(kc);
+    kc.applyToHTTPSOptions = (async (opts: any) => {
+      applyCount += 1;
+      return orig(opts);
+    }) as typeof kc.applyToHTTPSOptions;
+
+    const lib = new BunTlsHttpLibrary(kc);
+    await lib.send(makeRequest()).toPromise();
+    await lib.send(makeRequest()).toPromise();
+    await lib.send(makeRequest()).toPromise();
+
+    // Cached after the first call — guards against re-running the auth/cert
+    // pipeline (e.g. exec credential plugins) on every request.
+    expect(applyCount).toBe(1);
+  });
+});
+
+describe('makeApiClient', () => {
+  it('builds a typed API client wired to the Bun TLS http library', () => {
+    const api = makeApiClient(makeKubeConfig({ token: 'tok' }), k8s.CoreV1Api);
+    expect(api).toBeInstanceOf(k8s.CoreV1Api);
+  });
+
+  it('throws when the kubeconfig has no active cluster', () => {
+    const kc = new k8s.KubeConfig();
+    expect(() => makeApiClient(kc, k8s.CoreV1Api)).toThrow('No active cluster!');
+  });
+});

--- a/backend/src/lib/kubeconfig.ts
+++ b/backend/src/lib/kubeconfig.ts
@@ -35,6 +35,80 @@ export function loadKubeConfig(): k8s.KubeConfig {
 }
 
 /**
+ * TLS material in the shape Bun's native `fetch` understands via its
+ * non-standard per-request `tls` option (see Bun's `TLSOptions`).
+ *
+ * Field names follow Bun, not Node: in particular SNI is `serverName`
+ * (camelCase), whereas the kubeconfig/Node side spells it `servername`.
+ */
+export interface BunTlsOptions {
+  ca?: Buffer;
+  cert?: Buffer;
+  key?: Buffer;
+  passphrase?: string;
+  serverName?: string;
+  rejectUnauthorized?: boolean;
+}
+
+/**
+ * Translate a `KubeConfig`'s TLS material into Bun's `fetch` `tls` option.
+ *
+ * This is the **single source of truth** for kubeconfig → Bun TLS mapping. Both
+ * {@link BunTlsHttpLibrary} (typed-API clients) and `proxyServiceRequest`
+ * (raw service-proxy `fetch`) must call it, so the two paths cannot drift —
+ * e.g. one gaining SNI support while the other silently misses it.
+ *
+ * It asks the SDK for the same `https.Agent` options its Node path would use
+ * (`applyToHTTPSOptions`, verified against `@kubernetes/client-node@1.4.0`
+ * `config.js`), then re-maps the subset Bun honours:
+ *   - `ca`/`cert`/`key`            — CA bundle + client cert/key
+ *   - `passphrase`                 — passphrase for an encrypted client key
+ *   - `servername` → `serverName`  — SNI / hostname-verification override
+ *                                    (`cluster.tls-server-name`)
+ *   - `rejectUnauthorized:false`   — only when `skipTLSVerify` (or the SDK)
+ *                                    explicitly disabled verification; the
+ *                                    default path leaves it unset so Bun keeps
+ *                                    verification ON.
+ *
+ * KNOWN LIMITATIONS (kubeconfig features the SDK's Node agent supports but
+ * Bun's `fetch` cannot express, so they are intentionally dropped here):
+ *   - `pfx` (PKCS#12 client certs) — Bun's `TLSOptions` has no `pfx` field.
+ *     PEM `cert`/`key` work; `.pfx`-based auth does not under Bun.
+ *   - `cluster.proxy-url`          — Bun has no per-request proxy-agent option;
+ *     kubeconfig-configured HTTP/SOCKS proxies are not honoured.
+ *
+ * @returns the mapped options, or `undefined` if the kubeconfig configured no
+ *          TLS material at all (so callers can omit `tls` entirely).
+ */
+export async function kubeConfigToBunTls(kc: k8s.KubeConfig): Promise<BunTlsOptions | undefined> {
+  // Ask the SDK for the Node `https.Agent` options it would build, then re-map
+  // the subset Bun honours. `servername`/`pfx`/`passphrase` are populated by
+  // the SDK even though our narrowed type only names what we forward.
+  const httpsOptions: {
+    ca?: Buffer;
+    cert?: Buffer;
+    key?: Buffer;
+    passphrase?: string;
+    servername?: string;
+    rejectUnauthorized?: boolean;
+  } = {};
+  await kc.applyToHTTPSOptions(httpsOptions as any);
+
+  const tls: BunTlsOptions = {};
+  if (httpsOptions.ca) tls.ca = httpsOptions.ca;
+  if (httpsOptions.cert) tls.cert = httpsOptions.cert;
+  if (httpsOptions.key) tls.key = httpsOptions.key;
+  if (httpsOptions.passphrase) tls.passphrase = httpsOptions.passphrase;
+  // Node spells SNI `servername`; Bun's `tls` option spells it `serverName`.
+  if (httpsOptions.servername) tls.serverName = httpsOptions.servername;
+  if (kc.getCurrentCluster()?.skipTLSVerify || httpsOptions.rejectUnauthorized === false) {
+    tls.rejectUnauthorized = false;
+  }
+
+  return Object.keys(tls).length > 0 ? tls : undefined;
+}
+
+/**
  * Bun-compatible HTTP library for `@kubernetes/client-node`.
  *
  * WHY THIS EXISTS:
@@ -47,49 +121,55 @@ export function loadKubeConfig(): k8s.KubeConfig {
  * private CA (e.g. AKS) fails with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`.
  *
  * This subclass overrides `send()` to call Bun's native `fetch` directly,
- * translating the kubeconfig's TLS material into the `tls` option Bun
- * understands. Auth headers (Bearer tokens, etc.) are still applied by the
- * generated client via `authMethods` before `send()` runs, so we only need to
- * re-inject the TLS material here. It mirrors the working pattern already used
- * by `proxyServiceRequest` in `kubernetes.ts`.
+ * translating the kubeconfig's TLS material (via {@link kubeConfigToBunTls})
+ * into the `tls` option Bun understands. Auth headers (Bearer tokens, etc.) are
+ * still applied by the generated client via `authMethods` before `send()` runs,
+ * so we only need to re-inject the TLS material here. It shares the exact same
+ * mapping helper as `proxyServiceRequest` in `kubernetes.ts`.
+ *
+ * The TLS material is resolved **once** and cached: `applyToHTTPSOptions` re-runs
+ * the kubeconfig's full option pipeline (re-reading cert files from disk and, for
+ * exec/OIDC users, re-invoking the auth plugin). Doing that per request would run
+ * exec credentials twice on every call — once here and once in the auth pipeline
+ * the generated client already applied. A KubeConfig's TLS material is fixed for
+ * the lifetime of a client, so caching is safe; auth headers are unaffected
+ * because they are applied upstream per request, not here.
  *
  * The response is wrapped exactly as the upstream library does: an `Observable`
  * constructed from a `Promise<ResponseContext>` (see `rxjsStub`), with a
  * `ResponseBody` exposing `text()` and `binary()`.
  */
 export class BunTlsHttpLibrary extends k8s.IsomorphicFetchHttpLibrary {
+  private tlsPromise?: Promise<BunTlsOptions | undefined>;
+
   constructor(private readonly kc: k8s.KubeConfig) {
     super();
   }
 
+  /** Resolve the kubeconfig's Bun `tls` material once and memoise it. */
+  private getTls(): Promise<BunTlsOptions | undefined> {
+    if (!this.tlsPromise) {
+      this.tlsPromise = kubeConfigToBunTls(this.kc);
+    }
+    return this.tlsPromise;
+  }
+
   send(request: k8s.RequestContext): k8s.Observable<k8s.ResponseContext> {
     const responsePromise = (async (): Promise<k8s.ResponseContext> => {
-      // Extract TLS material (CA, client cert/key, verification mode) from the
-      // kubeconfig the same way the SDK's Node path would, then hand it to Bun
-      // via the `tls` option instead of a Node https.Agent.
-      const httpsOptions: {
-        ca?: Buffer;
-        cert?: Buffer;
-        key?: Buffer;
-        rejectUnauthorized?: boolean;
-      } = {};
-      await this.kc.applyToHTTPSOptions(httpsOptions as any);
+      const tls = await this.getTls();
 
-      const tls: Record<string, unknown> = {};
-      if (httpsOptions.ca) tls.ca = httpsOptions.ca;
-      if (httpsOptions.cert) tls.cert = httpsOptions.cert;
-      if (httpsOptions.key) tls.key = httpsOptions.key;
-      if (this.kc.getCurrentCluster()?.skipTLSVerify || httpsOptions.rejectUnauthorized === false) {
-        tls.rejectUnauthorized = false;
-      }
-
-      const fetchOptions: RequestInit & { tls?: Record<string, unknown> } = {
+      // NOTE: the generated API classes used by this backend send only JSON or
+      // empty bodies. The SDK's Node path can produce `form-data` multipart
+      // bodies (e.g. some file-upload endpoints) which would NOT serialise under
+      // Bun's `fetch`; if a future caller hits such an endpoint, body handling
+      // here must be revisited.
+      const fetchOptions: RequestInit & { tls?: BunTlsOptions } = {
         method: request.getHttpMethod().toString(),
         body: request.getBody() as BodyInit | undefined,
         headers: request.getHeaders(),
         signal: request.getSignal(),
       };
-      if (Object.keys(tls).length > 0) {
+      if (tls) {
         fetchOptions.tls = tls;
       }
 
@@ -122,6 +202,12 @@ export class BunTlsHttpLibrary extends k8s.IsomorphicFetchHttpLibrary {
  * All backend services must construct their clients through this helper rather
  * than calling `kc.makeApiClient(...)` directly; otherwise requests to clusters
  * with a private CA fail with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` under Bun.
+ *
+ * NOTE (SDK coupling): this hand-reproduces the SDK's own `makeApiClient` wiring
+ * (`createConfiguration` + `ServerConfiguration`) and subclasses
+ * `IsomorphicFetchHttpLibrary`. Verified against `@kubernetes/client-node@1.4.0`.
+ * These are generated/internal surfaces — re-check this wiring (and the
+ * `kubeConfigToBunTls` field mapping) when bumping the SDK across a major version.
  */
 export function makeApiClient<T extends k8s.ApiType>(
   kc: k8s.KubeConfig,

--- a/backend/src/lib/kubeconfig.ts
+++ b/backend/src/lib/kubeconfig.ts
@@ -33,3 +33,110 @@ export function loadKubeConfig(): k8s.KubeConfig {
 
   return kc;
 }
+
+/**
+ * Bun-compatible HTTP library for `@kubernetes/client-node`.
+ *
+ * WHY THIS EXISTS:
+ * The client's default `IsomorphicFetchHttpLibrary` imports `node-fetch` and
+ * passes the kubeconfig CA (and client cert/key) as a Node.js `https.Agent`
+ * (`request.getAgent()`). Bun's runtime resolves `node-fetch` to its native
+ * `fetch`, which **ignores** the Node `https.Agent` entirely — it only honours
+ * TLS material supplied via the per-request `tls` option. The CA therefore never
+ * reaches the TLS stack, so every request to a cluster whose API server uses a
+ * private CA (e.g. AKS) fails with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`.
+ *
+ * This subclass overrides `send()` to call Bun's native `fetch` directly,
+ * translating the kubeconfig's TLS material into the `tls` option Bun
+ * understands. Auth headers (Bearer tokens, etc.) are still applied by the
+ * generated client via `authMethods` before `send()` runs, so we only need to
+ * re-inject the TLS material here. It mirrors the working pattern already used
+ * by `proxyServiceRequest` in `kubernetes.ts`.
+ *
+ * The response is wrapped exactly as the upstream library does: an `Observable`
+ * constructed from a `Promise<ResponseContext>` (see `rxjsStub`), with a
+ * `ResponseBody` exposing `text()` and `binary()`.
+ */
+export class BunTlsHttpLibrary extends k8s.IsomorphicFetchHttpLibrary {
+  constructor(private readonly kc: k8s.KubeConfig) {
+    super();
+  }
+
+  send(request: k8s.RequestContext): k8s.Observable<k8s.ResponseContext> {
+    const responsePromise = (async (): Promise<k8s.ResponseContext> => {
+      // Extract TLS material (CA, client cert/key, verification mode) from the
+      // kubeconfig the same way the SDK's Node path would, then hand it to Bun
+      // via the `tls` option instead of a Node https.Agent.
+      const httpsOptions: {
+        ca?: Buffer;
+        cert?: Buffer;
+        key?: Buffer;
+        rejectUnauthorized?: boolean;
+      } = {};
+      await this.kc.applyToHTTPSOptions(httpsOptions as any);
+
+      const tls: Record<string, unknown> = {};
+      if (httpsOptions.ca) tls.ca = httpsOptions.ca;
+      if (httpsOptions.cert) tls.cert = httpsOptions.cert;
+      if (httpsOptions.key) tls.key = httpsOptions.key;
+      if (this.kc.getCurrentCluster()?.skipTLSVerify || httpsOptions.rejectUnauthorized === false) {
+        tls.rejectUnauthorized = false;
+      }
+
+      const fetchOptions: RequestInit & { tls?: Record<string, unknown> } = {
+        method: request.getHttpMethod().toString(),
+        body: request.getBody() as BodyInit | undefined,
+        headers: request.getHeaders(),
+        signal: request.getSignal(),
+      };
+      if (Object.keys(tls).length > 0) {
+        fetchOptions.tls = tls;
+      }
+
+      const response = await fetch(request.getUrl(), fetchOptions);
+
+      const headers: Record<string, string> = {};
+      response.headers.forEach((value, name) => {
+        headers[name] = value;
+      });
+
+      return new k8s.ResponseContext(response.status, headers, {
+        text: () => response.text(),
+        binary: async () => Buffer.from(await response.arrayBuffer()),
+      });
+    })();
+
+    return new k8s.Observable<k8s.ResponseContext>(responsePromise);
+  }
+}
+
+/**
+ * Build a Kubernetes API client that works under Bun.
+ *
+ * Drop-in replacement for `kc.makeApiClient(ApiClass)`. It reproduces the SDK's
+ * own `makeApiClient` wiring (`createConfiguration` with the kubeconfig as the
+ * `default` auth method and a `ServerConfiguration` for the current cluster) but
+ * swaps in {@link BunTlsHttpLibrary} so the kubeconfig CA is honoured on Bun's
+ * native `fetch`.
+ *
+ * All backend services must construct their clients through this helper rather
+ * than calling `kc.makeApiClient(...)` directly; otherwise requests to clusters
+ * with a private CA fail with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` under Bun.
+ */
+export function makeApiClient<T extends k8s.ApiType>(
+  kc: k8s.KubeConfig,
+  apiClientType: k8s.ApiConstructor<T>
+): T {
+  const cluster = kc.getCurrentCluster();
+  if (!cluster) {
+    throw new Error('No active cluster!');
+  }
+
+  const configuration = k8s.createConfiguration({
+    baseServer: new k8s.ServerConfiguration(cluster.server, {}),
+    authMethods: { default: kc },
+    httpApi: new BunTlsHttpLibrary(kc),
+  });
+
+  return new apiClientType(configuration);
+}

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -2,7 +2,7 @@ import * as k8s from '@kubernetes/client-node';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import { loadKubeConfig } from '../lib/kubeconfig';
+import { loadKubeConfig, makeApiClient } from '../lib/kubeconfig';
 import logger from '../lib/logger';
 
 /**
@@ -46,7 +46,7 @@ class AuthService {
 
   constructor() {
     this.kc = loadKubeConfig();
-    this.authApi = this.kc.makeApiClient(k8s.AuthenticationV1Api);
+    this.authApi = makeApiClient(this.kc, k8s.AuthenticationV1Api);
   }
 
   /**

--- a/backend/src/services/autoscaler.ts
+++ b/backend/src/services/autoscaler.ts
@@ -1,7 +1,7 @@
 import * as k8s from '@kubernetes/client-node';
 import type { AutoscalerDetectionResult, AutoscalerStatusInfo } from '@airunway/shared';
 import { withRetry } from '../lib/retry';
-import { loadKubeConfig } from '../lib/kubeconfig';
+import { loadKubeConfig, makeApiClient } from '../lib/kubeconfig';
 import logger from '../lib/logger';
 import * as yaml from 'js-yaml';
 
@@ -13,9 +13,9 @@ class AutoscalerService {
 
   constructor() {
     this.kc = loadKubeConfig();
-    this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
-    this.appsV1Api = this.kc.makeApiClient(k8s.AppsV1Api);
-    this.customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi);
+    this.coreV1Api = makeApiClient(this.kc, k8s.CoreV1Api);
+    this.appsV1Api = makeApiClient(this.kc, k8s.AppsV1Api);
+    this.customObjectsApi = makeApiClient(this.kc, k8s.CustomObjectsApi);
   }
 
   /**

--- a/backend/src/services/config.ts
+++ b/backend/src/services/config.ts
@@ -1,5 +1,5 @@
 import * as k8s from '@kubernetes/client-node';
-import { loadKubeConfig } from '../lib/kubeconfig';
+import { loadKubeConfig, makeApiClient } from '../lib/kubeconfig';
 import logger from '../lib/logger';
 
 // Default namespace for AI Runway deployments
@@ -28,7 +28,7 @@ class ConfigService {
 
   constructor() {
     this.kc = loadKubeConfig();
-    this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
+    this.coreV1Api = makeApiClient(this.kc, k8s.CoreV1Api);
   }
 
   /**

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -3,7 +3,7 @@ import { configService } from './config';
 import type { DeploymentStatus, PodStatus, ClusterStatus, PodPhase, DeploymentConfig, RuntimeStatus, ModelDeployment, GatewayInfo, GatewayModelInfo, GatewayCRDStatus } from '@airunway/shared';
 import { toModelDeploymentManifest, toDeploymentStatus, INFERENCE_GATEWAY_LABEL } from '@airunway/shared';
 import { withRetry } from '../lib/retry';
-import { loadKubeConfig } from '../lib/kubeconfig';
+import { loadKubeConfig, makeApiClient } from '../lib/kubeconfig';
 import logger from '../lib/logger';
 import { aggregateRequiresCRDFromCapabilities, getAnnotatedProviderDisplayName, getProviderDisplayName, providerRequiresRuntimeCRD } from '../lib/providers';
 
@@ -221,9 +221,9 @@ class KubernetesService {
 
   constructor() {
     this.kc = loadKubeConfig();
-    this.customObjectsApi = this.kc.makeApiClient(k8s.CustomObjectsApi);
-    this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
-    this.apiExtensionsApi = this.kc.makeApiClient(k8s.ApiextensionsV1Api);
+    this.customObjectsApi = makeApiClient(this.kc, k8s.CustomObjectsApi);
+    this.coreV1Api = makeApiClient(this.kc, k8s.CoreV1Api);
+    this.apiExtensionsApi = makeApiClient(this.kc, k8s.ApiextensionsV1Api);
     this.defaultNamespace = process.env.DEFAULT_NAMESPACE || 'airunway-system';
   }
 
@@ -242,7 +242,7 @@ class KubernetesService {
     if (!userToken) {
       return this.customObjectsApi;
     }
-    return this.createUserKubeConfig(userToken).makeApiClient(k8s.CustomObjectsApi);
+    return makeApiClient(this.createUserKubeConfig(userToken), k8s.CustomObjectsApi);
   }
 
   /**
@@ -252,7 +252,7 @@ class KubernetesService {
     if (!userToken) {
       return this.coreV1Api;
     }
-    return this.createUserKubeConfig(userToken).makeApiClient(k8s.CoreV1Api);
+    return makeApiClient(this.createUserKubeConfig(userToken), k8s.CoreV1Api);
   }
 
   /**
@@ -261,7 +261,7 @@ class KubernetesService {
   private createUserClients(userToken: string) {
     const userKc = this.createUserKubeConfig(userToken);
     return {
-      authorizationV1Api: userKc.makeApiClient(k8s.AuthorizationV1Api),
+      authorizationV1Api: makeApiClient(userKc, k8s.AuthorizationV1Api),
     };
   }
 

--- a/backend/src/services/kubernetes.ts
+++ b/backend/src/services/kubernetes.ts
@@ -3,7 +3,7 @@ import { configService } from './config';
 import type { DeploymentStatus, PodStatus, ClusterStatus, PodPhase, DeploymentConfig, RuntimeStatus, ModelDeployment, GatewayInfo, GatewayModelInfo, GatewayCRDStatus } from '@airunway/shared';
 import { toModelDeploymentManifest, toDeploymentStatus, INFERENCE_GATEWAY_LABEL } from '@airunway/shared';
 import { withRetry } from '../lib/retry';
-import { loadKubeConfig, makeApiClient } from '../lib/kubeconfig';
+import { loadKubeConfig, makeApiClient, kubeConfigToBunTls } from '../lib/kubeconfig';
 import logger from '../lib/logger';
 import { aggregateRequiresCRDFromCapabilities, getAnnotatedProviderDisplayName, getProviderDisplayName, providerRequiresRuntimeCRD } from '../lib/providers';
 
@@ -2167,17 +2167,10 @@ class KubernetesService {
     // Extract auth headers from KubeConfig
     const authOpts = await kubeConfig.applyToFetchOptions({ headers: {} } as any);
 
-    // Extract TLS options (CA cert, client cert/key) from KubeConfig
-    const httpsOpts: { ca?: Buffer; cert?: Buffer; key?: Buffer; rejectUnauthorized?: boolean } = {};
-    await kubeConfig.applyToHTTPSOptions(httpsOpts as any);
-
-    const tlsOpts: Record<string, any> = {};
-    if (httpsOpts.ca) tlsOpts.ca = httpsOpts.ca;
-    if (httpsOpts.cert) tlsOpts.cert = httpsOpts.cert;
-    if (httpsOpts.key) tlsOpts.key = httpsOpts.key;
-    if (cluster.skipTLSVerify || httpsOpts.rejectUnauthorized === false) {
-      tlsOpts.rejectUnauthorized = false;
-    }
+    // Extract TLS material (CA, client cert/key, SNI, verification mode) via the
+    // shared kubeconfig→Bun mapping, so this raw-`fetch` path and the typed-API
+    // path (`BunTlsHttpLibrary`) stay in lockstep and cannot drift.
+    const tlsOpts = await kubeConfigToBunTls(kubeConfig);
 
     const headers = new Headers((authOpts.headers as HeadersInit) || {});
     if (requestInit.headers) {
@@ -2189,7 +2182,7 @@ class KubernetesService {
       headers,
     };
 
-    if (Object.keys(tlsOpts).length > 0) {
+    if (tlsOpts) {
       fetchOpts.tls = tlsOpts;
     }
 

--- a/backend/src/services/registry.ts
+++ b/backend/src/services/registry.ts
@@ -1,5 +1,5 @@
 import * as k8s from '@kubernetes/client-node';
-import { loadKubeConfig } from '../lib/kubeconfig';
+import { loadKubeConfig, makeApiClient } from '../lib/kubeconfig';
 import logger from '../lib/logger';
 import { withRetry } from '../lib/retry';
 
@@ -37,8 +37,8 @@ class RegistryService {
 
   constructor() {
     this.kc = loadKubeConfig();
-    this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
-    this.appsV1Api = this.kc.makeApiClient(k8s.AppsV1Api);
+    this.coreV1Api = makeApiClient(this.kc, k8s.CoreV1Api);
+    this.appsV1Api = makeApiClient(this.kc, k8s.AppsV1Api);
   }
 
   /**

--- a/backend/src/services/secrets.ts
+++ b/backend/src/services/secrets.ts
@@ -1,5 +1,5 @@
 import * as k8s from '@kubernetes/client-node';
-import { loadKubeConfig } from '../lib/kubeconfig';
+import { loadKubeConfig, makeApiClient } from '../lib/kubeconfig';
 import logger from '../lib/logger';
 import { withRetry } from '../lib/retry';
 import type { HfSecretStatus, HfUserInfo } from '@airunway/shared';
@@ -31,7 +31,7 @@ class SecretsService {
 
   constructor() {
     this.kc = loadKubeConfig();
-    this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
+    this.coreV1Api = makeApiClient(this.kc, k8s.CoreV1Api);
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes Kubernetes authentication failures in the backend when running under **Bun** against clusters that use a private CA (e.g. AKS). Every API-server request was failing with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` because Bun's native `fetch` ignores the kubeconfig CA that `@kubernetes/client-node` supplies via a Node.js `https.Agent`. This PR re-injects the TLS material through the per-request `tls` option that Bun honours, routes all backend client construction through a single Bun-safe helper, and hardens that helper (shared TLS mapping, SNI, cached extraction) with regression tests.

Get a visual overview of the PR here: https://suraj.io/share/prs/github.com/kaito-project/airunway/pull/319/PR-319-review-dashboard.html

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Changes Made

**Core fix — honour the kubeconfig CA under Bun (`d44f5a0`)**

- Add `BunTlsHttpLibrary` to `backend/src/lib/kubeconfig.ts` — a subclass of `k8s.IsomorphicFetchHttpLibrary` that overrides `send()` to call Bun's native `fetch` directly, translating the kubeconfig's TLS material into the per-request `tls` option Bun understands. Auth headers (Bearer tokens, etc.) are still applied upstream by the generated client via `authMethods`, so only the TLS material is re-injected.
- Add a `makeApiClient(kc, ApiClass)` helper — a drop-in replacement for `kc.makeApiClient(...)` that reproduces the SDK's wiring (`createConfiguration` + `ServerConfiguration`) but swaps in `BunTlsHttpLibrary`.
- Route all client construction through `makeApiClient(...)` across the backend services: `auth.ts`, `autoscaler.ts`, `config.ts`, `kubernetes.ts`, `registry.ts`, and `secrets.ts` — including the per-user token clients built from `createUserKubeConfig(...)`.

**Hardening from PR review (`c9157b7`)**

- Extract a shared `kubeConfigToBunTls()` helper as the single source of truth for kubeconfig → Bun TLS mapping, and route **both** `BunTlsHttpLibrary.send()` and `proxyServiceRequest()` (`kubernetes.ts`) through it so the two TLS paths can no longer drift.
- Forward the **SNI override**, mapping the Node-side `servername` to Bun's camelCase `serverName` (previously dropped — broke clusters that set `tls-server-name`).
- Forward the client-key `passphrase`, previously dropped.
- Resolve the TLS material **once per client and cache it**, so `applyToHTTPSOptions` no longer re-runs the auth/cert pipeline (e.g. exec credential plugins, disk reads) on every request.
- Document `pfx` and `cluster.proxy-url` as known Bun limitations, note the `@kubernetes/client-node@1.4.0` SDK coupling, and flag the multipart-body caveat.
- Add `backend/src/lib/kubeconfig.test.ts` regression tests, including a guard that the **default path never disables certificate verification**.

## Testing

- [x] Unit tests pass (`bun run test`)
- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

**Automated:** `bun run test` passes — **864 tests, 0 failing** (backend 736, frontend 128), including 13 new tests for the Bun TLS shim. The new tests cover: `makeApiClient` throws with no cluster; `send()` passes TLS material and the `Authorization` header to `fetch`; `skipTLSVerify` maps to `rejectUnauthorized:false`; the default path leaves verification on; SNI `serverName` mapping; non-2xx still yields a `ResponseContext`; and the TLS material is resolved only once across requests.

**Manual:** Verified end-to-end against a live AKS cluster (`aks-0`, private CA) via the running Web UI:

- `GET /api/cluster/status` → `200` with `{"connected":true,"clusterName":"aks-0","providerInstallation":{"installed":true,"crdFound":true}}`
- `GET /api/deployments` → `200` (CRD list succeeds; renders "No deployments yet")
- `GET /api/installation/gpu-capacity` → `200`
- Zero `UNABLE_TO_VERIFY_LEAF_SIGNATURE` / certificate errors in backend logs or browser console.

### Manual Testing w/ & w/o changes

```bash
git checkout main
bun install
bun run dev
```

You will start seeing logs like this in the terminal:

```bash
@airunway/backend dev $ bun --watch src/index.ts
│ [39 lines elided]
│ {"level":"error","time":"2026-06-08T22:12:13.274Z","pid":38386,"hostname":"Users-MacBook-Pro.local","error":{"code":"UNABLE_TO_VERIFY_LEAF_SIGNATURE","path":"https://suraj-cluster.hcp.southcentralus.azmk8s.io/api/v1/namespaces/kube-system/configmaps/cluster-autoscaler-status","errno":0},"msg":"Error getting autoscaler status"}
│ {"level":"error","time":"2026-06-08T22:12:13.434Z","pid":38386,"hostname":"Users-MacBook-Pro.local","error":{"code":"UNABLE_TO_VERIFY_LEAF_SIGNATURE","path":"https://suraj-cluster.hcp.southcentralus.azmk8s.io/apis/apps/v1/namespaces/kube-system/deployments?labelSelector=app%3Dcluster-autoscaler","errno":0},"msg":"Error detecting cluster-autoscaler"}
│ {"level":"error","time":"2026-06-08T22:12:13.440Z","pid":38386,"hostname":"Users-MacBook-Pro.local","operation":"listPVCs","namespace":"dynamo-system","errorMessage":"unable to verify the first certificate","statusCode":500,"rawError":{"message":"unable to verify the first certificate","stack":"Error: unable to verify the first certificate\n    at async fetch (node-fetch:96:41)\n    at async withRetry (/Users/user/code/kubeairunway/backend/src/lib/retry.ts:96:20)\n    at async listPVCs (/Users/user/code/kubeairunway/backend/src/services/kubernetes.ts:2204:28)\n    at async <anonymous> (/Users/user/code/kubeairunway/backend/src/routes/deployments.ts:1053:44)\n    at async dispatch (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/compose.js:22:23)\n    at async <anonymous> (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/validator/validator.js:81:18)\n    at async dispatch (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/compose.js:22:23)\n    at async dispatch (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/compose.js:22:23)\n    at async <anonymous> (/Users/user/code/kubeairunway/backend/src/hono-app.ts:119:9)\n    at async dispatch (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/compose.js:22:23)"},"msg":"Kubernetes API error: unable to verify the first certificate"}
│ {"level":"error","time":"2026-06-08T22:12:13.441Z","pid":38386,"hostname":"Users-MacBook-Pro.local","error":{"status":500},"stack":"Error: Failed to list storage disks: unable to verify the first certificate\n    at <anonymous> (/Users/user/code/kubeairunway/backend/src/routes/deployments.ts:1061:17)\n    at async dispatch (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/compose.js:22:23)\n    at async <anonymous> (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/validator/validator.js:81:18)\n    at async dispatch (/Users/user/code/kubeairunway/node_modules/.bun/hono@4.11.9/node_modules/hono/dist/compose.js:22:23)\n    at processTicksAndRejections (native:7:39)","msg":"Error: Failed to list storage disks: unable to verify the first certificate"}
│ {"level":"info","time":"2026-06-08T22:12:21.390Z","pid":38386,"hostname":"Users-MacBook-Pro.local","method":"GET","url":"http://localhost:3001/api/installation/gpu-capacity","msg":"GET /api/installation/gpu-capacity"}
│ {"level":"info","time":"2026-06-08T22:12:21.402Z","pid":38386,"hostname":"Users-MacBook-Pro.local","method":"GET","url":"http://localhost:3001/api/cluster/status","msg":"GET /api/cluster/status"}
│ {"level":"error","time":"2026-06-08T22:12:21.543Z","pid":38386,"hostname":"Users-MacBook-Pro.local","error":{"code":"UNABLE_TO_VERIFY_LEAF_SIGNATURE","path":"https://suraj-cluster.hcp.southcentralus.azmk8s.io/api/v1/nodes","errno":0},"msg":"Error getting cluster GPU capacity"}
│ {"level":"info","time":"2026-06-08T22:12:51.561Z","pid":38386,"hostname":"Users-MacBook-Pro.local","method":"GET","url":"http://localhost:3001/api/installation/gpu-capacity","msg":"GET /api/installation/gpu-capacity"}
│ {"level":"info","time":"2026-06-08T22:12:51.577Z","pid":38386,"hostname":"Users-MacBook-Pro.local","method":"GET","url":"http://localhost:3001/api/cluster/status","msg":"GET /api/cluster/status"}
│ {"level":"error","time":"2026-06-08T22:12:51.720Z","pid":38386,"hostname":"Users-MacBook-Pro.local","error":{"code":"UNABLE_TO_VERIFY_LEAF_SIGNATURE","path":"https://suraj-cluster.hcp.southcentralus.azmk8s.io/api/v1/nodes","errno":0},"msg":"Error getting cluster GPU capacity"}
```

Now go to <http://localhost:5173/> and you should see **Disconnected** state on the top right.

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/42a9aada-85e1-4833-b22d-7367294aee9f" />

Now with this PR's changes you should see a connected state:

```bash
gh pr checkout 319
bun install
bun run dev
```

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/3887a11b-b17f-4e5a-86e3-d23462637a15" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have run `bun run lint`
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings

## Additional Notes

- Scope is limited to backend client construction (`backend/src/`); no public API, CRD, or frontend changes. `package.json` and `bun.lock` are untouched.
- **`bun run lint` is not ticked** because it fails for a pre-existing, unrelated reason: ESLint v9+ requires a flat `eslint.config.js`, which is absent on this branch (the migration lives in a separate PR). It is not caused by these changes.
- Addresses the GitHub Copilot review comment requesting unit tests for `BunTlsHttpLibrary` / `makeApiClient`.
- **Known Bun limitations** (documented in code): kubeconfig `pfx` client certs and `cluster.proxy-url` are not honoured under Bun's `fetch`.
