### PR TITLE
security: block vLLM provider overrides to spec.template.spec

### DIFF
--- a/providers/vllm/transformer.go
+++ b/providers/vllm/transformer.go
@@ -864,8 +864,37 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		}
 	}
 
+	if hasNestedMapPath(overrides, "spec", "template", "spec") {
+		return fmt.Errorf("overriding %q is not allowed", "spec.template.spec")
+	}
+
 	obj.Object = deepMerge(obj.Object, overrides)
 	return nil
+}
+
+// hasNestedMapPath reports whether a nested map path exists in m.
+func hasNestedMapPath(m map[string]interface{}, path ...string) bool {
+	if len(path) == 0 {
+		return false
+	}
+
+	current := m
+	for i, key := range path {
+		value, exists := current[key]
+		if !exists {
+			return false
+		}
+		if i == len(path)-1 {
+			return true
+		}
+		next, ok := value.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		current = next
+	}
+
+	return false
 }
 
 // deepMerge recursively merges src into dst.

--- a/providers/vllm/transformer_test.go
+++ b/providers/vllm/transformer_test.go
@@ -912,6 +912,71 @@ func TestTransformOverrideBlocksMetadata(t *testing.T) {
 	}
 }
 
+func TestTransformOverrideBlocksPodSpec(t *testing.T) {
+	tr := NewTransformer()
+	md := newTestMD("test-model", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Overrides: &runtime.RawExtension{
+			Raw: []byte(`{"spec": {"template": {"spec": {"volumes": [{"name": "host", "hostPath": {"path": "/"}}]}}}}`),
+		},
+	}
+
+	_, err := tr.Transform(context.Background(), md)
+	if err == nil {
+		t.Fatal("expected error when overriding spec.template.spec")
+	}
+	if !strings.Contains(err.Error(), "spec.template.spec") {
+		t.Fatalf("expected error to mention spec.template.spec, got %v", err)
+	}
+}
+
+func TestHasNestedMapPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		path     []string
+		expected bool
+	}{
+		{
+			name: "path exists",
+			input: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			path:     []string{"spec", "template", "spec"},
+			expected: true,
+		},
+		{
+			name: "path missing",
+			input: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			},
+			path:     []string{"spec", "template", "spec"},
+			expected: false,
+		},
+		{
+			name: "path blocked by non-map",
+			input: map[string]interface{}{
+				"spec": "not-a-map",
+			},
+			path:     []string{"spec", "template", "spec"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasNestedMapPath(tt.input, tt.path...)
+			if result != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestBuildResourceLimits(t *testing.T) {
 	tr := NewTransformer()
 


### PR DESCRIPTION
### Motivation
- The vLLM transformer applied `spec.provider.overrides` after building a native `apps/v1` Deployment and only blocked top-level keys, which allowed attackers to replace `spec.template.spec` (containers, volumes, volumeMounts, initContainers) and escalate privileges via hostPath mounts.
- This change prevents a low-privileged ModelDeployment author from causing the controller to materialize an attacker-controlled pod spec using the provider escape hatch.

### Description
- Added a guard in `providers/vllm/transformer.go` to reject overrides that contain the nested path `spec.template.spec` before merging user overrides. 
- Implemented `hasNestedMapPath` in `providers/vllm/transformer.go` to detect nested override paths safely. 
- Added regression tests in `providers/vllm/transformer_test.go` which verify that a hostPath-style pod spec override is rejected and that `hasNestedMapPath` behaves correctly.
- Changes are limited to the vLLM provider transformer and its tests to preserve existing behavior for other providers.

### Testing
- Ran `go test -run 'TestTransform(OverrideBlocksPodSpec|AggregatedOverride)|TestHasNestedMapPath' -count=1 -v` in `providers/vllm`, and the targeted tests passed. 
- Ran `go test .` in `providers/vllm` and the package test suite passed. 
- Verified the new tests exercise rejection of `spec.template.spec` overrides and the nested-path detector, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a334bb25468832a83958b8bff4ab952)