### PR TITLE
docs: add maintainers page

### DIFF
--- a/.github/workflows/e2e-backend.yml
+++ b/.github/workflows/e2e-backend.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Load component versions
+        run: |
+          set -a
+          source versions.env
+          set +a
+          echo "KAITO_VERSION=${KAITO_VERSION}" >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -41,6 +48,7 @@ jobs:
           # If Gateway API Inference Extension CRDs are pre-installed (e.g. via kubectl apply),
           # add --skip-crds to avoid a field-manager conflict on InferencePool.
           helm install kaito-workspace kaito/workspace \
+            --version "$KAITO_VERSION" \
             --namespace kaito-workspace \
             --create-namespace \
             --set featureGates.disableNodeAutoProvisioning=true

--- a/.github/workflows/e2e-controller.yml
+++ b/.github/workflows/e2e-controller.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Load component versions
+        run: |
+          set -a
+          source versions.env
+          set +a
+          echo "KAITO_VERSION=${KAITO_VERSION}" >> "$GITHUB_ENV"
+
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -41,6 +48,7 @@ jobs:
           # If Gateway API Inference Extension CRDs are pre-installed (e.g. via kubectl apply),
           # add --skip-crds to avoid a field-manager conflict on InferencePool.
           helm install kaito-workspace kaito/workspace \
+            --version "$KAITO_VERSION" \
             --namespace kaito-workspace \
             --create-namespace \
             --set featureGates.disableNodeAutoProvisioning=true

--- a/.github/workflows/e2e-gateway.yml
+++ b/.github/workflows/e2e-gateway.yml
@@ -25,6 +25,7 @@ jobs:
           source versions.env
           set +a
           echo "GAIE_VERSION=${GAIE_VERSION}" >> "$GITHUB_ENV"
+          echo "KAITO_VERSION=${KAITO_VERSION}" >> "$GITHUB_ENV"
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -78,6 +79,7 @@ jobs:
           # If Gateway API Inference Extension CRDs are pre-installed (e.g. via kubectl apply),
           # add --skip-crds to avoid a field-manager conflict on InferencePool.
           helm install kaito-workspace kaito/workspace \
+            --version "$KAITO_VERSION" \
             --namespace kaito-workspace \
             --create-namespace \
             --set featureGates.disableNodeAutoProvisioning=true

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,45 @@
+# Overview
+
+This page provides contact information for the AIRunway maintainers and outlines
+their responsibilities.
+
+## Maintainers
+
+The following are current AIRunway maintainers:
+
+* Suraj Deshmukh @surajssd
+* Robbie Cronin @robert-cronin
+* Sertaç Özercan @sozercan
+
+## Maintainer Responsibilities
+
+Maintainers are active and visible members of the community. They have
+experience with the project and are expected to have the knowledge and
+insight to lead its growth, and below are their responsibilities.
+
+### Uphold Code of Conduct
+
+Uphold the values and behavior set forward by the
+[Code of Conduct](CODE_OF_CONDUCT.md) to ensure a safe and welcoming community.
+
+### Prioritize Security
+
+Prioritize reported security vulnerabilities and ensure that they are addressed
+in a timely manner. See AIRunway's [security policy](SECURITY.md).
+
+### Review Pull Requests
+
+Review pull requests regularly with comments, suggestions, decision to reject,
+merge or close them. Accept only high quality pull requests. Provide code
+reviews and guidance on incoming pull requests to adhere to established
+standards and best practices.
+
+### Triage Open Issues
+
+Review issues regularly to determine their priority and relevance, with proper
+labeling to identify milestones, blockers, complexity, etc.
+
+### Maintain Overall System Quality
+
+Maintain healthy test coverage and code quality report score. Avoid dependency
+bloat and mitigate breaking changes.


### PR DESCRIPTION
## Summary

- add a root `MAINTAINERS.md` modeled after the KAITO maintainers document
- list the current AIRunway maintainers with full names and GitHub aliases
- update project references and security-policy wording for AIRunway
- pin KAITO e2e installs to the repo's `KAITO_VERSION` to avoid external chart drift in CI

## Validation

- Verified `MAINTAINERS.md` contains AIRunway references and no stale KAITO references
- Verified referenced local files exist: `CODE_OF_CONDUCT.md`, `SECURITY.md`
- Checked for trailing whitespace and staged diff whitespace errors
- Parsed the touched workflow YAML files
- Rendered the pinned KAITO Helm chart (`KAITO_VERSION=0.10.0`) and verified it does not include the newer `--node-provisioner` flag that triggered the e2e failure
- Ran `make verify-versions`
- Ran `.agents/skills/autoreview/scripts/autoreview --mode local` with no accepted/actionable findings
