### PR TITLE
fix(test): stop huggingface.test reloading the shared module singleton

### DIFF
--- a/backend/TESTING.md
+++ b/backend/TESTING.md
@@ -122,6 +122,41 @@ test('multi-step flow', async () => {
 });
 ```
 
+## Gotchas
+
+### Never `delete require.cache` on a shared-singleton service module
+
+Do **not** reset test state by reloading a service module, e.g.:
+
+```typescript
+// ❌ Don't do this — forks the shared singleton.
+delete require.cache[require.resolve('./huggingface')];
+const { huggingFaceService } = await import('./huggingface');
+```
+
+Services are exported as singletons (`export const fooService = new FooService()`).
+Other modules — including route handlers — capture that instance at import time.
+Reloading the module installs a *different* instance in the registry, so a test
+mocking the reloaded copy patches an object the route never calls. Because test
+files run in a shared worker and their order isn't deterministic, this surfaces
+as an order-dependent, CI-only flake (see PR #358).
+
+Instead, reset internal state through an explicit test-only method on the
+singleton and keep a single static import:
+
+```typescript
+// ✅ Static import + explicit state reset.
+import { huggingFaceService } from './huggingface';
+
+beforeEach(() => {
+  huggingFaceService.clearArchitectureCacheForTests();
+});
+```
+
+Note that services reading `global.fetch` at call time only need the global
+mocked (via `mockFetch` / `mockFetchByUrl`) — no module reload is required to
+intercept their network calls.
+
 ## Test Helpers
 
 Located in `src/test/helpers.ts`:

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, afterEach } from 'bun:test';
 import { PINNED_GAIE_VERSION } from '@airunway/shared';
 import app from '../hono-app';
 import { kubernetesService } from '../services/kubernetes';
@@ -982,41 +982,9 @@ describe('Installation Provider Routes', () => {
 describe('Gateway Installation Routes', () => {
   const restores: Array<() => void> = [];
 
-  // Deterministic mock guard for the gpu-throughput suite.
-  //
-  // Those route tests each stub huggingFaceService.getModelArchitecture on the
-  // shared singleton. When that stub is not in effect at request time, the
-  // route falls through to the REAL implementation, which fetches config.json
-  // from HuggingFace. Crucially, getModelArchitecture swallows every fetch
-  // error and returns `undefined`, so the route silently degrades — dropping
-  // arch-derived fields (doesNotFit / aggregateTokensPerSec) and defaulting
-  // contextLen — and the assertion fails with a confusing value rather than
-  // pointing at the missing mock. Because it depends on real network behaviour,
-  // it fails only intermittently in CI (the observed flake) while passing
-  // locally. A fetch-level guard can't catch this — the service swallows the
-  // throw — so instead we install a throwing default for the method itself.
-  // Every gpu-throughput test overrides it with its own mock (applied after
-  // this beforeEach); any test that fails to do so now fails loudly and
-  // identically everywhere instead of flaking.
-  const realGetModelArchitecture = huggingFaceService.getModelArchitecture;
-  beforeEach(() => {
-    (huggingFaceService as unknown as Record<string, unknown>).getModelArchitecture = async (
-      modelId: string,
-    ) => {
-      throw new Error(
-        `getModelArchitecture called without a test mock (modelId=${modelId}). ` +
-          'Stub it via mockServiceMethod(huggingFaceService, ...) in the test.',
-      );
-    };
-  });
-
   afterEach(() => {
     restores.forEach((r) => r());
     restores.length = 0;
-    // Restore the real method last, after any mockServiceMethod restores (which
-    // would otherwise reinstate the throwing default captured as their original).
-    (huggingFaceService as unknown as Record<string, unknown>).getModelArchitecture =
-      realGetModelArchitecture;
   });
 
 

--- a/backend/src/routes/installation.test.ts
+++ b/backend/src/routes/installation.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { PINNED_GAIE_VERSION } from '@airunway/shared';
 import app from '../hono-app';
 import { kubernetesService } from '../services/kubernetes';
@@ -982,9 +982,41 @@ describe('Installation Provider Routes', () => {
 describe('Gateway Installation Routes', () => {
   const restores: Array<() => void> = [];
 
+  // Deterministic mock guard for the gpu-throughput suite.
+  //
+  // Those route tests each stub huggingFaceService.getModelArchitecture on the
+  // shared singleton. When that stub is not in effect at request time, the
+  // route falls through to the REAL implementation, which fetches config.json
+  // from HuggingFace. Crucially, getModelArchitecture swallows every fetch
+  // error and returns `undefined`, so the route silently degrades — dropping
+  // arch-derived fields (doesNotFit / aggregateTokensPerSec) and defaulting
+  // contextLen — and the assertion fails with a confusing value rather than
+  // pointing at the missing mock. Because it depends on real network behaviour,
+  // it fails only intermittently in CI (the observed flake) while passing
+  // locally. A fetch-level guard can't catch this — the service swallows the
+  // throw — so instead we install a throwing default for the method itself.
+  // Every gpu-throughput test overrides it with its own mock (applied after
+  // this beforeEach); any test that fails to do so now fails loudly and
+  // identically everywhere instead of flaking.
+  const realGetModelArchitecture = huggingFaceService.getModelArchitecture;
+  beforeEach(() => {
+    (huggingFaceService as unknown as Record<string, unknown>).getModelArchitecture = async (
+      modelId: string,
+    ) => {
+      throw new Error(
+        `getModelArchitecture called without a test mock (modelId=${modelId}). ` +
+          'Stub it via mockServiceMethod(huggingFaceService, ...) in the test.',
+      );
+    };
+  });
+
   afterEach(() => {
     restores.forEach((r) => r());
     restores.length = 0;
+    // Restore the real method last, after any mockServiceMethod restores (which
+    // would otherwise reinstate the throwing default captured as their original).
+    (huggingFaceService as unknown as Record<string, unknown>).getModelArchitecture =
+      realGetModelArchitecture;
   });
 
 

--- a/backend/src/services/huggingface.test.ts
+++ b/backend/src/services/huggingface.test.ts
@@ -1,23 +1,26 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { isValidHfRepoId, encodeHfRepoPath } from './huggingface';
+import { huggingFaceService, isValidHfRepoId, encodeHfRepoPath } from './huggingface';
 
 // Store original fetch
 const originalFetch = global.fetch;
 
 describe('HuggingFaceService', () => {
   let mockFetch: ReturnType<typeof mock>;
-  let huggingFaceService: typeof import('./huggingface').huggingFaceService;
 
-  beforeEach(async () => {
-    // Create mock fetch
+  beforeEach(() => {
+    // Create mock fetch. The service reads global.fetch at call time, so
+    // swapping it here is enough — no need to reload the module. Reloading
+    // (delete require.cache + re-import) would replace the shared singleton in
+    // the module registry and break other test files that captured the
+    // original instance at import time (e.g. the installation route), which is
+    // a nondeterministic, order-dependent, CI-only flake.
     mockFetch = mock(() => Promise.resolve(new Response()));
     // @ts-expect-error - Mocking global fetch for testing
     global.fetch = mockFetch;
 
-    // Clear module cache and re-import
-    delete require.cache[require.resolve('./huggingface')];
-    const module = await import('./huggingface');
-    huggingFaceService = module.huggingFaceService;
+    // Reset the module-level architecture cache so cache-behaviour tests start
+    // clean. (Previously a full module reload gave each test a fresh cache.)
+    huggingFaceService.clearArchitectureCacheForTests();
   });
 
   afterEach(() => {

--- a/backend/src/services/huggingface.test.ts
+++ b/backend/src/services/huggingface.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, mock, beforeEach, afterEach, afterAll } from 'bun:test';
 import { huggingFaceService, isValidHfRepoId, encodeHfRepoPath } from './huggingface';
 
 // Store original fetch
@@ -25,6 +25,15 @@ describe('HuggingFaceService', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    // The architecture cache is module-level and now shared across the whole
+    // process lifetime (this suite is the only one that populates it with real
+    // config bodies). Clear it on the way out so no warm entry from these tests
+    // — notably the 500 entries the LRU test inserts — can bleed into a later
+    // test file that happens to call the real getModelArchitecture.
+    huggingFaceService.clearArchitectureCacheForTests();
   });
 
   describe('getClientId', () => {
@@ -481,6 +490,23 @@ describe('HuggingFaceService', () => {
       expect(mockFetch).toHaveBeenCalledTimes(CAP + 2);
     });
 
+    test('clearArchitectureCacheForTests drops cached entries so the next call re-fetches', async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(configJson, { status: 200 }))
+      );
+
+      // First call populates the cache; second is served from it (no re-fetch).
+      await huggingFaceService.getModelArchitecture('org/model');
+      await huggingFaceService.getModelArchitecture('org/model');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Clearing the cache must force the next call to hit the network again.
+      // Other suites rely on this in beforeEach to guarantee a clean cache.
+      huggingFaceService.clearArchitectureCacheForTests();
+      await huggingFaceService.getModelArchitecture('org/model');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     test('returns undefined on a non-ok response', async () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve(new Response('not found', { status: 404 }))
@@ -576,5 +602,18 @@ describe('HuggingFaceService', () => {
       expect(encodeHfRepoPath('owner/name')).toBe('owner/name');
       expect(encodeHfRepoPath('gpt2')).toBe('gpt2');
     });
+  });
+});
+
+describe('huggingFaceService singleton identity', () => {
+  // Regression guard for the order-dependent CI flake this file once caused:
+  // a `delete require.cache[...]` + re-import here forked the shared singleton,
+  // so other modules (e.g. the installation route) held a different instance
+  // than the tests mocked. Re-importing the module must return the SAME
+  // instance the static import captured; if this ever fails, something has
+  // reintroduced module reloading / a duplicate registry entry.
+  test('re-importing the module yields the same instance', async () => {
+    const reimported = await import('./huggingface');
+    expect(reimported.huggingFaceService).toBe(huggingFaceService);
   });
 });

--- a/backend/src/services/huggingface.ts
+++ b/backend/src/services/huggingface.ts
@@ -497,6 +497,16 @@ class HuggingFaceService {
     }
     return arch;
   }
+
+  /**
+   * Clear the in-memory model-architecture cache. Intended for tests, which
+   * need a clean cache between cases without reloading the module (reloading
+   * would replace this shared singleton and break other suites that captured
+   * the original instance at import time).
+   */
+  clearArchitectureCacheForTests(): void {
+    architectureCache.clear();
+  }
 }
 
 // Export singleton instance


### PR DESCRIPTION
## Description

Fixes an order-dependent, CI-only test flake in the backend. The `GET /api/installation/gpu-throughput` route tests failed intermittently in CI (but passed locally) because `huggingFaceService.getModelArchitecture` was not the mocked instance at request time — the route fell through to a real HuggingFace `config.json` fetch, and since that method swallows fetch errors and returns `undefined`, the response silently degraded (dropping `doesNotFit` / `aggregateTokensPerSec`, defaulting `contextLen`).

Root cause: `huggingface.test.ts` reset state between cases by deleting the module from `require.cache` and re-importing it, which replaced the shared `huggingFaceService` singleton in the module registry. Any module that captured the original instance at import time (notably the `installation` route via `installation.ts`) then pointed at a different instance than the one the tests mocked. Because it depends on test-file execution order, it surfaced only in CI.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Changes Made

- **Root-cause fix** (`backend/src/services/huggingface.test.ts`): use the statically-imported `huggingFaceService` singleton and drop the `require.cache` delete + dynamic `import()` reload. The service reads `global.fetch` at call time, so mocking `global.fetch` in `beforeEach` is sufficient to isolate tests.
- **Test-support helper** (`backend/src/services/huggingface.ts`): add `clearArchitectureCacheForTests()` so the module-level `architectureCache` can be reset between cases without reloading the module (preserving the cache-TTL / LRU-eviction test behaviour that previously relied on a fresh module).
- **Review follow-ups** (`backend/src/services/huggingface.test.ts`):
  - Add a test locking the `clearArchitectureCacheForTests()` contract (populate → cache hit → clear → re-fetch expects 2 fetches).
  - Clear `architectureCache` in `afterAll` so warm entries from this suite (notably the 500 the LRU test inserts) can't bleed into a later test file that calls the real `getModelArchitecture`.
  - Add a singleton-identity regression test asserting a re-import returns the same instance, guarding against reintroducing the module reload.
- **Docs** (`backend/TESTING.md`): add a "never `delete require.cache` on a shared-singleton service module" gotcha, with the correct `*ForTests` reset pattern.
- Note: an earlier method-level guard in `backend/src/routes/installation.test.ts` targeted the wrong instance and never fired in CI; it was reverted, so that file nets to no change vs `main`.

## Testing

- [x] Unit tests pass (`bun run test`)
- [ ] Manual testing performed
- [ ] Tested with a Kubernetes cluster

Full backend suite: **874 pass / 0 fail** (+2 new tests). Verified stable across both test-file orderings and repeated runs. `bunx eslint` clean on all changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `bun run lint`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Additional Notes

The red CI runs were on intermediate Dependabot commits (Docker action version bumps); current `main` HEAD is green. No production request-handling behaviour changed — the only production-code addition is a test-support helper (`clearArchitectureCacheForTests()`); the fix is entirely about test isolation.

**On the fail-loud guard (reviewer thread):** an earlier revision added a throwing `beforeEach` guard so a missing arch mock would fail loudly. That was deliberately dropped in favour of the root-cause singleton fix. The residual "silent degradation if a future test omits its stub" risk is now mitigated structurally by the restored singleton identity (regression-tested) plus the `TESTING.md` convention, rather than by a per-suite guard.

The branch has three commits (`522a825`, `0219089`, `6cf4161`); on squash-merge the combined diff is just the three files above.
