### PR TITLE
ci: use ubuntu-latest for e2e jobs

### DIFF
--- a/.github/workflows/e2e-backend.yml
+++ b/.github/workflows/e2e-backend.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   e2e-backend:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/e2e-controller.yml
+++ b/.github/workflows/e2e-controller.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   e2e-controller:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e-dynamo-mocker.yml
+++ b/.github/workflows/e2e-dynamo-mocker.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   e2e-dynamo-mocker:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/e2e-gateway.yml
+++ b/.github/workflows/e2e-gateway.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   e2e-gateway:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 45
 
     steps:

--- a/controller/test/e2e/testdata/cpu-modeldeployment.yaml
+++ b/controller/test/e2e/testdata/cpu-modeldeployment.yaml
@@ -6,5 +6,5 @@ spec:
   model:
     source: custom
   resources:
-    cpu: "4"
+    cpu: "1"
   image: "ghcr.io/kaito-project/aikit/llama3.2:1b"

--- a/controller/test/e2e/testdata/gateway-modeldeployment.yaml
+++ b/controller/test/e2e/testdata/gateway-modeldeployment.yaml
@@ -6,7 +6,7 @@ spec:
   model:
     source: custom
   resources:
-    cpu: "4"
+    cpu: "1"
   image: "ghcr.io/kaito-project/aikit/llama3.2:1b"
   gateway:
     enabled: true


### PR DESCRIPTION
Switch the e2e workflows from the ubuntu-latest-16-cores custom runner to the standard ubuntu-latest runner.