### PR TITLE
fix(gateway): stop restarting shared BBR on each new ModelDeployment

### DIFF
--- a/controller/api/v1alpha1/modeldeployment_types.go
+++ b/controller/api/v1alpha1/modeldeployment_types.go
@@ -720,7 +720,6 @@ const (
 
 const (
 	HTTPRouteCreated     = "airunway.ai/httproute-created"
-	BBRRestarted         = "airunway.ai/bbr-restarted"
 	LabelModelDeployment = "airunway.ai/model-deployment"
 	LabelManagedBy       = "airunway.ai/managed-by"
 	LabelJobType         = "airunway.ai/job-type"

--- a/controller/internal/controller/gateway_reconciler.go
+++ b/controller/internal/controller/gateway_reconciler.go
@@ -33,11 +33,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
@@ -129,7 +127,7 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 
 	// Use provider managed inference pool if it exists,
 	// otherwise use the default inference pool.
-	if ok, err := r.providerInferencePoolExistsOrCreateDefault(ctx, md, gatewayCapabilities, gwConfig); ok && err == nil {
+	if ok, err := r.providerInferencePoolExistsOrCreateDefault(ctx, md, gatewayCapabilities); ok && err == nil {
 		logger.Info("Skipping InferencePool creation, provider manages InferencePool", "provider", resolvedProviderName(md))
 
 		// Resolve the InferencePool name for the provider.
@@ -138,7 +136,7 @@ func (r *ModelDeploymentReconciler) reconcileGateway(ctx context.Context, md *ai
 		poolNamespace = resolveProviderPoolField(gatewayCapabilities.InferencePoolNamespace, md.Name, md.Namespace, md.Namespace)
 
 		// Use provider-managed InferencePool
-		providerEPPName, err := r.reconcileProviderManagedInferencePool(ctx, md, poolName, poolNamespace, gwConfig.GetBBRNamespace())
+		providerEPPName, err := r.reconcileProviderManagedInferencePool(ctx, md, poolName, poolNamespace)
 		if err != nil {
 			logger.Info("Error reconciling provider-managed InferencePool", "error", err)
 			return err
@@ -239,21 +237,16 @@ func (r *ModelDeploymentReconciler) resolveGatewayConfig(ctx context.Context) (*
 	}
 }
 
-// gatewayConfigFromResource builds a GatewayConfig from a Gateway resource,
-// reading the optional airunway.ai/bbr-namespace annotation.
+// gatewayConfigFromResource builds a GatewayConfig from a Gateway resource.
 func gatewayConfigFromResource(gw *gatewayv1.Gateway) *gateway.GatewayConfig {
-	cfg := &gateway.GatewayConfig{
+	return &gateway.GatewayConfig{
 		GatewayName:      gw.Name,
 		GatewayNamespace: gw.Namespace,
 	}
-	if gw.Annotations != nil {
-		cfg.BBRNamespace = gw.Annotations[gateway.AnnotationBBRNamespace]
-	}
-	return cfg
 }
 
 // reconcileInferencePool creates or updates the InferencePool for a ModelDeployment.
-func (r *ModelDeploymentReconciler) reconcileInferencePool(ctx context.Context, md *airunwayv1alpha1.ModelDeployment, port int32, bbrNamespace string) error {
+func (r *ModelDeploymentReconciler) reconcileInferencePool(ctx context.Context, md *airunwayv1alpha1.ModelDeployment, port int32) error {
 	pool := &inferencev1.InferencePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      md.Name,
@@ -288,19 +281,11 @@ func (r *ModelDeploymentReconciler) reconcileInferencePool(ctx context.Context, 
 
 	log.FromContext(ctx).V(1).Info("InferencePool reconciled", "name", pool.Name, "result", result)
 
-	// When a new InferencePool is created, restart the BBR deployment (if present) so it
-	// discovers the new model. BBR watches ConfigMaps via controller-runtime and rebuilds
-	// its internal model registry on startup.
-	if result == controllerutil.OperationResultCreated {
-		if err := r.restartBBRIfPresent(ctx, bbrNamespace); err != nil {
-			log.FromContext(ctx).Info("Could not restart BBR deployment (non-fatal)", "error", err)
-		}
-	}
 	return nil
 }
 
 func (r *ModelDeploymentReconciler) reconcileProviderManagedInferencePool(ctx context.Context,
-	md *airunwayv1alpha1.ModelDeployment, poolName, poolNamespace, bbrNamespace string,
+	md *airunwayv1alpha1.ModelDeployment, poolName, poolNamespace string,
 ) (string, error) {
 	logger := log.FromContext(ctx)
 	mdNamespace := md.Namespace
@@ -320,27 +305,6 @@ func (r *ModelDeploymentReconciler) reconcileProviderManagedInferencePool(ctx co
 	}
 
 	logger.V(1).Info("Found provider-managed InferencePool", "pool", poolKey)
-
-	// BBR builds its internal model registry from HTTPRoute headers at startup and
-	// needs a rolling restart whenever a new model is added. For default (airunway-
-	// managed) pools, reconcileInferencePool handles this when CreateOrUpdate reports
-	// Created. Provider-managed pools are created by the provider's operator, so
-	// there's no Created signal. This is gated on a one-shot annotation instead,
-	// restart BBR exactly once per ModelDeployment, not on every reconcile.
-	if md.Annotations[airunwayv1alpha1.BBRRestarted] != "true" {
-		if err := r.restartBBRIfPresent(ctx, bbrNamespace); err != nil {
-			logger.Info("Could not restart BBR deployment (non-fatal)", "error", err)
-		} else {
-			mdBase := md.DeepCopy()
-			if md.Annotations == nil {
-				md.Annotations = map[string]string{}
-			}
-			md.Annotations[airunwayv1alpha1.BBRRestarted] = "true"
-			if patchErr := r.Patch(ctx, md, client.MergeFrom(mdBase)); patchErr != nil {
-				logger.V(1).Info("Could not annotate ModelDeployment after BBR restart", "error", patchErr)
-			}
-		}
-	}
 
 	// Use it as HTTPRoute backend ref (cross-namespace ref + ReferenceGrant).
 	// Create ReferenceGrant in the inference pool namespace.
@@ -1346,7 +1310,7 @@ func (r *ModelDeploymentReconciler) cleanupGatewayResources(ctx context.Context,
 	return nil
 }
 
-func (r *ModelDeploymentReconciler) providerInferencePoolExistsOrCreateDefault(ctx context.Context, md *airunwayv1alpha1.ModelDeployment, gatewayCapabilitities *airunwayv1alpha1.GatewayCapabilities, gwConfig *gateway.GatewayConfig) (bool, error) {
+func (r *ModelDeploymentReconciler) providerInferencePoolExistsOrCreateDefault(ctx context.Context, md *airunwayv1alpha1.ModelDeployment, gatewayCapabilitities *airunwayv1alpha1.GatewayCapabilities) (bool, error) {
 	logger := log.FromContext(ctx)
 
 	// Only treat the pool as provider-managed when the provider has explicitly
@@ -1376,7 +1340,7 @@ func (r *ModelDeploymentReconciler) providerInferencePoolExistsOrCreateDefault(c
 	}
 
 	// Create or update InferencePool
-	if err := r.reconcileInferencePool(ctx, md, port, gwConfig.GetBBRNamespace()); err != nil {
+	if err := r.reconcileInferencePool(ctx, md, port); err != nil {
 		r.setCondition(md, airunwayv1alpha1.ConditionTypeGatewayReady, metav1.ConditionFalse, "InferencePoolFailed", err.Error())
 		return false, fmt.Errorf("reconciling InferencePool: %w", err)
 	}
@@ -1493,24 +1457,4 @@ func (r *ModelDeploymentReconciler) cleanupGatewayAllowedRoutesForNamespace(ctx 
 	if changed {
 		logger.Info("Removed namespace from Gateway allowedRoutes after MD deletion", "gateway", gwConfig.GatewayName, "namespace", namespace)
 	}
-}
-
-// restartBBRIfPresent triggers a rolling restart of the body-based-router Deployment (if present
-// in the given namespace) by updating its restart annotation. This is necessary because BBR builds
-// its internal model registry on startup and does not dynamically watch InferencePools.
-//
-// The namespace is resolved by GatewayConfig.GetBBRNamespace(), which reads the
-// airunway.ai/bbr-namespace annotation from the Gateway resource, falling back to the
-// Gateway's own namespace.
-func (r *ModelDeploymentReconciler) restartBBRIfPresent(ctx context.Context, namespace string) error {
-	var bbr appsv1.Deployment
-	if err := r.Get(ctx, client.ObjectKey{Name: "body-based-router", Namespace: namespace}, &bbr); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-	patch := []byte(`{"spec":{"template":{"metadata":{"annotations":{"airunway.ai/restartedAt":"` + time.Now().UTC().Format(time.RFC3339) + `"}}}}}`)
-	if err := r.Patch(ctx, &bbr, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
-		return fmt.Errorf("patching body-based-router: %w", err)
-	}
-	log.FromContext(ctx).Info("Triggered BBR rolling restart to discover new InferencePool", "namespace", namespace)
-	return nil
 }

--- a/controller/internal/controller/gateway_reconciler_test.go
+++ b/controller/internal/controller/gateway_reconciler_test.go
@@ -128,6 +128,42 @@ func newTestGateway(name, ns string) *gatewayv1.Gateway {
 	}
 }
 
+// newBBRDeployment returns a stand-in for the shared body-based-router
+// Deployment installed by the upstream GAIE helm chart. It carries an unrelated
+// pod-template annotation so a wholesale rewrite is detectable, not just the
+// restart annotation itself.
+func newBBRDeployment(ns string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "body-based-router", Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"unrelated": "keep-me"},
+				},
+			},
+		},
+	}
+}
+
+// assertBBRNotRestarted fails if anything rolled the shared BBR Deployment.
+// The controller used to patch airunway.ai/restartedAt onto its pod template to
+// force a restart; nothing should write to that Deployment at all now.
+func assertBBRNotRestarted(t *testing.T, r *ModelDeploymentReconciler, ns string) {
+	t.Helper()
+	var bbr appsv1.Deployment
+	key := types.NamespacedName{Name: "body-based-router", Namespace: ns}
+	if err := r.Get(context.Background(), key, &bbr); err != nil {
+		t.Fatalf("body-based-router Deployment not found: %v", err)
+	}
+	if _, found := bbr.Spec.Template.Annotations["airunway.ai/restartedAt"]; found {
+		t.Errorf("BBR was restarted: pod template carries airunway.ai/restartedAt (%v)",
+			bbr.Spec.Template.Annotations)
+	}
+	if got := bbr.Spec.Template.Annotations["unrelated"]; got != "keep-me" {
+		t.Errorf("BBR pod template annotations were rewritten: %v", bbr.Spec.Template.Annotations)
+	}
+}
+
 // --- Tests ---
 
 func TestGateway_InferencePoolCreation(t *testing.T) {
@@ -137,7 +173,7 @@ func TestGateway_InferencePoolCreation(t *testing.T) {
 	r := newTestReconciler(scheme, detector, md)
 	ctx := context.Background()
 
-	err := r.reconcileInferencePool(ctx, md, 8080, "gateway-ns")
+	err := r.reconcileInferencePool(ctx, md, 8080)
 	if err != nil {
 		t.Fatalf("reconcileInferencePool failed: %v", err)
 	}
@@ -186,6 +222,78 @@ func TestGateway_InferencePoolCreation(t *testing.T) {
 	}
 }
 
+// TestGateway_InferencePoolCreationDoesNotRestartBBR is a regression guard for
+// #334. Creating an InferencePool used to force a rolling restart of the shared
+// body-based-router Deployment, on the mistaken premise that BBR builds a model
+// registry at startup. It does not — its body-field-to-header plugin sets the
+// model header per request, and its ServiceAccount is only granted read access
+// to ConfigMaps — so the restart bought nothing while opening a window in which
+// an already-serving model could mis-route. Nothing should touch BBR now.
+func TestGateway_InferencePoolCreationDoesNotRestartBBR(t *testing.T) {
+	scheme := newTestScheme()
+	md := newModelDeployment("test-model", "default")
+	// The removed code resolved BBR's namespace from the Gateway, so seed the
+	// Deployment where a restart would have gone looking for it.
+	bbr := newBBRDeployment("gateway-ns")
+	detector := fakeDetector(true, "my-gateway", "gateway-ns")
+	r := newTestReconciler(scheme, detector, md, bbr)
+	ctx := context.Background()
+
+	if err := r.reconcileInferencePool(ctx, md, 8080); err != nil {
+		t.Fatalf("reconcileInferencePool failed: %v", err)
+	}
+
+	// Confirm the pool was actually created, otherwise the restart path never
+	// ran and this test would pass vacuously.
+	var pool inferencev1.InferencePool
+	if err := r.Get(ctx, types.NamespacedName{Name: "test-model", Namespace: "default"}, &pool); err != nil {
+		t.Fatalf("InferencePool not created, so this test proves nothing: %v", err)
+	}
+
+	assertBBRNotRestarted(t, r, "gateway-ns")
+}
+
+// TestGateway_ProviderManagedPoolDoesNotRestartBBR covers the second removed
+// call site (#334). Provider-managed pools are created by the provider's own
+// operator, so there is no "created" signal; the restart was gated on a
+// one-shot airunway.ai/bbr-restarted annotation written back to the
+// ModelDeployment instead. Neither the restart nor that annotation should
+// happen now.
+func TestGateway_ProviderManagedPoolDoesNotRestartBBR(t *testing.T) {
+	scheme := newTestScheme()
+	md := newModelDeployment("test-model", "default")
+	bbr := newBBRDeployment("gateway-ns")
+	pool := &inferencev1.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "provider-pool", Namespace: "default"},
+		Spec: inferencev1.InferencePoolSpec{
+			EndpointPickerRef: inferencev1.EndpointPickerRef{
+				Name: inferencev1.ObjectName("provider-pool-epp"),
+			},
+		},
+	}
+	detector := fakeDetector(true, "my-gateway", "gateway-ns")
+	r := newTestReconciler(scheme, detector, md, bbr, pool)
+	ctx := context.Background()
+
+	eppName, err := r.reconcileProviderManagedInferencePool(ctx, md, "provider-pool", "default")
+	if err != nil {
+		t.Fatalf("reconcileProviderManagedInferencePool failed: %v", err)
+	}
+	if eppName != "provider-pool-epp" {
+		t.Errorf("expected EPP name %q, got %q", "provider-pool-epp", eppName)
+	}
+
+	assertBBRNotRestarted(t, r, "gateway-ns")
+
+	var got airunwayv1alpha1.ModelDeployment
+	if err := r.Get(ctx, types.NamespacedName{Name: "test-model", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("ModelDeployment not found: %v", err)
+	}
+	if _, found := got.Annotations["airunway.ai/bbr-restarted"]; found {
+		t.Error("ModelDeployment carries the removed airunway.ai/bbr-restarted annotation")
+	}
+}
+
 func TestGateway_InferencePoolDefaultPort(t *testing.T) {
 	scheme := newTestScheme()
 	md := newModelDeployment("test-model", "default")
@@ -195,7 +303,7 @@ func TestGateway_InferencePoolDefaultPort(t *testing.T) {
 	ctx := context.Background()
 
 	// reconcileGateway uses default port 8000 when no endpoint
-	err := r.reconcileInferencePool(ctx, md, 8000, "gateway-ns")
+	err := r.reconcileInferencePool(ctx, md, 8000)
 	if err != nil {
 		t.Fatalf("reconcileInferencePool failed: %v", err)
 	}
@@ -917,7 +1025,7 @@ func TestGateway_ProviderManagedInferencePool_Found(t *testing.T) {
 
 	r := newTestReconciler(scheme, nil, md, pool)
 
-	_, err := r.reconcileProviderManagedInferencePool(context.Background(), md, "default-llama-70b-pool", "dynamo-system", "default")
+	_, err := r.reconcileProviderManagedInferencePool(context.Background(), md, "default-llama-70b-pool", "dynamo-system")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -929,7 +1037,7 @@ func TestGateway_ProviderManagedInferencePool_NotFound(t *testing.T) {
 	md := newModelDeployment("llama-70b", "default")
 	r := newTestReconciler(scheme, nil, md)
 
-	_, err := r.reconcileProviderManagedInferencePool(context.Background(), md, "default-llama-70b-pool", "dynamo-system", "default")
+	_, err := r.reconcileProviderManagedInferencePool(context.Background(), md, "default-llama-70b-pool", "dynamo-system")
 	if err == nil {
 		t.Fatal("expected error when InferencePool does not exist")
 	}

--- a/controller/internal/gateway/detection.go
+++ b/controller/internal/gateway/detection.go
@@ -35,11 +35,6 @@ const (
 
 	// LabelInferenceGateway is the label to identify the inference gateway
 	LabelInferenceGateway = "airunway.ai/inference-gateway"
-
-	// AnnotationBBRNamespace is the annotation on the Gateway resource that specifies which
-	// namespace the body-based-router (BBR) deployment lives in. If not set, the controller
-	// assumes the BBR is in the same namespace as the Gateway.
-	AnnotationBBRNamespace = "airunway.ai/bbr-namespace"
 )
 
 // DefaultGAIEVersion is the default Gateway API Inference Extension version.
@@ -62,20 +57,6 @@ type GatewayConfig struct {
 	GatewayName string
 	// GatewayNamespace is the namespace of the Gateway resource
 	GatewayNamespace string
-	// BBRNamespace is the namespace where the body-based-router deployment lives.
-	// Resolved from the airunway.ai/bbr-namespace annotation on the Gateway resource.
-	// If empty, callers should fall back to GatewayNamespace.
-	BBRNamespace string
-}
-
-// GetBBRNamespace returns the namespace where the BBR deployment is expected.
-// Returns BBRNamespace if set (from the Gateway annotation), otherwise falls back
-// to GatewayNamespace.
-func (c *GatewayConfig) GetBBRNamespace() string {
-	if c.BBRNamespace != "" {
-		return c.BBRNamespace
-	}
-	return c.GatewayNamespace
 }
 
 // Detector checks for Gateway API CRD availability in the cluster

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -215,13 +215,15 @@ See the [upstream multi-model guide](https://gateway-api-inference-extension.sig
 > [!NOTE]
 > **Adding a model needs no BBR restart.** BBR holds no model registry. On every
 > request its `body-field-to-header` plugin reads the `model` field from the body
-> and sets `X-Gateway-Model-Name` unconditionally — it never looks up HTTPRoutes
-> or InferencePools, and its ServiceAccount is only granted `get`/`list`/`watch`
-> on ConfigMaps, so it cannot read them. The one piece of state it does cache is
-> the optional LoRA adapter → base-model map, kept current by a live watch on
-> ConfigMaps labelled `inference.networking.k8s.io/bbr-managed`. A new
-> `ModelDeployment` therefore starts routing as soon as the Gateway admits the
-> HTTPRoute for its model name.
+> and copies it into `X-Gateway-Model-Name`; when that field is missing or empty
+> it records a metric, skips the header, and lets the request through without it.
+> Either way the decision is made from the request body alone — BBR never looks
+> up HTTPRoutes or InferencePools, and its ServiceAccount is only granted
+> `get`/`list`/`watch` on ConfigMaps, so it cannot read them. The one piece of
+> state it does cache is the optional LoRA adapter → base-model map, kept current
+> by a live watch on ConfigMaps labelled
+> `inference.networking.k8s.io/bbr-managed`. A new `ModelDeployment` therefore
+> starts routing as soon as the Gateway admits the HTTPRoute for its model name.
 >
 > Earlier releases rolled the shared BBR Deployment once per new
 > `ModelDeployment` on the mistaken premise that it built a registry at startup.

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -212,19 +212,25 @@ Replace `provider.name` with your gateway implementation (`istio`, `gke`, or omi
 
 See the [upstream multi-model guide](https://gateway-api-inference-extension.sigs.k8s.io/guides/serving-multiple-inference-pools-latest/) for full details.
 
-> **Known limitation — BBR restart on each new model.** BBR builds its model
-> registry only at startup and does not dynamically watch InferencePools, so the
-> controller triggers a rolling restart of the shared BBR Deployment once per new
-> `ModelDeployment` (tracked by the `airunway.ai/bbr-restarted` annotation). The
-> restart is **not zero-downtime**: while BBR is restarting, its registry is
-> incomplete, so an in-flight request for an *already-serving* model can miss its
-> `X-Gateway-Model-Name` header and mis-route to another model's InferencePool.
-> With disaggregated Dynamo serving this surfaces as a `Worker ID required
-> (--direct-route)` 500 on a concurrent aggregated request. This mainly affects
-> deploying multiple models close together; once all models are settled, routing
-> is correct and stable. A zero-downtime BBR reload (or a BBR that watches
-> InferencePools) would remove the window. The GPU e2e suite leaves
-> disaggregated serving out of its default matrix for this reason.
+> [!NOTE]
+> **Adding a model needs no BBR restart.** BBR holds no model registry. On every
+> request its `body-field-to-header` plugin reads the `model` field from the body
+> and sets `X-Gateway-Model-Name` unconditionally — it never looks up HTTPRoutes
+> or InferencePools, and its ServiceAccount is only granted `get`/`list`/`watch`
+> on ConfigMaps, so it cannot read them. The one piece of state it does cache is
+> the optional LoRA adapter → base-model map, kept current by a live watch on
+> ConfigMaps labelled `inference.networking.k8s.io/bbr-managed`. A new
+> `ModelDeployment` therefore starts routing as soon as the Gateway admits the
+> HTTPRoute for its model name.
+>
+> Earlier releases rolled the shared BBR Deployment once per new
+> `ModelDeployment` on the mistaken premise that it built a registry at startup.
+> That restart was never load-bearing and opened a window in which a request for
+> an already-serving model could mis-route to another model's InferencePool
+> ([#334](https://github.com/ai-runway/airunway/issues/334)); it has been
+> removed. ModelDeployments created by an older controller may still carry an
+> inert `airunway.ai/bbr-restarted` annotation, which nothing reads and which is
+> safe to leave in place.
 
 ### Auto-detection with Multiple Gateways
 

--- a/test/e2e/gpu/cases_test.go
+++ b/test/e2e/gpu/cases_test.go
@@ -85,7 +85,10 @@ var cases = []testCase{
 		workloadSelector: "nvidia.com/dynamo-graph-deployment-name=qwen3-0-6b-dynamo,nvidia.com/dynamo-component-type=worker",
 		extraAssert:      assertDynamoDeep,
 	},
-	// Disaggregated Dynamo serving is intentionally excluded: it serves correctly
-	// in isolation but its shared-BBR restart races with concurrent aggregated
-	// requests (ai-runway/airunway#334). Re-add as a data-only case once fixed.
+	// Disaggregated Dynamo serving is not in the matrix yet. It was excluded
+	// because the shared-BBR restart raced with concurrent aggregated requests
+	// (ai-runway/airunway#334); that restart has since been removed, so this
+	// blocker is gone. Adding the case still needs a testdata fixture plus an
+	// upstreamCR/podSelector pair confirmed against a live multi-GPU cluster,
+	// since disaggregated serving schedules separate prefill and decode workers.
 }


### PR DESCRIPTION
## Description

The controller force-restarted the shared body-based-router (BBR) Deployment
every time a new `ModelDeployment` produced an InferencePool, on the premise
that BBR builds its model registry at startup and does not watch InferencePools.

**That premise is wrong**, at both the currently pinned GAIE v1.5.0 and at
v1.3.1 where the restart was introduced (`243dbc7`, #141):

- v1.5.0's `body-field-to-header` plugin reads the `model` field from each
  request body and sets `X-Gateway-Model-Name` unconditionally. There is no
  registry, no allow-list and no HTTPRoute/InferencePool lookup
  (`pkg/bbr/plugins/bodyfieldtoheader`). v1.3.1's `HandleRequestBody` was
  equally stateless.
- BBR's only cached state is the LoRA adapter → base-model map, kept current by
  a live watch on ConfigMaps labelled `inference.networking.k8s.io/bbr-managed`,
  so it is restart-free too. AI Runway creates no such ConfigMaps.
- Decisively: the BBR chart grants its ServiceAccount **only** `get`/`list`/`watch`
  on ConfigMaps, at both versions. BBR cannot read HTTPRoutes or InferencePools
  even in principle.

So the restart bought nothing while opening a window in which an in-flight
request for an *already-serving* model could miss its `X-Gateway-Model-Name`
header and mis-route to another model's InferencePool. In the GPU e2e suite that
surfaced as a `500 Worker ID required (--direct-route)` on a settled aggregated
model while a disaggregated Dynamo model was deploying concurrently.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Fix #334. The issue proposes making the BBR restart zero-downtime. Before
implementing that, verify the issue's stated root cause against upstream GAIE
at the pinned version: does BBR actually build a model registry at startup?
If the premise doesn't hold, remove the mechanism instead, and remove any
supporting plumbing that existed only to serve it. Add regression tests that
fail if the restart is reintroduced.
```

**AI Tool:** Claude (Claude Code)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #334

## Changes Made

- Removed `restartBBRIfPresent` and both call sites (the `OperationResultCreated`
  branch in `reconcileInferencePool`, and the annotation-gated branch in
  `reconcileProviderManagedInferencePool`), dropping the now-dead `bbrNamespace`
  parameter from both signatures.
- Removed the `airunwayv1alpha1.BBRRestarted` annotation constant that gated the
  provider-managed path. It is not part of the CRD schema — `make manifests
  generate` produces no drift.
- Removed the `airunway.ai/bbr-namespace` plumbing (`AnnotationBBRNamespace`,
  `GatewayConfig.BBRNamespace`, `GetBBRNamespace`), which existed solely to
  locate the Deployment to restart. It was undocumented and referenced only by
  the two files implementing the restart.
- Added two regression tests, one per removed call site, asserting the BBR
  Deployment's pod template is never touched and the removed annotation never
  reappears on the ModelDeployment.
- Rewrote the "Known limitation — BBR restart on each new model" note in
  `docs/gateway.md`, which documented the false premise, and recorded that
  older deployments may carry an inert `airunway.ai/bbr-restarted` annotation.
- Updated the GPU e2e comment noting that #334 no longer blocks re-adding the
  disaggregated Dynamo case.

## Testing

- [x] Unit tests pass — Go suite for this change: `go test ./...` in
      `controller/` (6 packages, all pass) with envtest assets. `bun run test`
      is unaffected; no TypeScript changed.
- [x] Manual testing performed — verified upstream BBR's behaviour and RBAC
      directly against the GAIE source at both v1.5.0 and v1.3.1.
- [ ] Tested with a Kubernetes cluster — **not yet done, see Additional Notes.**

**The regression tests were verified to fail without the fix.** The restart was
temporarily reintroduced in both functions; both tests failed with specific
messages, then the simulation was reverted and the full suite re-run green. A
regression test that has never been observed failing proves nothing.

## Checklist

- [x] My code follows the project's style guidelines — `gofmt`, `go vet` clean
- [x] Linted — Go change, so `golangci-lint` rather than `bun run lint`. Verified
      against a baseline of the pristine base commit: 28 findings before, 28
      after, identical category breakdown. Zero lint regressions.
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Screenshots

N/A — no user-facing UI change.

## Additional Notes

**Outstanding: no live cluster verification.** Unit tests prove the restart no
longer happens; they cannot prove routing still works without it. Before merge,
`e2e-gateway` should deploy a second model and assert (a) the BBR pod UID is
unchanged throughout, and (b) requests to the first model return 200 continuously
across the second model's rollout. This needs no GPU — `e2e-gateway` already runs
a full CPU-only gateway path.

**RBAC deliberately unchanged.** The `apps/deployments` grant is not
restart-only: the EPP Deployment still needs `create`/`update`/`get`/`list`/
`watch`/`delete`. Only the `patch` verb has no consumer left, and `update` on the
same resource already subsumes it, so narrowing would remove no real privilege
while risking breakage if EPP handling ever moves to patch/SSA.

**Existing clusters need no migration.** ModelDeployments created by an earlier
controller may still carry an inert `airunway.ai/bbr-restarted` annotation.
Nothing reads it and it is not in the CRD schema, so it is safe to leave. Anyone
who wants it gone: `kubectl annotate modeldeployment --all airunway.ai/bbr-restarted-`.

**Docs caveat.** `docs/gateway.md` now describes upstream BBR's RBAC scope, which
is accurate for GAIE v1.5.0 but could drift when the pin is bumped — worth
re-checking alongside `GAIE_VERSION`.
