### PR TITLE
fix(providers): reject unknown upstream fields instead of pruning them silently

### DIFF
--- a/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
+++ b/controller/internal/webhook/v1alpha1/modeldeployment_webhook.go
@@ -1036,9 +1036,23 @@ func checkBlockedKeys(m map[string]interface{}, fldPath *field.Path) field.Error
 // checkSizingOverrideKeys recursively walks provider overrides and rejects
 // fields that would let raw provider overrides bypass resource/replica ceilings.
 func checkSizingOverrideKeys(m map[string]interface{}, fldPath *field.Path) field.ErrorList {
-	return checkForbiddenOverrideKeys(m, fldPath, sizingOverrideKeys, func(key string) string {
+	allErrs := checkForbiddenOverrideKeys(m, fldPath, sizingOverrideKeys, func(key string) string {
 		return fmt.Sprintf("overriding %q is not allowed because it can bypass admission resource limits; use spec.resources / spec.scaling instead", key)
 	})
+
+	// KAITO names its replica field resource.count rather than replicas. Keep this
+	// check path-specific: other count fields in provider-specific configuration do
+	// not necessarily control workload size.
+	if resourceOverride, ok := m["resource"].(map[string]interface{}); ok {
+		if _, exists := resourceOverride["count"]; exists {
+			allErrs = append(allErrs, field.Forbidden(
+				fldPath.Child("resource", "count"),
+				"overriding \"resource.count\" is not allowed because it can bypass admission replica limits; use spec.scaling.replicas instead",
+			))
+		}
+	}
+
+	return allErrs
 }
 
 // checkForbiddenOverrideKeys recursively walks an unmarshalled JSON object and

--- a/controller/internal/webhook/v1alpha1/security_validation_test.go
+++ b/controller/internal/webhook/v1alpha1/security_validation_test.go
@@ -197,6 +197,50 @@ func TestValidateOverrides_BlocksSizingKeysInsideArray(t *testing.T) {
 	requireValidationErrorField(t, errs, "spec.provider.overrides.services[0].replicas")
 }
 
+func TestValidateOverrides_BlocksKaitoResourceCount(t *testing.T) {
+	v := &ModelDeploymentCustomValidator{}
+	overrides := map[string]interface{}{
+		"resource": map[string]interface{}{
+			"count": 10,
+		},
+	}
+	raw, _ := json.Marshal(overrides)
+	spec := &airunwayv1alpha1.ModelDeploymentSpec{
+		Provider: &airunwayv1alpha1.ProviderSpec{
+			Name:      "kaito",
+			Overrides: &runtime.RawExtension{Raw: raw},
+		},
+	}
+	errs := v.validateOverrides(spec, field.NewPath("spec"))
+	requireValidationErrorField(t, errs, "spec.provider.overrides.resource.count")
+	requireValidationErrorDetail(t, errs, "overriding \"resource.count\" is not allowed because it can bypass admission replica limits; use spec.scaling.replicas instead")
+}
+
+func TestValidateOverrides_AllowsNonSizingCountAndKaitoResourceFields(t *testing.T) {
+	v := &ModelDeploymentCustomValidator{}
+	overrides := map[string]interface{}{
+		"resource": map[string]interface{}{
+			"instanceType": "Standard_NC24ads_A100_v4",
+			"labelSelector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{"accelerator": "nvidia"},
+			},
+		},
+		"inference": map[string]interface{}{
+			"preset": map[string]interface{}{"count": 2},
+		},
+	}
+	raw, _ := json.Marshal(overrides)
+	spec := &airunwayv1alpha1.ModelDeploymentSpec{
+		Provider: &airunwayv1alpha1.ProviderSpec{
+			Name:      "kaito",
+			Overrides: &runtime.RawExtension{Raw: raw},
+		},
+	}
+	if errs := v.validateOverrides(spec, field.NewPath("spec")); len(errs) != 0 {
+		t.Fatalf("expected non-sizing KAITO overrides to remain allowed, got %v", errs)
+	}
+}
+
 func TestValidateOverrides_NilOverrides(t *testing.T) {
 	v := &ModelDeploymentCustomValidator{}
 	spec := &airunwayv1alpha1.ModelDeploymentSpec{}

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,7 @@ See [controller-architecture.md](controller-architecture.md) for controller inte
 | `engine.args` | map[string]string | No | `{}` | Engine-specific named arguments/CLI flags |
 | `engine.extraArgs` | []string | No | `[]` | Additional raw engine flags |
 | `provider.name` | string | No | Auto-selected | `dynamo`, `kaito`, `kuberay`, `llmd`, or `vllm` |
-| `provider.overrides` | object | No | `{}` | Provider-specific escape hatch |
+| `provider.overrides` | object | No | `{}` | Provider-specific escape hatch. Accepts `spec` plus documented provider-specific keys (KAITO instead accepts `resource`/`inference`); any other root key is rejected by the provider. KubeRay ignores overrides entirely. Keys nested under `spec` must exist in the installed upstream CRD or the API server rejects the write |
 | `serving.mode` | string | No | `aggregated` | `aggregated` or `disaggregated` |
 | `scaling.replicas` | int | No | `1` | Replicas (aggregated mode) |
 | `scaling.prefill` | object | No | — | Prefill scaling (disaggregated mode) |
@@ -205,8 +205,8 @@ spec:
     name: dynamo
     overrides:
       routerMode: "kv"
-      frontend:
-        replicas: 2
+      epp:
+        image: "my-registry/epp:v1"
   engine:
     type: vllm
   serving:

--- a/docs/controller-architecture.md
+++ b/docs/controller-architecture.md
@@ -261,12 +261,14 @@ provider:
   name: dynamo
   overrides:
     routerMode: "kv"          # kv | round-robin | none (default: round-robin)
-    frontend:
-      replicas: 2
-      resources:
-        cpu: "4"
-        memory: "8Gi"
+    epp:
+      image: "my-registry/epp:v1"
 ```
+
+> The validating webhook rejects `replicas` and `resources` **anywhere** inside
+> `provider.overrides` (including nested, e.g. `frontend.replicas`), because raw overrides
+> are merged after admission has checked `spec.resources` / `spec.scaling` ceilings. Use
+> `spec.resources` and `spec.scaling` for sizing.
 
 **KubeRay overrides:**
 ```yaml
@@ -282,7 +284,44 @@ provider:
         num-cpus: "0"
 ```
 
-KAITO currently has no supported overrides. Unknown keys trigger warnings; invalid types cause reconciliation failure.
+**KAITO overrides:**
+```yaml
+provider:
+  name: kaito
+  overrides:
+    inference:
+      preset:
+        name: "phi-3-mini-4k-instruct"
+```
+
+KAITO places `resource` and `inference` at the object root rather than under `spec`, so those
+are the keys its overrides accept. Invalid types cause reconciliation failure.
+
+> Do not use overrides for sizing. `resource.count` is how `spec.scaling.replicas` is
+> rendered, and unlike `spec.scaling.replicas` it is not subject to the admission ceiling —
+> setting it here bypasses the limit the warning above describes.
+
+> **Overrides are no longer silently dropped.** Two different checks now apply:
+>
+> - An unsupported **root** key is rejected by the provider before any write, surfacing as
+>   `ResourceCreated=False` with reason `TransformFailed`. The accepted root keys differ by
+>   provider: `spec` for Dynamo, llm-d and vLLM (Dynamo additionally accepts its documented
+>   `routerMode`/`frontend`/`epp`), and `resource`/`inference` for KAITO, whose Workspace does
+>   not nest them under `spec`. **KubeRay does not read `spec.provider.overrides` at all**, so
+>   overrides are ignored there — see the note below.
+> - A key nested under the accepted root (**`spec`**, or `resource`/`inference` for KAITO)
+>   that the installed upstream CRD does not declare is
+>   rejected by the API server, because provider writes use `fieldValidation=Strict` — see
+>   [Upstream compatibility](providers.md#upstream-compatibility). That surfaces as
+>   `IncompatibleUpstream`.
+>
+> Previously both were pruned by the API server, so an override that never took effect
+> looked like it worked. The escape hatch reaches fields the upstream CRD *has* but the
+> unified API does not expose — it cannot invent fields the upstream does not support.
+
+> **Note:** the KubeRay overrides above are not currently implemented — `providers/kuberay`
+> does not read `spec.provider.overrides`. Documented here as intent, not behaviour. Note
+> also that the `resources` key shown would be rejected by the webhook as above.
 
 ## Validation Webhook
 

--- a/docs/controller-architecture.md
+++ b/docs/controller-architecture.md
@@ -270,58 +270,9 @@ provider:
 > are merged after admission has checked `spec.resources` / `spec.scaling` ceilings. Use
 > `spec.resources` and `spec.scaling` for sizing.
 
-**KubeRay overrides:**
-```yaml
-provider:
-  name: kuberay
-  overrides:
-    head:
-      resources:
-        cpu: "4"
-        memory: "8Gi"
-      rayStartParams:
-        dashboard-host: "0.0.0.0"
-        num-cpus: "0"
-```
-
-**KAITO overrides:**
-```yaml
-provider:
-  name: kaito
-  overrides:
-    inference:
-      preset:
-        name: "phi-3-mini-4k-instruct"
-```
-
-KAITO places `resource` and `inference` at the object root rather than under `spec`, so those
-are the keys its overrides accept. Invalid types cause reconciliation failure.
-
-> Do not use overrides for sizing. `resource.count` is how `spec.scaling.replicas` is
-> rendered, and unlike `spec.scaling.replicas` it is not subject to the admission ceiling —
-> setting it here bypasses the limit the warning above describes.
-
-> **Overrides are no longer silently dropped.** Two different checks now apply:
->
-> - An unsupported **root** key is rejected by the provider before any write, surfacing as
->   `ResourceCreated=False` with reason `TransformFailed`. The accepted root keys differ by
->   provider: `spec` for Dynamo, llm-d and vLLM (Dynamo additionally accepts its documented
->   `routerMode`/`frontend`/`epp`), and `resource`/`inference` for KAITO, whose Workspace does
->   not nest them under `spec`. **KubeRay does not read `spec.provider.overrides` at all**, so
->   overrides are ignored there — see the note below.
-> - A key nested under the accepted root (**`spec`**, or `resource`/`inference` for KAITO)
->   that the installed upstream CRD does not declare is
->   rejected by the API server, because provider writes use `fieldValidation=Strict` — see
->   [Upstream compatibility](providers.md#upstream-compatibility). That surfaces as
->   `IncompatibleUpstream`.
->
-> Previously both were pruned by the API server, so an override that never took effect
-> looked like it worked. The escape hatch reaches fields the upstream CRD *has* but the
-> unified API does not expose — it cannot invent fields the upstream does not support.
-
-> **Note:** the KubeRay overrides above are not currently implemented — `providers/kuberay`
-> does not read `spec.provider.overrides`. Documented here as intent, not behaviour. Note
-> also that the `resources` key shown would be rejected by the webhook as above.
+KAITO and KubeRay have no documented override surface. KubeRay does not read
+`spec.provider.overrides` at all, so overrides set for it have no effect; KAITO merges them,
+but the supported keys are not specified here. Invalid types cause reconciliation failure.
 
 ## Validation Webhook
 

--- a/docs/controller-architecture.md
+++ b/docs/controller-architecture.md
@@ -270,9 +270,17 @@ provider:
 > are merged after admission has checked `spec.resources` / `spec.scaling` ceilings. Use
 > `spec.resources` and `spec.scaling` for sizing.
 
-KAITO and KubeRay have no documented override surface. KubeRay does not read
-`spec.provider.overrides` at all, so overrides set for it have no effect; KAITO merges them,
-but the supported keys are not specified here. Invalid types cause reconciliation failure.
+**KubeRay** does not read `spec.provider.overrides` at all, so overrides set for it have no
+effect.
+
+**KAITO** accepts `resource` and `inference`, which the Workspace places at the object root
+rather than under `spec` — so unlike the other providers, `spec` is not an accepted key here.
+Any other root key is rejected with an error naming it. The allowlist is deliberately narrower
+than the Workspace schema, which also declares `tuning`: a `ModelDeployment` describes an
+inference deployment and the status translator reads inference conditions, so a tuning
+Workspace would report status the provider cannot interpret.
+
+Invalid types cause reconciliation failure.
 
 ## Validation Webhook
 

--- a/docs/controller-architecture.md
+++ b/docs/controller-architecture.md
@@ -268,17 +268,21 @@ provider:
 > The validating webhook rejects `replicas` and `resources` **anywhere** inside
 > `provider.overrides` (including nested, e.g. `frontend.replicas`), because raw overrides
 > are merged after admission has checked `spec.resources` / `spec.scaling` ceilings. Use
-> `spec.resources` and `spec.scaling` for sizing.
+> `spec.resources` and `spec.scaling` for sizing. KAITO's equivalent replica field,
+> `resource.count`, is rejected explicitly; use `spec.scaling.replicas` instead.
 
-**KubeRay** does not read `spec.provider.overrides` at all, so overrides set for it have no
-effect.
+**KubeRay** does not read `spec.provider.overrides`. Overrides that pass the global webhook
+do not affect the rendered `RayService`; the webhook still rejects globally blocked security
+and sizing paths.
 
 **KAITO** accepts `resource` and `inference`, which the Workspace places at the object root
 rather than under `spec` — so unlike the other providers, `spec` is not an accepted key here.
 Any other root key is rejected with an error naming it. The allowlist is deliberately narrower
 than the Workspace schema, which also declares `tuning`: a `ModelDeployment` describes an
 inference deployment and the status translator reads inference conditions, so a tuning
-Workspace would report status the provider cannot interpret.
+Workspace would report status the provider cannot interpret. Within `resource`, `count` is
+managed by `spec.scaling.replicas` and cannot be overridden; fields such as `labelSelector`
+and `instanceType` remain available.
 
 Invalid types cause reconciliation failure.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -189,9 +189,20 @@ writers are **not** covered and carry the same skew risk:
 degraded workload now blocks the deployment. There is no runtime opt-out — to revert the
 behaviour, pin the previous provider image.
 
-`spec.provider.overrides` is subject to the same rule — only keys the installed upstream CRD
-declares will be accepted. See
-[Provider Overrides](controller-architecture.md#provider-overrides).
+`spec.provider.overrides` passes through **two** separate checks, and it is worth keeping them
+apart:
+
+1. **The provider checks the root keys** before rendering. Each provider accepts only the roots
+   it knows how to apply — `spec` plus its own transformer-specific keys, or `resource` and
+   `inference` for KAITO, which places them at the object root. Anything else is rejected with
+   an error naming the offending key, rather than being merged and silently pruned.
+2. **The API server checks everything sent upstream.** Keys nested under `spec` reach the
+   upstream object, so they must be declared by the installed CRD or the write is rejected.
+
+The distinction matters because the transformer-specific keys are *not* declared upstream and
+are never sent: Dynamo's `routerMode` and `epp`, for example, are decoded into the shim's own
+config and stripped before the write. They are accepted despite being absent from the upstream
+schema. See [Provider Overrides](controller-architecture.md#provider-overrides).
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -125,6 +125,76 @@ For HuggingFace GGUF models, KAITO uses in-cluster image building:
 
 ---
 
+## Upstream Compatibility
+
+A provider shim renders manifests it does not own the schema for. For `dynamo`, `kaito` and
+`kuberay` that means a third-party CRD installed separately; if the cluster's installed
+upstream is older than the shim expects, it may not declare a field the shim emits. `dynamo`
+and `kaito` pin their target version in `versions.env`; **KubeRay is not pinned at all**, so
+that shim has no declared target to compare against. `llmd` and `vllm` render only built-in `apps/v1` and `v1` types, whose
+schemas ship with the API server, so their exposure is to Kubernetes version skew rather than
+to a third-party operator.
+
+Kubernetes CRDs with a structural schema **prune** undeclared fields by default: the write
+succeeds, the field vanishes, and no error is raised. That produced a real failure
+([#308](https://github.com/ai-runway/airunway/issues/308)) where a workload came up without
+its HTTP frontend, the gateway returned 503, and `ModelDeployment.status.phase` still read
+`Running`.
+
+Provider writes to the upstream resource therefore set **`fieldValidation=Strict`**, so the
+API server rejects unknown fields instead of dropping them.
+
+This is what protects `dynamo`, `kaito` and `kuberay`. For `llmd` and `vllm` it changes
+little: they render built-in types through server-side apply, where the field manager already
+rejects unknown fields during typed conversion regardless of this option (verified — an SSA
+apply with validation explicitly ignored still fails with `field not declared in schema`).
+Setting it there adds duplicate-key detection and keeps one uniform rule across all five.
+
+**How a rejection surfaces.** `ResourceCreated=False` and `Ready=False`, both with reason
+`IncompatibleUpstream`, and phase `Failed`. For `dynamo`, `kaito` and `kuberay` the offending
+field is named in `status.message`. For `llmd` and `vllm` it is not: server-side apply reports
+only one arbitrarily-chosen unknown field and picks a different one per call, so storing it
+would rewrite status on every reconcile and re-enqueue the object each time. Those two store a
+stable summary and log the specific field instead.
+The provider keeps requeueing, so upgrading the upstream recovers the deployment without
+anyone touching the `ModelDeployment`. `Ready` is forced false deliberately: #308 was a
+deployment that reported healthy while unable to serve.
+
+**Detection is by error message, not status code**, because the API server's response varies
+by write path — a custom resource create returns `400` with `strict decoding error: unknown
+field`, a merge patch returns `422` with the same prefix, and server-side apply on a built-in
+type returns **`500`** with `field not declared in schema`. The last one is not a field-validation
+error at all: it originates in the field manager's typed conversion
+(`structured-merge-diff`, `typed/validate.go`), which is why it has a different status class and
+why SSA rejects unknown fields even when field validation is disabled. Matching on the status class alone would both miss the apply path and wrongly
+capture ordinary CEL and type-validation failures, which no upstream upgrade would fix.
+
+**Scope.** This covers writes to the upstream resource from the five provider shims. Three
+writers are **not** covered and carry the same skew risk:
+
+- provider self-registration to `InferenceProviderConfig` (`providers/*/config.go`), when a
+  provider binary is newer than the installed AI Runway CRDs;
+- the PVC and Job writes in `controller/pkg/storage`;
+- **the gateway reconciler** (`controller/internal/controller/gateway_reconciler.go`), which
+  writes `InferencePool`, `HTTPRoute`, an Istio `DestinationRule` and a Gateway API
+  `ReferenceGrant` — third-party CRDs pinned by `GAIE_VERSION`, `GATEWAY_API_VERSION` and
+  `ISTIO_VERSION`. This is the closest remaining instance of #308 in the codebase: an older
+  upstream that does not declare a field the reconciler sets would prune it silently.
+  Covering it is uneven: the `HTTPRoute` writes are a plain `Create`/`Update` and would take
+  the option directly, while `InferencePool`, `DestinationRule` and `ReferenceGrant` go
+  through `ctrl.CreateOrUpdate`, which accepts no field-validation option and would need
+  restructuring.
+
+**Rollback.** This is a fail-closed change: a mismatch that previously produced a silently
+degraded workload now blocks the deployment. There is no runtime opt-out — to revert the
+behaviour, pin the previous provider image.
+
+`spec.provider.overrides` is subject to the same rule — only keys the installed upstream CRD
+declares will be accepted. See
+[Provider Overrides](controller-architecture.md#provider-overrides).
+
+---
+
 ## See also
 
 - [Architecture Overview](architecture.md)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -130,10 +130,11 @@ For HuggingFace GGUF models, KAITO uses in-cluster image building:
 A provider shim renders manifests it does not own the schema for. For `dynamo`, `kaito` and
 `kuberay` that means a third-party CRD installed separately; if the cluster's installed
 upstream is older than the shim expects, it may not declare a field the shim emits. `dynamo`
-and `kaito` pin their target version in `versions.env`; **KubeRay is not pinned at all**, so
-that shim has no declared target to compare against. `llmd` and `vllm` render only built-in `apps/v1` and `v1` types, whose
-schemas ship with the API server, so their exposure is to Kubernetes version skew rather than
-to a third-party operator.
+and `kaito` pin their target version in `versions.env`. KubeRay's installation metadata pins
+operator chart `1.3.0` in `providers/kuberay/config.go`, but unlike those two it has no
+centralized `KUBERAY_VERSION` pin or version-sync check. `llmd` and `vllm` render only built-in
+`apps/v1` and `v1` types, whose schemas ship with the API server, so their exposure is to
+Kubernetes version skew rather than to a third-party operator.
 
 Kubernetes CRDs with a structural schema **prune** undeclared fields by default: the write
 succeeds, the field vanishes, and no error is raised. That produced a real failure
@@ -189,20 +190,28 @@ writers are **not** covered and carry the same skew risk:
 degraded workload now blocks the deployment. There is no runtime opt-out — to revert the
 behaviour, pin the previous provider image.
 
-`spec.provider.overrides` passes through **two** separate checks, and it is worth keeping them
+`spec.provider.overrides` passes through **three** separate checks, and it is worth keeping them
 apart:
 
-1. **The provider checks the root keys** before rendering. Each provider accepts only the roots
-   it knows how to apply — `spec` plus its own transformer-specific keys, or `resource` and
-   `inference` for KAITO, which places them at the object root. Anything else is rejected with
-   an error naming the offending key, rather than being merged and silently pruned.
-2. **The API server checks everything sent upstream.** Keys nested under `spec` reach the
-   upstream object, so they must be declared by the installed CRD or the write is rejected.
+1. **The AI Runway validating webhook checks every provider's override payload** before a
+   `ModelDeployment` is admitted. Its recursive rules reject security-sensitive fields and
+   workload-sizing fields that could bypass the unified resource and replica limits.
+2. **Providers that consume overrides check the root keys** before rendering. Dynamo, KAITO,
+   llm-d and Direct vLLM accept only the roots they know how to apply — `spec` plus Dynamo's
+   transformer-specific keys, or `resource` and `inference` for KAITO, which places them at the
+   object root. Anything else is rejected with an error naming the offending key, rather than
+   being merged and silently pruned. KubeRay does not consume overrides that pass the global
+   admission rules, so they do not change the rendered `RayService`.
+3. **The target API server checks the rendered object.** Passed-through fields must be
+   declared by the target CRD or built-in Kubernetes schema, otherwise the write is rejected.
 
 The distinction matters because the transformer-specific keys are *not* declared upstream and
 are never sent: Dynamo's `routerMode` and `epp`, for example, are decoded into the shim's own
 config and stripped before the write. They are accepted despite being absent from the upstream
-schema. See [Provider Overrides](controller-architecture.md#provider-overrides).
+schema, but their documented structure is decoded strictly so a typo such as `epp.imag` is
+rejected rather than silently discarded. KAITO similarly rejects its replica path
+`resource.count`; replicas must be set through `spec.scaling.replicas`. See
+[Provider Overrides](controller-architecture.md#provider-overrides).
 
 ---
 

--- a/providers/dynamo/controller.go
+++ b/providers/dynamo/controller.go
@@ -94,8 +94,25 @@ func isUpstreamSchemaRejection(err error) bool {
 		return false
 	}
 	msg := err.Error()
-	return strings.Contains(msg, "strict decoding error") ||
-		strings.Contains(msg, "field not declared in schema")
+
+	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
+	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
+	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
+	// containing either phrase on its own must not be misclassified as a version mismatch
+	// and retried forever.
+	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+		return true
+	}
+
+	// Server-side apply on built-in types: the rejection comes from the field manager's
+	// typed conversion, not from field validation, so it carries a different wrapper and a
+	// different status class. Bind the diagnostic to that wrapper for the same reason.
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return strings.Contains(msg, "field not declared in schema")
+	}
+
+	return false
 }
 
 // DynamoProviderReconciler reconciles ModelDeployment resources for the Dynamo provider

--- a/providers/dynamo/controller.go
+++ b/providers/dynamo/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -62,6 +63,40 @@ const (
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
 )
+
+// strictFieldValidation makes the API server reject fields the installed upstream does
+// not declare, instead of silently pruning them — see issue #308 and the "Upstream
+// compatibility" section of docs/providers.md. kubectl sends strict validation by default;
+// Go clients do not, so it must be set explicitly on every upstream write.
+var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// isUpstreamSchemaRejection reports whether err is the API server refusing a field the
+// installed upstream does not declare, as opposed to any other rejection.
+//
+// Matching on the message rather than the status class is deliberate, because the class
+// varies by write path:
+//   - custom resource create/update -> 400 BadRequest, "strict decoding error: unknown field"
+//   - custom resource merge patch   -> 422 Invalid,    same prefix (verified live)
+//   - server-side apply on built-in types -> 500, "field not declared in schema"
+//     (verified against a live cluster: the error is a plain error from the field manager,
+//     so it is neither IsBadRequest nor IsInvalid)
+//
+// Gating on IsInvalid alone would also swallow every CEL and OpenAPI type violation, which
+// are user configuration errors that no upstream upgrade would fix — reporting those as an
+// upstream version mismatch would send operators down the wrong path entirely.
+//
+// The needle is the "strict decoding error" prefix rather than the bare "unknown field"
+// cause it wraps, because an Invalid status echoes the offending value back and a
+// user-supplied string (a model id, an image, an engine arg) could otherwise contain the
+// bare phrase and be misclassified.
+func isUpstreamSchemaRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "strict decoding error") ||
+		strings.Contains(msg, "field not declared in schema")
+}
 
 // DynamoProviderReconciler reconciles ModelDeployment resources for the Dynamo provider
 type DynamoProviderReconciler struct {
@@ -192,7 +227,14 @@ func (r *DynamoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	resources, err := r.Transformer.Transform(ctx, &md)
 	if err != nil {
 		logger.Error(err, "Failed to transform ModelDeployment", "name", md.Name)
+		// Same treatment as the upstream-rejection path below: force Ready False and drop
+		// the stale endpoint/replica counts. Otherwise a previously-Running deployment whose
+		// spec is edited into something unrenderable reports Failed while still advertising
+		// a live endpoint and "1/1 ready" — the contradiction strict validation exists to surface.
 		r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "TransformFailed", err.Error())
+		r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "TransformFailed", err.Error())
+		md.Status.Endpoint = nil
+		md.Status.Replicas = nil
 		md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 		md.Status.Message = fmt.Sprintf("Failed to generate Dynamo resources: %s", err.Error())
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
@@ -212,15 +254,60 @@ func (r *DynamoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
+			// Strict field validation rejected the write: the cluster does not accept a field
+			// this provider renders. Give it its own reason so an operator can tell it apart
+			// from a generic create failure, and keep requeueing — the remedy is
+			// an out-of-band upstream upgrade, and nothing else would re-trigger this
+			// reconcile. The provider-config watch fires only on Spec/Ready changes, and no
+			// upstream object exists to watch, so without a requeue the deployment would sit
+			// Failed until the ~10h resync even after the cluster is fixed.
+			//
+			// Ready is forced False here because the failure it catches is precisely a
+			// deployment that reports healthy while being unable to serve. Note this deliberately does NOT
+			// touch ProviderCompatible: that is set True earlier in this same reconcile, so
+			// flipping it here would rewrite LastTransitionTime on every requeue and the
+			// condition would never settle.
+			if isUpstreamSchemaRejection(err) {
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "IncompatibleUpstream", err.Error())
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "IncompatibleUpstream", err.Error())
+				// Clear the Running-era endpoint and replica counts. This branch returns
+				// before syncStatus, so on an update rejection they would otherwise keep
+				// their previous values and the object would report Failed alongside a live
+				// endpoint and "1/1 ready" — the same contradiction described above.
+				md.Status.Endpoint = nil
+				md.Status.Replicas = nil
+				md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
+				md.Status.Message = fmt.Sprintf("Incompatible with the installed upstream: the installed Dynamo CRD does not declare a field this provider renders. This usually means the cluster's Dynamo is older than this provider requires, or that spec.provider.overrides sets a key it does not support. %s", err.Error())
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			}
 			reason := "CreateFailed"
 			if isResourceConflict(err) {
+				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
-				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "ResourceConflict", err.Error())
 			}
+			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
+			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
+			// Leaving this branch alone would make the most common failure the one that
+			// still reports healthy — the same shape.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, err.Error())
+			md.Status.Endpoint = nil
+			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create DynamoGraphDeployment: %s", err.Error())
-			return ctrl.Result{}, r.Status().Update(ctx, &md)
+			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
+			// leader change, a momentary 500 — and it is the case that most needs a retry.
+			// Without one the second pass writes identical status, which the API server
+			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
+			// its endpoint cleared until the ~10h resync even though the workload may still
+			// be serving.
+			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
 		}
 	}
 
@@ -341,7 +428,7 @@ func (r *DynamoProviderReconciler) createOrUpdateResource(ctx context.Context, r
 	if errors.IsNotFound(err) {
 		// Create new resource
 		logger.Info("Creating resource", "kind", resource.GetKind(), "name", resource.GetName())
-		return r.Create(ctx, resource)
+		return r.Create(ctx, resource, strictFieldValidation)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get existing resource: %w", err)
@@ -363,7 +450,7 @@ func (r *DynamoProviderReconciler) createOrUpdateResource(ctx context.Context, r
 	if !equality.Semantic.DeepEqual(stripEmptyDefaults(existingSpec), stripEmptyDefaults(newSpec)) {
 		logger.Info("Updating resource", "kind", resource.GetKind(), "name", resource.GetName())
 		resource.SetResourceVersion(existing.GetResourceVersion())
-		return r.Update(ctx, resource)
+		return r.Update(ctx, resource, strictFieldValidation)
 	}
 
 	return nil

--- a/providers/dynamo/controller.go
+++ b/providers/dynamo/controller.go
@@ -18,9 +18,13 @@ package dynamo
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"io"
+	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -33,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,6 +65,10 @@ const (
 	// RequeueInterval is the default requeue interval for periodic reconciliation
 	RequeueInterval = 30 * time.Second
 
+	// ExternalRecoveryInterval retries failures that require an out-of-band fix without
+	// hot-looping while the installed upstream or resource ownership remains unchanged.
+	ExternalRecoveryInterval = 5 * time.Minute
+
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
 )
@@ -69,6 +78,13 @@ const (
 // compatibility" section of docs/providers.md. kubectl sends strict validation by default;
 // Go clients do not, so it must be set explicitly on every upstream write.
 var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// strictUnknownFieldRejection matches the terminal diagnostic emitted by apimachinery's
+// strict decoder. Anchoring the diagnostic at the end keeps an ordinary validation error
+// from matching when its echoed user value contains the same words.
+var strictUnknownFieldRejection = regexp.MustCompile(
+	`(^|: )strict decoding error: unknown field "(\\.|[^"\\])*"(, unknown field "(\\.|[^"\\])*")*$`,
+)
 
 // isUpstreamSchemaRejection reports whether err is the API server refusing a field the
 // installed upstream does not declare, as opposed to any other rejection.
@@ -95,12 +111,11 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 	msg := err.Error()
 
-	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
-	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
-	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
-	// containing either phrase on its own must not be misclassified as a version mismatch
-	// and retried forever.
-	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+	// Custom-resource paths: match the complete terminal diagnostic, not independent
+	// substrings. An Invalid status echoes the offending value back, so a user-supplied
+	// string may itself contain both phrases and must not be misclassified as a version
+	// mismatch and retried forever.
+	if strictUnknownFieldRejection.MatchString(msg) {
 		return true
 	}
 
@@ -113,6 +128,56 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 
 	return false
+}
+
+// isRetryableUpstreamWriteError reports failures that can recover without changing the
+// ModelDeployment or cluster configuration. These must not erase last-known serving status:
+// a failed or ambiguous API response does not mean the existing workload stopped serving.
+func isRetryableUpstreamWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.IsConflict(err) || errors.IsAlreadyExists(err) ||
+		errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsTooManyRequests(err) ||
+		errors.IsServiceUnavailable(err) || errors.IsInternalError(err) {
+		return true
+	}
+
+	var status errors.APIStatus
+	if stderrors.As(err, &status) && status.Status().Code >= 500 {
+		return true
+	}
+
+	return stderrors.Is(err, context.DeadlineExceeded) ||
+		stderrors.Is(err, io.EOF) || stderrors.Is(err, io.ErrUnexpectedEOF) ||
+		stderrors.Is(err, syscall.EPIPE) ||
+		utilnet.IsTimeout(err) || utilnet.IsProbableEOF(err) ||
+		utilnet.IsConnectionReset(err) || utilnet.IsConnectionRefused(err) ||
+		utilnet.IsHTTP2ConnectionLost(err)
+}
+
+// resourceWriteError records whether the target was observed as owned, active, and serving
+// before its write. A transient update failure can retain last-known serving status only after
+// that safe observation; create failures, terminating or unready resources, and unverified
+// read failures cannot.
+type resourceWriteError struct {
+	err                              error
+	resourceWasOwnedActiveAndServing bool
+}
+
+func (e *resourceWriteError) Error() string { return e.err.Error() }
+func (e *resourceWriteError) Unwrap() error { return e.err }
+
+func wrapResourceWriteError(err error, resourceWasOwnedActiveAndServing bool) error {
+	if err == nil {
+		return nil
+	}
+	return &resourceWriteError{err: err, resourceWasOwnedActiveAndServing: resourceWasOwnedActiveAndServing}
+}
+
+func canPreserveLastKnownStatus(err error) bool {
+	var writeErr *resourceWriteError
+	return stderrors.As(err, &writeErr) && writeErr.resourceWasOwnedActiveAndServing
 }
 
 // DynamoProviderReconciler reconciles ModelDeployment resources for the Dynamo provider
@@ -261,16 +326,6 @@ func (r *DynamoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	for _, resource := range resources {
 		if err := r.createOrUpdateResource(ctx, resource, &md); err != nil {
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
-			// requeue to retry with the latest version rather than marking
-			// the deployment as Failed to prevent triggering gateway resource cleanup and
-			// invalidate the EPP pod's ServiceAccount token.
-			if errors.IsConflict(err) {
-				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "ResourceConflict", err.Error())
-				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
-					return ctrl.Result{}, statusErr
-				}
-				return ctrl.Result{RequeueAfter: time.Second}, nil
-			}
 			// Strict field validation rejected the write: the cluster does not accept a field
 			// this provider renders. Give it its own reason so an operator can tell it apart
 			// from a generic create failure, and keep requeueing — the remedy is
@@ -298,33 +353,56 @@ func (r *DynamoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 					return ctrl.Result{}, statusErr
 				}
-				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+				return ctrl.Result{RequeueAfter: ExternalRecoveryInterval}, nil
+			}
+			// Conflicts, throttling, server failures, and transport interruptions say nothing
+			// about whether the existing workload is still serving. Record the failed write,
+			// but preserve last-known Phase/Ready/Endpoint/Replicas until a successful read can
+			// replace them.
+			retryableWriteError := isRetryableUpstreamWriteError(err)
+			if retryableWriteError && canPreserveLastKnownStatus(err) {
+				reason := "CreateFailed"
+				if errors.IsConflict(err) || errors.IsAlreadyExists(err) {
+					reason = "ResourceConflict"
+				}
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				requeueAfter := RequeueInterval
+				if errors.IsConflict(err) {
+					// A fresh read resolves a resourceVersion race; do not delay desired
+					// spec convergence by the normal transient-error interval.
+					requeueAfter = time.Second
+				}
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
 			}
 			reason := "CreateFailed"
+			requeueAfter := ExternalRecoveryInterval
+			if errors.IsConflict(err) {
+				requeueAfter = time.Second
+			} else if errors.IsNotFound(err) || retryableWriteError {
+				// A definite 404 means the write did not reach an existing upstream
+				// object. Fail closed, but retry on the normal recovery cadence because
+				// discovery or admission ordering can make this short-lived.
+				requeueAfter = RequeueInterval
+			}
 			if isResourceConflict(err) {
-				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
 			}
-			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
-			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
-			// Leaving this branch alone would make the most common failure the one that
-			// still reports healthy — the same shape.
+			// Definite write failures fail closed. Validation/admission and ownership
+			// failures use a slower retry because an out-of-band policy, CRD, or ownership
+			// change can make the same ModelDeployment valid without changing its spec.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, err.Error())
 			md.Status.Endpoint = nil
 			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create DynamoGraphDeployment: %s", err.Error())
-			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
-			// leader change, a momentary 500 — and it is the case that most needs a retry.
-			// Without one the second pass writes identical status, which the API server
-			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
-			// its endpoint cleared until the ~10h resync even though the workload may still
-			// be serving.
 			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
-			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 	}
 
@@ -445,7 +523,7 @@ func (r *DynamoProviderReconciler) createOrUpdateResource(ctx context.Context, r
 	if errors.IsNotFound(err) {
 		// Create new resource
 		logger.Info("Creating resource", "kind", resource.GetKind(), "name", resource.GetName())
-		return r.Create(ctx, resource, strictFieldValidation)
+		return wrapResourceWriteError(r.Create(ctx, resource, strictFieldValidation), false)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get existing resource: %w", err)
@@ -454,6 +532,11 @@ func (r *DynamoProviderReconciler) createOrUpdateResource(ctx context.Context, r
 	// Verify ownership before updating
 	if err := verifyDynamoOwnership(existing, md.UID); err != nil {
 		return err
+	}
+	resourceWasOwnedActiveAndServing := false
+	if existing.GetDeletionTimestamp() == nil && r.StatusTranslator != nil {
+		statusResult, statusErr := r.StatusTranslator.TranslateStatus(existing)
+		resourceWasOwnedActiveAndServing = statusErr == nil && statusResult.Phase == airunwayv1alpha1.DeploymentPhaseRunning
 	}
 
 	// Update existing resource if spec has changed.
@@ -464,13 +547,81 @@ func (r *DynamoProviderReconciler) createOrUpdateResource(ctx context.Context, r
 	existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
 	newSpec, _, _ := unstructured.NestedMap(resource.Object, "spec")
 
-	if !equality.Semantic.DeepEqual(stripEmptyDefaults(existingSpec), stripEmptyDefaults(newSpec)) {
+	// Normalize server-added zero values on both sides for the ordinary comparison, then
+	// compare paths explicitly supplied through provider.overrides.spec with presence-aware
+	// semantics. Without the second check an empty unknown override such as futureField: {}
+	// disappears during normalization, so no strict update is attempted and the incompatible
+	// override appears to succeed.
+	if !equality.Semantic.DeepEqual(stripEmptyDefaults(existingSpec), stripEmptyDefaults(newSpec)) ||
+		overrideSpecDiffers(md, existingSpec, newSpec) {
 		logger.Info("Updating resource", "kind", resource.GetKind(), "name", resource.GetName())
 		resource.SetResourceVersion(existing.GetResourceVersion())
-		return r.Update(ctx, resource, strictFieldValidation)
+		return wrapResourceWriteError(r.Update(ctx, resource, strictFieldValidation), resourceWasOwnedActiveAndServing)
 	}
 
 	return nil
+}
+
+// overrideSpecDiffers reports whether any path explicitly supplied through
+// provider.overrides.spec is absent from, or differs between, the observed and desired
+// specs. The override value acts as a path selector: provider-generated and server-defaulted
+// siblings are deliberately ignored, while key presence is still significant for empty maps
+// and strings that stripEmptyDefaults removes.
+func overrideSpecDiffers(md *airunwayv1alpha1.ModelDeployment, existingSpec, desiredSpec map[string]interface{}) bool {
+	if md.Spec.Provider == nil || md.Spec.Provider.Overrides == nil {
+		return false
+	}
+
+	var overrides map[string]interface{}
+	if err := json.Unmarshal(md.Spec.Provider.Overrides.Raw, &overrides); err != nil {
+		// Transform validates the same payload before this function is reached. Keep this
+		// comparison side-effect free if a direct caller supplies malformed test data.
+		return false
+	}
+	overrideSpec, ok := overrides["spec"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	return selectedOverrideValuesDiffer(existingSpec, desiredSpec, overrideSpec)
+}
+
+func selectedOverrideValuesDiffer(existing, desired, selected interface{}) bool {
+	switch selectedValue := selected.(type) {
+	case map[string]interface{}:
+		existingMap, existingOK := existing.(map[string]interface{})
+		desiredMap, desiredOK := desired.(map[string]interface{})
+		if !existingOK || !desiredOK {
+			return !equality.Semantic.DeepEqual(existing, desired)
+		}
+		for key, childSelection := range selectedValue {
+			desiredChild, desiredFound := desiredMap[key]
+			if !desiredFound {
+				// A deep-merged override path should always be present in the desired
+				// object. If it is not, there is nothing this update could validate.
+				continue
+			}
+			existingChild, existingFound := existingMap[key]
+			if !existingFound || selectedOverrideValuesDiffer(existingChild, desiredChild, childSelection) {
+				return true
+			}
+		}
+		return false
+	case []interface{}:
+		existingSlice, existingOK := existing.([]interface{})
+		desiredSlice, desiredOK := desired.([]interface{})
+		if !existingOK || !desiredOK || len(existingSlice) != len(desiredSlice) || len(selectedValue) != len(desiredSlice) {
+			return !equality.Semantic.DeepEqual(existing, desired)
+		}
+		for i, childSelection := range selectedValue {
+			if selectedOverrideValuesDiffer(existingSlice[i], desiredSlice[i], childSelection) {
+				return true
+			}
+		}
+		return false
+	default:
+		return !equality.Semantic.DeepEqual(existing, desired)
+	}
 }
 
 // stripEmptyDefaults recursively removes zero-value fields (empty strings,

--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -1139,9 +1139,53 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		}
 	}
 
+	// Only "spec" may be merged into the object, plus the keys parseOverrides has already
+	// consumed into DynamoOverrides (routerMode, frontend, epp), which are inputs to this
+	// transformer rather than DynamoGraphDeployment fields. A DGD root declares
+	// apiVersion/kind/metadata/spec/status, so anything else is a field no API server will
+	// store.
+	//
+	// Unsupported keys are REJECTED rather than dropped. Silently ignoring them would
+	// reproduce exactly the failure strict validation exists to surface: an override visible in the
+	// ModelDeployment, absent from the rendered object, and a deployment reporting healthy.
+	//
+	// The consumed-key comparison is case-insensitive because encoding/json matches field
+	// names that way — parseOverrides decodes {"RouterMode": ...} into the typed struct just
+	// as happily as the documented spelling, so a case-sensitive check would let it through
+	// to the root. The "spec" comparison is deliberately case-SENSITIVE: "Spec" is not a
+	// field of any upstream CRD, so it must be rejected rather than merged.
+	// Collected and sorted rather than returning on the first offender: Go randomises map
+	// iteration, so returning early would produce a different message on each call for the
+	// same spec. That message becomes status.message, and since the ModelDeployment watch
+	// has no GenerationChangedPredicate, a changing message means every reconcile writes
+	// status, which re-enqueues the object — an unbounded write loop for as long as the
+	// bad spec exists.
+	var unsupported []string
+	for key := range overrides {
+		if key == "spec" {
+			continue
+		}
+		if consumedOverrideKeys[strings.ToLower(key)] {
+			delete(overrides, key)
+			continue
+		}
+		unsupported = append(unsupported, key)
+	}
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		return fmt.Errorf("unsupported provider.overrides key(s) %q: only \"spec\" and the "+
+			"Dynamo-specific keys routerMode, frontend and epp are supported (note the webhook "+
+			"rejects replicas/resources anywhere inside overrides, so only epp.image and "+
+			"routerMode are settable in practice)", unsupported)
+	}
+
 	obj.Object = deepMerge(obj.Object, overrides)
 	return nil
 }
+
+// consumedOverrideKeys are the provider.overrides root keys parseOverrides decodes into
+// DynamoOverrides. Lowercased, because encoding/json matches field names case-insensitively.
+var consumedOverrideKeys = map[string]bool{"routermode": true, "frontend": true, "epp": true}
 
 // deepMerge recursively merges src into dst. dst is modified in place and also
 // returned for convenience. For maps, values are merged recursively. For all

--- a/providers/dynamo/transformer.go
+++ b/providers/dynamo/transformer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dynamo
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -98,6 +99,16 @@ type ResourceOverrides struct {
 	Memory string `json:"memory,omitempty"`
 }
 
+// dynamoOverridesWire is the strict decoding boundary for keys the transformer
+// consumes itself. Spec remains opaque because it is passed through to the
+// upstream DynamoGraphDeployment and validated against the installed CRD.
+type dynamoOverridesWire struct {
+	RouterMode string             `json:"routerMode,omitempty"`
+	Frontend   *FrontendOverrides `json:"frontend,omitempty"`
+	Epp        *EPPOverrides      `json:"epp,omitempty"`
+	Spec       json.RawMessage    `json:"spec,omitempty"`
+}
+
 // Transformer handles transformation of ModelDeployment to DynamoGraphDeployment
 type Transformer struct{}
 
@@ -176,12 +187,29 @@ func (t *Transformer) parseOverrides(md *airunwayv1alpha1.ModelDeployment) (*Dyn
 		return &DynamoOverrides{}, nil
 	}
 
-	var overrides DynamoOverrides
-	if err := json.Unmarshal(md.Spec.Provider.Overrides.Raw, &overrides); err != nil {
+	// Validate root keys separately before strict typed decoding. Besides preserving
+	// a deterministic error that names every unsupported root, this keeps exact-root
+	// "spec" semantics: encoding/json would otherwise match "Spec" case-insensitively.
+	var overrideRoots map[string]interface{}
+	if err := json.Unmarshal(md.Spec.Provider.Overrides.Raw, &overrideRoots); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal overrides: %w", err)
+	}
+	if err := validateDynamoOverrideRootKeys(overrideRoots); err != nil {
+		return nil, err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(md.Spec.Provider.Overrides.Raw))
+	decoder.DisallowUnknownFields()
+	var wire dynamoOverridesWire
+	if err := decoder.Decode(&wire); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal overrides: %w", err)
 	}
 
-	return &overrides, nil
+	return &DynamoOverrides{
+		RouterMode: wire.RouterMode,
+		Frontend:   wire.Frontend,
+		Epp:        wire.Epp,
+	}, nil
 }
 
 // mapEngineType maps AI Runway engine types to Dynamo backend framework names
@@ -1131,14 +1159,6 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		return fmt.Errorf("failed to unmarshal overrides: %w", err)
 	}
 
-	// Block dangerous top-level keys to prevent privilege escalation
-	blockedKeys := []string{"apiVersion", "kind", "metadata", "status"}
-	for _, key := range blockedKeys {
-		if _, exists := overrides[key]; exists {
-			return fmt.Errorf("overriding %q is not allowed", key)
-		}
-	}
-
 	// Only "spec" may be merged into the object, plus the keys parseOverrides has already
 	// consumed into DynamoOverrides (routerMode, frontend, epp), which are inputs to this
 	// transformer rather than DynamoGraphDeployment fields. A DGD root declares
@@ -1160,23 +1180,17 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 	// has no GenerationChangedPredicate, a changing message means every reconcile writes
 	// status, which re-enqueues the object — an unbounded write loop for as long as the
 	// bad spec exists.
-	var unsupported []string
+	if err := validateDynamoOverrideRootKeys(overrides); err != nil {
+		return err
+	}
+
 	for key := range overrides {
 		if key == "spec" {
 			continue
 		}
 		if consumedOverrideKeys[strings.ToLower(key)] {
 			delete(overrides, key)
-			continue
 		}
-		unsupported = append(unsupported, key)
-	}
-	if len(unsupported) > 0 {
-		sort.Strings(unsupported)
-		return fmt.Errorf("unsupported provider.overrides key(s) %q: only \"spec\" and the "+
-			"Dynamo-specific keys routerMode, frontend and epp are supported (note the webhook "+
-			"rejects replicas/resources anywhere inside overrides, so only epp.image and "+
-			"routerMode are settable in practice)", unsupported)
 	}
 
 	obj.Object = deepMerge(obj.Object, overrides)
@@ -1186,6 +1200,33 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 // consumedOverrideKeys are the provider.overrides root keys parseOverrides decodes into
 // DynamoOverrides. Lowercased, because encoding/json matches field names case-insensitively.
 var consumedOverrideKeys = map[string]bool{"routermode": true, "frontend": true, "epp": true}
+
+func validateDynamoOverrideRootKeys(overrides map[string]interface{}) error {
+	// Block dangerous top-level keys to prevent privilege escalation.
+	blockedKeys := []string{"apiVersion", "kind", "metadata", "status"}
+	for _, key := range blockedKeys {
+		if _, exists := overrides[key]; exists {
+			return fmt.Errorf("overriding %q is not allowed", key)
+		}
+	}
+
+	var unsupported []string
+	for key := range overrides {
+		if key == "spec" || consumedOverrideKeys[strings.ToLower(key)] {
+			continue
+		}
+		unsupported = append(unsupported, key)
+	}
+	if len(unsupported) == 0 {
+		return nil
+	}
+
+	sort.Strings(unsupported)
+	return fmt.Errorf("unsupported provider.overrides key(s) %q: only \"spec\" and the "+
+		"Dynamo-specific keys routerMode, frontend and epp are supported (note the webhook "+
+		"rejects replicas/resources anywhere inside overrides, so only epp.image and "+
+		"routerMode are settable in practice)", unsupported)
+}
 
 // deepMerge recursively merges src into dst. dst is modified in place and also
 // returned for convenience. For maps, values are merged recursively. For all

--- a/providers/dynamo/upstream_strict_validation_test.go
+++ b/providers/dynamo/upstream_strict_validation_test.go
@@ -13,12 +13,16 @@ package dynamo
 import (
 	"context"
 	"fmt"
+	"io"
 	"reflect"
 	"sort"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -146,6 +150,219 @@ func TestUpstreamUpdateUsesStrictFieldValidation(t *testing.T) {
 	}
 }
 
+// TestUpstreamUpdateDoesNotIgnoreDesiredUnknownEmptyFields guards the update
+// half of strict validation. The API server may add empty defaults to the object it
+// returns, but empty values explicitly present in the desired spec must not be
+// normalized away: an installed CRD that does not declare them still needs to see a
+// strict update and reject them.
+func TestUpstreamUpdateDoesNotIgnoreDesiredUnknownEmptyFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		overrideRaw    string
+		existingFields map[string]interface{}
+		desiredFields  map[string]interface{}
+	}{
+		{
+			name:          "empty string",
+			overrideRaw:   `{"spec":{"futureField":""}}`,
+			desiredFields: map[string]interface{}{"futureField": ""},
+		},
+		{
+			name:          "empty object",
+			overrideRaw:   `{"spec":{"futureField":{}}}`,
+			desiredFields: map[string]interface{}{"futureField": map[string]interface{}{}},
+		},
+		{
+			name:        "nested empty object",
+			overrideRaw: `{"spec":{"services":{"VllmWorker":{"futureField":{}}}}}`,
+			existingFields: map[string]interface{}{
+				"services": map[string]interface{}{
+					"VllmWorker": map[string]interface{}{},
+				},
+			},
+			desiredFields: map[string]interface{}{
+				"services": map[string]interface{}{
+					"VllmWorker": map[string]interface{}{
+						"futureField": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme()
+
+			existing := &unstructured.Unstructured{}
+			setDGDGVK(existing)
+			existing.SetName("test")
+			existing.SetNamespace("default")
+			existing.SetOwnerReferences([]metav1.OwnerReference{{
+				APIVersion: airunwayv1alpha1.GroupVersion.String(),
+				Kind:       "ModelDeployment",
+				Name:       "test",
+				UID:        types.UID("test-uid"),
+			}})
+			existingSpec := map[string]interface{}{
+				"backendFramework": "vllm",
+				"serverDefault":    "",
+			}
+			for key, value := range tt.existingFields {
+				existingSpec[key] = value
+			}
+			existing.Object["spec"] = existingSpec
+
+			var called bool
+			var got string
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(_ context.Context, _ client.WithWatch, _ client.Object, opts ...client.UpdateOption) error {
+						called = true
+						o := &client.UpdateOptions{}
+						for _, opt := range opts {
+							opt.ApplyToUpdate(o)
+						}
+						got = o.FieldValidation
+						return fmt.Errorf(`strict decoding error: unknown field "spec.futureField"`)
+					},
+				}).Build()
+
+			r := NewDynamoProviderReconciler(c, scheme, "")
+			md := &airunwayv1alpha1.ModelDeployment{ObjectMeta: metav1.ObjectMeta{
+				Name: "test", Namespace: "default", UID: types.UID("test-uid"),
+			}}
+			md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+				Name: ProviderName,
+				Overrides: &runtime.RawExtension{
+					Raw: []byte(tt.overrideRaw),
+				},
+			}
+			desired := &unstructured.Unstructured{}
+			setDGDGVK(desired)
+			desired.SetName("test")
+			desired.SetNamespace("default")
+			desired.SetOwnerReferences(existing.GetOwnerReferences())
+			desiredSpec := map[string]interface{}{
+				"backendFramework": "vllm",
+			}
+			for key, value := range tt.desiredFields {
+				desiredSpec[key] = value
+			}
+			desired.Object["spec"] = desiredSpec
+
+			err := r.createOrUpdateResource(context.Background(), desired, md)
+			if err == nil {
+				t.Fatal("expected strict unknown-field rejection")
+			}
+			if !called {
+				t.Fatal("Update was not called; desired empty unknown field was normalized away")
+			}
+			if got != metav1.FieldValidationStrict {
+				t.Errorf("update fieldValidation = %q, want %q", got, metav1.FieldValidationStrict)
+			}
+			if !isUpstreamSchemaRejection(err) {
+				t.Errorf("error was not classified as an upstream schema rejection: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpstreamUpdateIgnoresDefaultsAndPersistedEmptyOverrides(t *testing.T) {
+	tests := []struct {
+		name         string
+		overrideRaw  string
+		existingSpec map[string]interface{}
+		desiredSpec  map[string]interface{}
+	}{
+		{
+			name: "server-added defaults",
+			existingSpec: map[string]interface{}{
+				"backendFramework": "vllm",
+				"name":             "",
+				"resources":        map[string]interface{}{},
+			},
+			desiredSpec: map[string]interface{}{"backendFramework": "vllm"},
+		},
+		{
+			name:        "persisted empty string override",
+			overrideRaw: `{"spec":{"futureField":""}}`,
+			existingSpec: map[string]interface{}{
+				"backendFramework": "vllm",
+				"futureField":      "",
+				"name":             "",
+			},
+			desiredSpec: map[string]interface{}{
+				"backendFramework": "vllm",
+				"futureField":      "",
+			},
+		},
+		{
+			name:        "persisted empty object override",
+			overrideRaw: `{"spec":{"futureField":{}}}`,
+			existingSpec: map[string]interface{}{
+				"backendFramework": "vllm",
+				"futureField":      map[string]interface{}{},
+				"resources":        map[string]interface{}{},
+			},
+			desiredSpec: map[string]interface{}{
+				"backendFramework": "vllm",
+				"futureField":      map[string]interface{}{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme()
+			existing := &unstructured.Unstructured{}
+			setDGDGVK(existing)
+			existing.SetName("test")
+			existing.SetNamespace("default")
+			existing.SetOwnerReferences([]metav1.OwnerReference{{
+				APIVersion: airunwayv1alpha1.GroupVersion.String(),
+				Kind:       "ModelDeployment",
+				Name:       "test",
+				UID:        types.UID("test-uid"),
+			}})
+			existing.Object["spec"] = tt.existingSpec
+
+			var updateCalled bool
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
+						updateCalled = true
+						return nil
+					},
+				}).Build()
+
+			md := &airunwayv1alpha1.ModelDeployment{ObjectMeta: metav1.ObjectMeta{
+				Name: "test", Namespace: "default", UID: types.UID("test-uid"),
+			}}
+			if tt.overrideRaw != "" {
+				md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+					Name:      ProviderName,
+					Overrides: &runtime.RawExtension{Raw: []byte(tt.overrideRaw)},
+				}
+			}
+
+			desired := &unstructured.Unstructured{}
+			setDGDGVK(desired)
+			desired.SetName("test")
+			desired.SetNamespace("default")
+			desired.SetOwnerReferences(existing.GetOwnerReferences())
+			desired.Object["spec"] = tt.desiredSpec
+
+			if err := NewDynamoProviderReconciler(c, scheme, "").createOrUpdateResource(context.Background(), desired, md); err != nil {
+				t.Fatalf("createOrUpdateResource: %v", err)
+			}
+			if updateCalled {
+				t.Fatal("Update was called even though defaults and explicit empty overrides were already satisfied")
+			}
+		})
+	}
+}
+
 // TestRenderedObjectHasNoUnknownRootFields guards the interaction between the
 // provider.overrides escape hatch and strict field validation.
 //
@@ -244,9 +461,9 @@ func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error, expected the rejection to be reported in status: %v", err)
 	}
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a strict-validation rejection; without one the " +
-			"deployment stays Failed until the default resync even after the upstream is upgraded")
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a strict-validation rejection",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -366,6 +583,17 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			want: false,
 		},
 		{
+			// Even the complete diagnostic can occur inside an echoed value. The real
+			// strict-decoding cause is terminal; this value is followed by its validation
+			// reason and must not be classified as an upstream mismatch.
+			name: "not ours: full strict diagnostic echoed inside a user value",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					`--served-model-name=strict decoding error: unknown field "spec.fake"`, "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
 			name: "not ours: typed-object wrapper without the schema diagnostic",
 			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
 			want: false,
@@ -377,6 +605,25 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
 				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableUpstreamWriteErrorRecognizesWrappedEOF(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "EOF", err: io.EOF},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF},
+		{name: "broken pipe", err: syscall.EPIPE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !isRetryableUpstreamWriteError(wrapResourceWriteError(tt.err, true)) {
+				t.Errorf("wrapped %v was not classified as retryable", tt.err)
 			}
 		})
 	}
@@ -415,27 +662,80 @@ func TestUnsupportedOverrideKeyIsRejected(t *testing.T) {
 // TestDocumentedOverrideKeysStillAccepted is the other half: the documented keys, in both
 // the documented spelling and the capitalisation encoding/json also accepts, must work.
 func TestDocumentedOverrideKeysStillAccepted(t *testing.T) {
-	md := &airunwayv1alpha1.ModelDeployment{}
-	md.Name = "test"
-	md.Namespace = "default"
-	md.Spec.Model = airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace}
-	md.Spec.Engine = airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM}
-	md.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 1}}
-	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
-		Name: "dynamo",
-		Overrides: &runtime.RawExtension{
-			Raw: []byte(`{"routerMode":"kv","epp":{"image":"custom:v1"},"spec":{"backendFramework":"sglang"}}`),
+	testCases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "documented spelling",
+			raw:  `{"routerMode":"kv","epp":{"image":"custom:v1"},"spec":{"backendFramework":"sglang"}}`,
+		},
+		{
+			name: "case-insensitive consumed keys",
+			raw:  `{"RouterMode":"kv","EPP":{"Image":"custom:v1"},"spec":{"backendFramework":"sglang"}}`,
 		},
 	}
 
-	results, err := NewTransformer().Transform(context.Background(), md)
-	if err != nil {
-		t.Fatalf("documented override keys were rejected: %v", err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			md := newTestMD("test", "default")
+			md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+				Name:      "dynamo",
+				Overrides: &runtime.RawExtension{Raw: []byte(tc.raw)},
+			}
+
+			results, err := NewTransformer().Transform(context.Background(), md)
+			if err != nil {
+				t.Fatalf("documented override keys were rejected: %v", err)
+			}
+			// The opaque upstream spec override still lands.
+			got, _, _ := unstructured.NestedString(results[0].Object, "spec", "backendFramework")
+			if got != "sglang" {
+				t.Errorf("spec override did not apply: backendFramework = %q, want %q", got, "sglang")
+			}
+		})
 	}
-	// the spec override still lands
-	got, _, _ := unstructured.NestedString(results[0].Object, "spec", "backendFramework")
-	if got != "sglang" {
-		t.Errorf("spec override did not apply: backendFramework = %q, want %q", got, "sglang")
+}
+
+func TestConsumedOverrideUnknownFieldsAreRejected(t *testing.T) {
+	testCases := []struct {
+		name         string
+		raw          string
+		unknownField string
+	}{
+		{
+			name:         "epp child",
+			raw:          `{"epp":{"imag":"custom:v1"}}`,
+			unknownField: "imag",
+		},
+		{
+			name:         "frontend child",
+			raw:          `{"frontend":{"bogus":true}}`,
+			unknownField: "bogus",
+		},
+		{
+			name:         "frontend resources child",
+			raw:          `{"frontend":{"resources":{"cpus":"4"}}}`,
+			unknownField: "cpus",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			md := newTestMD("test", "default")
+			md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+				Name:      "dynamo",
+				Overrides: &runtime.RawExtension{Raw: []byte(tc.raw)},
+			}
+
+			_, err := NewTransformer().Transform(context.Background(), md)
+			if err == nil {
+				t.Fatalf("unknown consumed override field %q was silently accepted", tc.unknownField)
+			}
+			if want := fmt.Sprintf(`unknown field %q`, tc.unknownField); !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q does not identify %q", err, want)
+			}
+		})
 	}
 }
 
@@ -570,25 +870,431 @@ func TestReconcileTransformFailureClearsStaleStatus(t *testing.T) {
 	}
 }
 
-// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
-// write failure that is neither a transform error nor a schema rejection.
-//
-// It is the most common of the three, and it must not be the one that still reports healthy.
-// Without the clearing, a previously-Running deployment hitting a transient upstream error
-// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
-// this guards against.
-func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+// TestReconcileTransientWriteFailurePreservesLastKnownStatus covers a retryable update
+// failure after the controller has observed an owned upstream resource. The ambiguous write
+// does not prove that existing workload stopped serving, so last-known status is retained.
+func TestReconcileTransientWriteFailurePreservesLastKnownStatus(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
 	controllerutil.AddFinalizer(md, FinalizerName)
 	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
 	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
-	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
 
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, "sglang", "spec", "backendFramework"); err != nil {
+		t.Fatalf("mutate existing spec: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, string(DynamoStateSuccessful), "status", "state"); err != nil {
+		t.Fatalf("mark existing resource ready: %v", err)
+	}
+
+	var updateCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					updateCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.RequeueAfter != RequeueInterval {
+		t.Errorf("RequeueAfter = %s, want %s", res.RequeueAfter, RequeueInterval)
+	}
+	if !updateCalled {
+		t.Fatal("Update was never called; test did not exercise the existing-resource path")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var createdStatus metav1.ConditionStatus
+	var readyStatus metav1.ConditionStatus
+	var readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+			createdStatus = cond.Status
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if createdStatus != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", createdStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+		t.Errorf("Status.Phase = %q, want Running", updated.Status.Phase)
+	}
+	if readyStatus != metav1.ConditionTrue || readyReason != "DeploymentReady" {
+		t.Errorf("Ready = %q reason %q, want True reason DeploymentReady", readyStatus, readyReason)
+	}
+	if updated.Status.Endpoint == nil || updated.Status.Endpoint.Service != "stale-svc" || updated.Status.Endpoint.Port != 8000 {
+		t.Errorf("Status.Endpoint = %+v, want stale-svc:8000", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas == nil || updated.Status.Replicas.Desired != 1 || updated.Status.Replicas.Ready != 1 || updated.Status.Replicas.Available != 1 {
+		t.Errorf("Status.Replicas = %+v, want 1 desired/ready/available", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileTransientWriteFailureOnUnreadyResourceFailsClosed proves that ownership and
+// an active object are not enough to retain stale serving status. The current upstream
+// observation is explicitly non-serving, so an ambiguous write failure must fail closed.
+func TestReconcileTransientWriteFailureOnUnreadyResourceFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, "sglang", "spec", "backendFramework"); err != nil {
+		t.Fatalf("mutate existing spec: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, string(DynamoStateDeploying), "status", "state"); err != nil {
+		t.Fatalf("mark existing resource unready: %v", err)
+	}
+
+	var updateCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					updateCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s", res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+	if !updateCalled {
+		t.Fatal("Update was never called; test did not exercise the active unready-resource path")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	created := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeResourceCreated)
+	if created == nil || created.Status != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %+v, want False", created)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse {
+		t.Errorf("Ready = %+v, want False", ready)
+	}
+}
+
+// TestReconcileTransientUpdateFailureOnTerminatingResourceFailsClosed covers an owned
+// upstream object that was observed but is already terminating. A retryable update failure
+// cannot preserve serving status in that case because the last observation says the workload
+// is going away, not that it remains safely available.
+func TestReconcileTransientUpdateFailureOnTerminatingResourceFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, "sglang", "spec", "backendFramework"); err != nil {
+		t.Fatalf("mutate existing spec: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, string(DynamoStateSuccessful), "status", "state"); err != nil {
+		t.Fatalf("mark existing resource ready: %v", err)
+	}
+	deletingAt := metav1.Now()
+	existing.SetDeletionTimestamp(&deletingAt)
+	existing.SetFinalizers([]string{"test.airunway.ai/upstream-cleanup"})
+
+	var updateCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					updateCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a transient update of a terminating resource",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+	if !updateCalled {
+		t.Fatal("Update was never called; test did not exercise the terminating existing-resource path")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	created := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeResourceCreated)
+	if created == nil || created.Status != metav1.ConditionFalse || created.Reason != "CreateFailed" {
+		t.Errorf("ResourceCreated = %+v, want False reason CreateFailed", created)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "CreateFailed" {
+		t.Errorf("Ready = %+v, want False reason CreateFailed", ready)
+	}
+}
+
+// TestReconcileTransientUpstreamGetFailureFailsClosed covers a retryable read failure before
+// the provider can determine whether the upstream object exists, is owned, or is active. With
+// no verified observation, stale serving status is unsafe to preserve.
+func TestReconcileTransientUpstreamGetFailureFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	var upstreamGetCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					upstreamGetCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream read outage"))
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a transient upstream read failure",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+	if !upstreamGetCalled {
+		t.Fatal("upstream Get was never called; test did not exercise the unverified-observation path")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	created := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeResourceCreated)
+	if created == nil || created.Status != metav1.ConditionFalse || created.Reason != "CreateFailed" {
+		t.Errorf("ResourceCreated = %+v, want False reason CreateFailed", created)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "CreateFailed" {
+		t.Errorf("Ready = %+v, want False reason CreateFailed", ready)
+	}
+}
+
+// TestReconcileOwnedUpdateConflictRetriesPromptly covers a resourceVersion race after the
+// controller has read and ownership-checked an existing DynamoGraphDeployment. A 409 from
+// that owned update is transient and should trigger a fresh read promptly, while preserving
+// the last-known serving status.
+func TestReconcileOwnedUpdateConflictRetriesPromptly(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "live-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, "sglang", "spec", "backendFramework"); err != nil {
+		t.Fatalf("mutate existing spec: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, string(DynamoStateSuccessful), "status", "state"); err != nil {
+		t.Fatalf("mark existing resource ready: %v", err)
+	}
+
+	var updateCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					updateCalled = true
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: DynamoAPIGroup, Resource: "dynamographdeployments"},
+						obj.GetName(), fmt.Errorf("the object has been modified"),
+					)
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; a conflict should requeue: %v", err)
+	}
+	if !updateCalled {
+		t.Fatal("Update was never called; test did not exercise the owned existing-resource path")
+	}
+	if res.Requeue || res.RequeueAfter != time.Second {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after an update conflict",
+			res.Requeue, res.RequeueAfter, time.Second)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+		t.Errorf("Status.Phase = %q, want Running", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint == nil || updated.Status.Endpoint.Service != "live-svc" {
+		t.Errorf("Status.Endpoint = %+v, want live-svc", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas == nil || updated.Status.Replicas.Ready != 1 {
+		t.Errorf("Status.Replicas = %+v, want last-known ready count preserved", updated.Status.Replicas)
+	}
+	created := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeResourceCreated)
+	if created == nil || created.Reason != "ResourceConflict" {
+		t.Errorf("ResourceCreated = %+v, want reason ResourceConflict", created)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Errorf("Ready = %+v, want last-known True condition preserved", ready)
+	}
+}
+
+// TestReconcileTransientCreateFailureClearsStaleStatus covers the same retryable API error
+// when the controller has just observed that no upstream resource exists. There is no known
+// workload to preserve, so stale serving status must be cleared while retrying promptly.
+func TestReconcileTransientCreateFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	var createCalled bool
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					createCalled = true
 					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
 				}
 				return cl.Create(ctx, obj, opts...)
@@ -602,32 +1308,161 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
 	}
-	// A generic write failure is usually transient, so it must retry. Without a requeue the
-	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
-	// deployment sits Failed with no endpoint until the default resync.
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a transient write failure")
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a transient create failure",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+	if !createCalled {
+		t.Fatal("Create was never called; test did not exercise the absent-resource path")
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	var createdReason string
-	var readyStatus metav1.ConditionStatus
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	if condition := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeReady); condition == nil || condition.Status != metav1.ConditionFalse {
+		t.Errorf("Ready = %+v, want False", condition)
+	}
+}
+
+// TestReconcileNotFoundWriteFailureClearsStaleStatus covers a definite API-server 404.
+// Unlike an ambiguous 5xx or transport failure, a 404 proves this write did not update an
+// existing workload, so stale serving status must be cleared while retrying promptly.
+func TestReconcileNotFoundWriteFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					return apierrors.NewNotFound(
+						schema.GroupResource{Group: DynamoAPIGroup, Resource: "dynamographdeployments"},
+						obj.GetName(),
+					)
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the 404 should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a 404",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	if condition := meta.FindStatusCondition(updated.Status.Conditions, airunwayv1alpha1.ConditionTypeReady); condition == nil || condition.Status != metav1.ConditionFalse {
+		t.Errorf("Ready = %+v, want False", condition)
+	}
+}
+
+// TestReconcileValidationFailureIsTerminal distinguishes deterministic admission failures
+// from retryable transport errors and schema-version mismatches. It fails closed and retries
+// slowly so an out-of-band policy or CRD repair can recover it without a spec edit.
+func TestReconcileValidationFailureIsTerminal(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	rejection := apierrors.NewInvalid(
+		schema.GroupKind{Group: DynamoAPIGroup, Kind: DynamoGraphDeploymentKind},
+		"test",
+		field.ErrorList{field.Invalid(
+			field.NewPath("spec", "services", "VllmWorker", "replicas"),
+			int64(0),
+			"must be greater than zero",
+		)},
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					return rejection
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the validation failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s for a deterministic validation failure",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
 	for _, cond := range updated.Status.Conditions {
-		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
-			createdReason = cond.Reason
-		}
-		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
-			readyStatus = cond.Status
-		}
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
 	}
-	if createdReason != "CreateFailed" {
-		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
 	}
-	if readyStatus != metav1.ConditionFalse {
-		t.Errorf("Ready = %q, want False", readyStatus)
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeResourceCreated]; got != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
 	}
 	if updated.Status.Endpoint != nil {
 		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
@@ -662,10 +1497,15 @@ func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
 	r := NewDynamoProviderReconciler(c, scheme, "")
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile returned an error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s for an ownership conflict",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment

--- a/providers/dynamo/upstream_strict_validation_test.go
+++ b/providers/dynamo/upstream_strict_validation_test.go
@@ -1,0 +1,679 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package dynamo
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
+)
+
+// Regression tests for upstream schema compatibility.
+//
+// Every write to the upstream resource must carry fieldValidation=Strict, so the API
+// server rejects fields the installed CRD does not declare instead of silently pruning
+// them. Without it the shim can render a field the cluster drops without error, leaving
+// a workload that reports healthy but cannot serve.
+//
+// These assert the option reaches the client. They deliberately do NOT assert the API
+// server's behaviour — the fake client has no structural schema and cannot prune, which
+// is precisely why no pre-existing test caught this bug. Proving the rejection itself needs a
+// real API server — there is no envtest harness for the providers yet, so that coverage is a
+// documented follow-up rather than something these tests provide.
+
+func TestUpstreamCreateUsesStrictFieldValidation(t *testing.T) {
+	scheme := newScheme()
+
+	var got string
+	var called bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			called = true
+			o := &client.CreateOptions{}
+			for _, opt := range opts {
+				opt.ApplyToCreate(o)
+			}
+			got = o.FieldValidation
+			return cl.Create(ctx, obj, opts...)
+		},
+	}).Build()
+
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.UID = types.UID("test-uid")
+
+	dgd := &unstructured.Unstructured{}
+	setDGDGVK(dgd)
+	dgd.SetName("test")
+	dgd.SetNamespace("default")
+	dgd.Object["spec"] = map[string]interface{}{"backendFramework": "vllm"}
+
+	if err := r.createOrUpdateResource(context.Background(), dgd, md); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("Create was never called — test is not exercising the create path")
+	}
+	if got != metav1.FieldValidationStrict {
+		t.Errorf("create fieldValidation = %q, want %q (unknown fields must be rejected, not pruned)",
+			got, metav1.FieldValidationStrict)
+	}
+}
+
+func TestUpstreamUpdateUsesStrictFieldValidation(t *testing.T) {
+	scheme := newScheme()
+
+	existing := &unstructured.Unstructured{}
+	setDGDGVK(existing)
+	existing.SetName("test")
+	existing.SetNamespace("default")
+	existing.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "test",
+		UID:        types.UID("test-uid"),
+	}})
+	// Differs from desired, so createOrUpdateResource takes the update path.
+	existing.Object["spec"] = map[string]interface{}{"backendFramework": "sglang"}
+
+	var got string
+	var called bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				called = true
+				o := &client.UpdateOptions{}
+				for _, opt := range opts {
+					opt.ApplyToUpdate(o)
+				}
+				got = o.FieldValidation
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.UID = types.UID("test-uid")
+
+	desired := &unstructured.Unstructured{}
+	setDGDGVK(desired)
+	desired.SetName("test")
+	desired.SetNamespace("default")
+	desired.SetOwnerReferences(existing.GetOwnerReferences())
+	desired.Object["spec"] = map[string]interface{}{"backendFramework": "vllm"}
+
+	if err := r.createOrUpdateResource(context.Background(), desired, md); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("Update was never called — test is not exercising the update path")
+	}
+	if got != metav1.FieldValidationStrict {
+		t.Errorf("update fieldValidation = %q, want %q (unknown fields must be rejected, not pruned)",
+			got, metav1.FieldValidationStrict)
+	}
+}
+
+// TestRenderedObjectHasNoUnknownRootFields guards the interaction between the
+// provider.overrides escape hatch and strict field validation.
+//
+// parseOverrides decodes routerMode/frontend/epp into DynamoOverrides to shape how this
+// transformer renders. applyOverrides then deep-merges the *raw* override map into the
+// object, so before this change those already-consumed keys also landed at the
+// object root as siblings of apiVersion/spec — fields no DynamoGraphDeployment CRD
+// declares at any version.
+//
+// The API server pruned them silently, so it looked like it worked. Under
+// fieldValidation=Strict an unknown root field is a hard rejection, which would have
+// broken the override example documented in docs/controller-architecture.md on a
+// perfectly up-to-date cluster.
+func TestRenderedObjectHasNoUnknownRootFields(t *testing.T) {
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.Spec.Model = airunwayv1alpha1.ModelSpec{
+		ID:     "Qwen/Qwen3-0.6B",
+		Source: airunwayv1alpha1.ModelSourceHuggingFace,
+	}
+	md.Spec.Engine = airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM}
+	md.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 1}}
+	// Only keys admission actually permits. The webhook rejects "replicas" and "resources"
+	// RECURSIVELY (modeldeployment_webhook.go sizingOverrideKeys), so frontend.replicas and
+	// epp.replicas cannot reach a cluster and must not be used as fixtures here.
+	// "RouterMode" is the interesting spelling: encoding/json matches field names
+	// case-insensitively, so parseOverrides consumes it into DynamoOverrides just as it does
+	// the documented lowercase form, and a case-sensitive strip would leak it to the root.
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name: "dynamo",
+		Overrides: &runtime.RawExtension{
+			Raw: []byte(`{"routerMode":"kv","RouterMode":"round-robin","epp":{"image":"custom:v1"}}`),
+		},
+	}
+
+	results, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+
+	allowed := map[string]bool{"apiVersion": true, "kind": true, "metadata": true, "spec": true}
+	var unknown []string
+	for k := range results[0].Object {
+		if !allowed[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	sort.Strings(unknown)
+	if len(unknown) > 0 {
+		t.Errorf("rendered DynamoGraphDeployment has root fields the CRD does not declare: %v\n"+
+			"strict field validation will reject the write; keys consumed by parseOverrides "+
+			"must be stripped before applyOverrides merges the raw map", unknown)
+	}
+}
+
+// TestReconcileRequeuesOnStrictRejection covers the recovery path for the failure mode
+// strict validation introduces.
+//
+// A schema rejection is terminal from the controller's point of view: the remedy is an
+// out-of-band upstream upgrade. Nothing in the watch set would re-trigger this reconcile
+// afterwards — the provider-config watch fires only on Spec/Ready changes, and no upstream
+// object exists to watch because the write failed. Without an explicit requeue the
+// deployment would sit in Failed until controller-runtime's ~10h resync, so an operator
+// who fixed their cluster would see nothing change.
+func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Seed the Running-era status. Without this the clearing below is a no-op the
+	// assertions cannot observe, and deleting it from the controller would not fail
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	rejection := apierrors.NewBadRequest(
+		`DynamoGraphDeployment in version "v1alpha1" cannot be handled as a DynamoGraphDeployment: ` +
+			`strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					return rejection
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error, expected the rejection to be reported in status: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a strict-validation rejection; without one the " +
+			"deployment stays Failed until the default resync even after the upstream is upgraded")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reasons := map[string]string{}
+	statuses := map[string]metav1.ConditionStatus{}
+	for _, cond := range updated.Status.Conditions {
+		reasons[cond.Type] = cond.Reason
+		statuses[cond.Type] = cond.Status
+	}
+
+	// ResourceCreated carries the distinguishing reason so an upstream schema mismatch is
+	// greppable rather than buried in free text under a generic CreateFailed.
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "IncompatibleUpstream" {
+		t.Errorf("ResourceCreated reason = %q, want %q", got, "IncompatibleUpstream")
+	}
+
+	// docs/providers.md promises the offending field is named in status.message; hold it.
+	if !strings.Contains(updated.Status.Message, "frontendSidecar") {
+		t.Errorf("status.message does not name the offending field: %q", updated.Status.Message)
+	}
+
+	// Ready must be forced False. The failure this guards is precisely a deployment that reports healthy
+	// while unable to serve, so leaving the primary health condition stale would reproduce
+	// the original sin in a new place.
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want %q", got, metav1.ConditionFalse)
+	}
+	// docs/providers.md promises BOTH conditions carry this reason.
+	if got := reasons[airunwayv1alpha1.ConditionTypeReady]; got != "IncompatibleUpstream" {
+		t.Errorf("Ready reason = %q, want IncompatibleUpstream", got)
+	}
+
+	// Stale endpoint/replicas must be cleared. Reporting Failed alongside a live endpoint
+	// and "1/1 ready" is the same contradiction.
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil — a Failed deployment must not still advertise an endpoint", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+
+	// ProviderCompatible is deliberately NOT touched here: it is set True earlier in the
+	// same reconcile, so flipping it would rewrite LastTransitionTime on every 30s requeue
+	// and the condition would never settle.
+	if got := statuses[airunwayv1alpha1.ConditionTypeProviderCompatible]; got != metav1.ConditionTrue {
+		t.Errorf("ProviderCompatible = %q, want %q — flipping it here causes permanent status churn",
+			got, metav1.ConditionTrue)
+	}
+}
+
+// TestIsUpstreamSchemaRejection pins the matcher to error strings actually observed against
+// a live cluster, not invented ones. The API server's response class varies by write path,
+// which is why this matches on message rather than status code:
+//
+//	CR create/update      -> 400 BadRequest
+//	CR merge patch        -> 422 Invalid
+//	SSA on a built-in type-> 500, from the field manager rather than field validation
+//
+// The negative cases are the reason a status-class check was rejected: an IsInvalid gate
+// would capture ordinary CEL and type violations and report them as an upstream version
+// mismatch, sending an operator to upgrade a cluster that is already fine.
+func TestIsUpstreamSchemaRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "observed: CR create against an older CRD (400)",
+			err: apierrors.NewBadRequest(`DynamoGraphDeployment in version "v1alpha1" cannot be handled as a ` +
+				`DynamoGraphDeployment: strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`),
+			want: true,
+		},
+		{
+			name: "observed: server-side apply on a built-in type (500)",
+			err: fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): " +
+				".spec.bogusUnknownField: field not declared in schema"),
+			want: true,
+		},
+		{
+			name: "not ours: CEL or type validation failure the user must fix",
+			err:  apierrors.NewInvalid(schema.GroupKind{Group: "nvidia.com", Kind: "DynamoGraphDeployment"}, "x", nil),
+			want: false,
+		},
+		{
+			name: "not ours: conflict",
+			err:  apierrors.NewConflict(schema.GroupResource{Resource: "dynamographdeployments"}, "x", fmt.Errorf("stale")),
+			want: false,
+		},
+		{
+			// The reason the needle is "strict decoding error" and not the bare
+			// "unknown field": an Invalid status echoes the offending value back, so a
+			// user-supplied string can contain the bare phrase. Classifying this as an
+			// upstream mismatch would tell an operator to upgrade a cluster that is fine,
+			// and retry every 30s forever.
+			name: "not ours: Invalid echoing a user value that contains the bare phrase",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=unknown field probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
+				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUnsupportedOverrideKeyIsRejected covers the reject-rather-than-drop decision.
+//
+// Silently ignoring an override key would reproduce the failure strict validation exists to surface:
+// the override is visible in the ModelDeployment, absent from the rendered object, and the
+// deployment reports healthy. So an unsupported root key must be a loud error.
+//
+// "Spec" (capital S) is the interesting case — encoding/json would NOT decode it into
+// DynamoOverrides, so it is neither consumed nor a valid root key and must be rejected.
+func TestUnsupportedOverrideKeyIsRejected(t *testing.T) {
+	for _, key := range []string{"Spec", "totallyUnknown", "services"} {
+		t.Run(key, func(t *testing.T) {
+			md := &airunwayv1alpha1.ModelDeployment{}
+			md.Name = "test"
+			md.Namespace = "default"
+			md.Spec.Model = airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace}
+			md.Spec.Engine = airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM}
+			md.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 1}}
+			md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+				Name:      "dynamo",
+				Overrides: &runtime.RawExtension{Raw: []byte(`{"` + key + `":{"x":1}}`)},
+			}
+
+			if _, err := NewTransformer().Transform(context.Background(), md); err == nil {
+				t.Errorf("override root key %q was accepted; it must be rejected rather than "+
+					"silently dropped, or the user gets a setting that does nothing", key)
+			}
+		})
+	}
+}
+
+// TestDocumentedOverrideKeysStillAccepted is the other half: the documented keys, in both
+// the documented spelling and the capitalisation encoding/json also accepts, must work.
+func TestDocumentedOverrideKeysStillAccepted(t *testing.T) {
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.Spec.Model = airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace}
+	md.Spec.Engine = airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM}
+	md.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 1}}
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name: "dynamo",
+		Overrides: &runtime.RawExtension{
+			Raw: []byte(`{"routerMode":"kv","epp":{"image":"custom:v1"},"spec":{"backendFramework":"sglang"}}`),
+		},
+	}
+
+	results, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("documented override keys were rejected: %v", err)
+	}
+	// the spec override still lands
+	got, _, _ := unstructured.NestedString(results[0].Object, "spec", "backendFramework")
+	if got != "sglang" {
+		t.Errorf("spec override did not apply: backendFramework = %q, want %q", got, "sglang")
+	}
+}
+
+// TestUnsupportedOverrideErrorIsDeterministic guards against a status-write loop.
+//
+// Go randomises map iteration, so an implementation that returns on the first unsupported
+// key produces a different message per call for the same spec. That message lands in
+// status.message, and because the ModelDeployment watch has no GenerationChangedPredicate,
+// a changing message means every reconcile writes status, which re-enqueues the object.
+func TestUnsupportedOverrideErrorIsDeterministic(t *testing.T) {
+	newMD := func() *airunwayv1alpha1.ModelDeployment {
+		md := &airunwayv1alpha1.ModelDeployment{}
+		md.Name = "test"
+		md.Namespace = "default"
+		md.Spec.Model = airunwayv1alpha1.ModelSpec{ID: "Qwen/Qwen3-0.6B", Source: airunwayv1alpha1.ModelSourceHuggingFace}
+		md.Spec.Engine = airunwayv1alpha1.EngineSpec{Type: airunwayv1alpha1.EngineTypeVLLM}
+		md.Spec.Resources = &airunwayv1alpha1.ResourceSpec{GPU: &airunwayv1alpha1.GPUSpec{Count: 1}}
+		md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+			Name:      "dynamo",
+			Overrides: &runtime.RawExtension{Raw: []byte(`{"alpha":{"a":1},"beta":{"b":2},"gamma":{"c":3}}`)},
+		}
+		return md
+	}
+
+	var first string
+	for i := 0; i < 200; i++ {
+		_, err := NewTransformer().Transform(context.Background(), newMD())
+		if err == nil {
+			t.Fatal("expected an error for unsupported override keys")
+		}
+		if i == 0 {
+			first = err.Error()
+			continue
+		}
+		if err.Error() != first {
+			t.Fatalf("override rejection message is nondeterministic across calls:\n  %q\n  %q\n"+
+				"a changing status.message re-enqueues the object every reconcile", first, err.Error())
+		}
+	}
+	// All offenders should be named, not just whichever the map yielded first.
+	for _, want := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(first, want) {
+			t.Errorf("error %q does not mention offending key %q", first, want)
+		}
+	}
+}
+
+// TestConsumedOverrideKeysMatchesStruct keeps the hand-written map in sync with
+// DynamoOverrides. Drift in the struct-has-field-map-doesn't direction leaks the key to the
+// object root; drift the other way silently drops a user's override — both are the failure
+// class strict validation exists to surface.
+func TestConsumedOverrideKeysMatchesStruct(t *testing.T) {
+	typ := reflect.TypeOf(DynamoOverrides{})
+	fromStruct := map[string]bool{}
+	for i := 0; i < typ.NumField(); i++ {
+		tag := typ.Field(i).Tag.Get("json")
+		name := strings.Split(tag, ",")[0]
+		if name == "" || name == "-" {
+			continue
+		}
+		fromStruct[strings.ToLower(name)] = true
+	}
+	for k := range fromStruct {
+		if !consumedOverrideKeys[k] {
+			t.Errorf("DynamoOverrides has json key %q but consumedOverrideKeys does not — it will leak to the object root", k)
+		}
+	}
+	for k := range consumedOverrideKeys {
+		if !fromStruct[k] {
+			t.Errorf("consumedOverrideKeys has %q but DynamoOverrides does not — that override would be silently dropped", k)
+		}
+	}
+}
+
+// TestReconcileTransformFailureClearsStaleStatus covers the OTHER failure branch: a spec the
+// transformer refuses to render (here, an unsupported provider.overrides root key).
+//
+// It must get the same treatment as an upstream rejection — Ready forced False and the
+// Running-era endpoint/replica counts dropped. Without that, a previously-Running deployment
+// edited into something unrenderable reports Failed while still advertising a live endpoint
+// and "1/1 ready", which is the contradiction this guards against.
+func TestReconcileTransformFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name:      md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{Raw: []byte(`{"totallyBogusRootKey":{"a":1}}`)},
+	}
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason, readyReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "TransformFailed" {
+		t.Errorf("ResourceCreated reason = %q, want TransformFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if readyReason != "TransformFailed" {
+		t.Errorf("Ready reason = %q, want TransformFailed", readyReason)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
+// write failure that is neither a transform error nor a schema rejection.
+//
+// It is the most common of the three, and it must not be the one that still reports healthy.
+// Without the clearing, a previously-Running deployment hitting a transient upstream error
+// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
+// this guards against.
+func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == DynamoGraphDeploymentKind {
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	// A generic write failure is usually transient, so it must retry. Without a requeue the
+	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
+	// deployment sits Failed with no endpoint until the default resync.
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a transient write failure")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileOwnershipConflictUsesItsOwnReason covers the ownership-collision branch.
+//
+// An upstream object of the right name already exists but belongs to someone else. That is
+// terminal — unlike a transient API 409 — so it is reported under its own reason rather than
+// the generic CreateFailed.
+func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Same name, different owner.
+	foreign := &unstructured.Unstructured{}
+	setDGDGVK(foreign)
+	foreign.SetName("test")
+	foreign.SetNamespace("default")
+	foreign.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "someone-else",
+		UID:        types.UID("a-different-uid"),
+	}})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
+	r := NewDynamoProviderReconciler(c, scheme, "")
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var reason, readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			reason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyReason = cond.Reason
+		}
+	}
+	// The branch comment claims "Ready is set below unconditionally with this same reason".
+	// Hold it: an operator alerting on Ready.reason=ResourceConflict needs to distinguish a
+	// collision needing manual intervention from a transient CreateFailed that will retry.
+	if readyReason != "ResourceConflict" {
+		t.Errorf("Ready reason = %q, want ResourceConflict", readyReason)
+	}
+	if reason != "ResourceConflict" {
+		t.Errorf("ResourceCreated reason = %q, want ResourceConflict — an ownership collision "+
+			"must be distinguishable from a generic create failure", reason)
+	}
+}

--- a/providers/dynamo/upstream_strict_validation_test.go
+++ b/providers/dynamo/upstream_strict_validation_test.go
@@ -355,6 +355,21 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			}),
 			want: false,
 		},
+		{
+			// The needle requires BOTH halves. An Invalid status echoes the offending value
+			// back, so a user-supplied string containing only the prefix must not match.
+			name: "not ours: 'strict decoding error' echoed without an unknown-field cause",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=strict decoding error probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
+			name: "not ours: typed-object wrapper without the schema diagnostic",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
+			want: false,
+		},
 		{name: "nil", err: nil, want: false},
 	}
 

--- a/providers/kaito/controller.go
+++ b/providers/kaito/controller.go
@@ -21,7 +21,10 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"io"
+	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +63,10 @@ const (
 	// RequeueInterval is the default requeue interval for periodic reconciliation
 	RequeueInterval = 30 * time.Second
 
+	// ExternalRecoveryInterval retries failures that require an out-of-band fix without
+	// hot-looping while the installed upstream or resource ownership remains unchanged.
+	ExternalRecoveryInterval = 5 * time.Minute
+
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
 )
@@ -68,6 +76,13 @@ const (
 // compatibility" section of docs/providers.md. kubectl sends strict validation by default;
 // Go clients do not, so it must be set explicitly on every upstream write.
 var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// strictUnknownFieldRejection matches the terminal diagnostic emitted by apimachinery's
+// strict decoder. Anchoring the diagnostic at the end keeps an ordinary validation error
+// from matching when its echoed user value contains the same words.
+var strictUnknownFieldRejection = regexp.MustCompile(
+	`(^|: )strict decoding error: unknown field "(\\.|[^"\\])*"(, unknown field "(\\.|[^"\\])*")*$`,
+)
 
 // isUpstreamSchemaRejection reports whether err is the API server refusing a field the
 // installed upstream does not declare, as opposed to any other rejection.
@@ -94,12 +109,11 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 	msg := err.Error()
 
-	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
-	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
-	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
-	// containing either phrase on its own must not be misclassified as a version mismatch
-	// and retried forever.
-	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+	// Custom-resource paths: match the complete terminal diagnostic, not independent
+	// substrings. An Invalid status echoes the offending value back, so a user-supplied
+	// string may itself contain both phrases and must not be misclassified as a version
+	// mismatch and retried forever.
+	if strictUnknownFieldRejection.MatchString(msg) {
 		return true
 	}
 
@@ -112,6 +126,56 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 
 	return false
+}
+
+// isRetryableUpstreamWriteError reports failures that can recover without changing the
+// ModelDeployment or cluster configuration. These must not erase last-known serving status:
+// a failed or ambiguous API response does not mean the existing workload stopped serving.
+func isRetryableUpstreamWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.IsConflict(err) || errors.IsAlreadyExists(err) ||
+		errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsTooManyRequests(err) ||
+		errors.IsServiceUnavailable(err) || errors.IsInternalError(err) {
+		return true
+	}
+
+	var status errors.APIStatus
+	if stderrors.As(err, &status) && status.Status().Code >= 500 {
+		return true
+	}
+
+	return stderrors.Is(err, context.DeadlineExceeded) ||
+		stderrors.Is(err, io.EOF) || stderrors.Is(err, io.ErrUnexpectedEOF) ||
+		stderrors.Is(err, syscall.EPIPE) ||
+		utilnet.IsTimeout(err) || utilnet.IsProbableEOF(err) ||
+		utilnet.IsConnectionReset(err) || utilnet.IsConnectionRefused(err) ||
+		utilnet.IsHTTP2ConnectionLost(err)
+}
+
+// resourceWriteError records whether the target was observed as owned, active, and serving
+// before its write. A transient update failure can retain last-known serving status only after
+// that safe observation; create failures, terminating or unready resources, and unverified
+// read failures cannot.
+type resourceWriteError struct {
+	err                              error
+	resourceWasOwnedActiveAndServing bool
+}
+
+func (e *resourceWriteError) Error() string { return e.err.Error() }
+func (e *resourceWriteError) Unwrap() error { return e.err }
+
+func wrapResourceWriteError(err error, resourceWasOwnedActiveAndServing bool) error {
+	if err == nil {
+		return nil
+	}
+	return &resourceWriteError{err: err, resourceWasOwnedActiveAndServing: resourceWasOwnedActiveAndServing}
+}
+
+func canPreserveLastKnownStatus(err error) bool {
+	var writeErr *resourceWriteError
+	return stderrors.As(err, &writeErr) && writeErr.resourceWasOwnedActiveAndServing
 }
 
 // KaitoProviderReconciler reconciles ModelDeployment resources for the KAITO provider
@@ -224,12 +288,6 @@ func (r *KaitoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Create or update the Workspace
 	for _, resource := range resources {
 		if err := r.createOrUpdateResource(ctx, resource, &md); err != nil {
-			// API conflict errors (stale resourceVersion) are transient — requeue to retry
-			if errors.IsConflict(err) {
-				logger.Info("Resource version conflict, requeuing", "name", resource.GetName(), "kind", resource.GetKind())
-				return ctrl.Result{Requeue: true}, nil
-			}
-
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
 			// Strict field validation rejected the write: the cluster does not accept a field
 			// this provider renders. Give it its own reason so an operator can tell it apart
@@ -258,33 +316,56 @@ func (r *KaitoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 					return ctrl.Result{}, statusErr
 				}
-				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+				return ctrl.Result{RequeueAfter: ExternalRecoveryInterval}, nil
+			}
+			// Conflicts, throttling, server failures, and transport interruptions say nothing
+			// about whether the existing workload is still serving. Record the failed write,
+			// but preserve last-known Phase/Ready/Endpoint/Replicas until a successful read can
+			// replace them.
+			retryableWriteError := isRetryableUpstreamWriteError(err)
+			if retryableWriteError && canPreserveLastKnownStatus(err) {
+				reason := "CreateFailed"
+				if errors.IsConflict(err) || errors.IsAlreadyExists(err) {
+					reason = "ResourceConflict"
+				}
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				requeueAfter := RequeueInterval
+				if errors.IsConflict(err) {
+					// A fresh read resolves a resourceVersion race; do not delay desired
+					// spec convergence by the normal transient-error interval.
+					requeueAfter = time.Second
+				}
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
 			}
 			reason := "CreateFailed"
+			requeueAfter := ExternalRecoveryInterval
+			if errors.IsConflict(err) {
+				requeueAfter = time.Second
+			} else if errors.IsNotFound(err) || retryableWriteError {
+				// A definite 404 means the write did not reach an existing upstream
+				// object. Fail closed, but retry on the normal recovery cadence because
+				// discovery or admission ordering can make this short-lived.
+				requeueAfter = RequeueInterval
+			}
 			if isResourceConflict(err) {
-				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
 			}
-			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
-			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
-			// Leaving this branch alone would make the most common failure the one that
-			// still reports healthy — the same shape.
+			// Definite write failures fail closed. Validation/admission and ownership
+			// failures use a slower retry because an out-of-band policy, CRD, or ownership
+			// change can make the same ModelDeployment valid without changing its spec.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, err.Error())
 			md.Status.Endpoint = nil
 			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create Workspace: %s", err.Error())
-			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
-			// leader change, a momentary 500 — and it is the case that most needs a retry.
-			// Without one the second pass writes identical status, which the API server
-			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
-			// its endpoint cleared until the ~10h resync even though the workload may still
-			// be serving.
 			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
-			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 	}
 
@@ -389,7 +470,7 @@ func (r *KaitoProviderReconciler) createOrUpdateResource(ctx context.Context, re
 	if errors.IsNotFound(err) {
 		// Create new resource
 		logger.Info("Creating resource", "kind", resource.GetKind(), "name", resource.GetName())
-		return r.Create(ctx, resource, strictFieldValidation)
+		return wrapResourceWriteError(r.Create(ctx, resource, strictFieldValidation), false)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get existing resource: %w", err)
@@ -398,6 +479,11 @@ func (r *KaitoProviderReconciler) createOrUpdateResource(ctx context.Context, re
 	// Verify ownership before updating
 	if err := verifyOwnerReference(existing, md.UID); err != nil {
 		return err
+	}
+	resourceWasOwnedActiveAndServing := false
+	if existing.GetDeletionTimestamp() == nil && r.StatusTranslator != nil {
+		statusResult, statusErr := r.StatusTranslator.TranslateStatus(existing)
+		resourceWasOwnedActiveAndServing = statusErr == nil && statusResult.Phase == airunwayv1alpha1.DeploymentPhaseRunning
 	}
 
 	// Update existing resource if managed fields or desired metadata have changed. Compare only the fields we manage.
@@ -413,7 +499,10 @@ func (r *KaitoProviderReconciler) createOrUpdateResource(ctx context.Context, re
 	metadataMatches := desiredMetadataMatches(resource, existing, lastAppliedLabels, lastAppliedAnnotations)
 	if !resourceMatches || !inferenceMatches || !metadataMatches {
 		logger.Info("Updating resource", "kind", resource.GetKind(), "name", resource.GetName())
-		return r.updateManagedWorkspaceFields(ctx, existing, resource, lastAppliedResource, lastAppliedInference, lastAppliedLabels, lastAppliedAnnotations)
+		return wrapResourceWriteError(
+			r.updateManagedWorkspaceFields(ctx, existing, resource, lastAppliedResource, lastAppliedInference, lastAppliedLabels, lastAppliedAnnotations),
+			resourceWasOwnedActiveAndServing,
+		)
 	}
 
 	return nil

--- a/providers/kaito/controller.go
+++ b/providers/kaito/controller.go
@@ -93,8 +93,25 @@ func isUpstreamSchemaRejection(err error) bool {
 		return false
 	}
 	msg := err.Error()
-	return strings.Contains(msg, "strict decoding error") ||
-		strings.Contains(msg, "field not declared in schema")
+
+	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
+	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
+	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
+	// containing either phrase on its own must not be misclassified as a version mismatch
+	// and retried forever.
+	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+		return true
+	}
+
+	// Server-side apply on built-in types: the rejection comes from the field manager's
+	// typed conversion, not from field validation, so it carries a different wrapper and a
+	// different status class. Bind the diagnostic to that wrapper for the same reason.
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return strings.Contains(msg, "field not declared in schema")
+	}
+
+	return false
 }
 
 // KaitoProviderReconciler reconciles ModelDeployment resources for the KAITO provider

--- a/providers/kaito/controller.go
+++ b/providers/kaito/controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +62,40 @@ const (
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
 )
+
+// strictFieldValidation makes the API server reject fields the installed upstream does
+// not declare, instead of silently pruning them — see issue #308 and the "Upstream
+// compatibility" section of docs/providers.md. kubectl sends strict validation by default;
+// Go clients do not, so it must be set explicitly on every upstream write.
+var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// isUpstreamSchemaRejection reports whether err is the API server refusing a field the
+// installed upstream does not declare, as opposed to any other rejection.
+//
+// Matching on the message rather than the status class is deliberate, because the class
+// varies by write path:
+//   - custom resource create/update -> 400 BadRequest, "strict decoding error: unknown field"
+//   - custom resource merge patch   -> 422 Invalid,    same prefix (verified live)
+//   - server-side apply on built-in types -> 500, "field not declared in schema"
+//     (verified against a live cluster: the error is a plain error from the field manager,
+//     so it is neither IsBadRequest nor IsInvalid)
+//
+// Gating on IsInvalid alone would also swallow every CEL and OpenAPI type violation, which
+// are user configuration errors that no upstream upgrade would fix — reporting those as an
+// upstream version mismatch would send operators down the wrong path entirely.
+//
+// The needle is the "strict decoding error" prefix rather than the bare "unknown field"
+// cause it wraps, because an Invalid status echoes the offending value back and a
+// user-supplied string (a model id, an image, an engine arg) could otherwise contain the
+// bare phrase and be misclassified.
+func isUpstreamSchemaRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "strict decoding error") ||
+		strings.Contains(msg, "field not declared in schema")
+}
 
 // KaitoProviderReconciler reconciles ModelDeployment resources for the KAITO provider
 type KaitoProviderReconciler struct {
@@ -156,7 +191,14 @@ func (r *KaitoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	resources, err := r.Transformer.Transform(ctx, &md)
 	if err != nil {
 		logger.Error(err, "Failed to transform ModelDeployment", "name", md.Name)
+		// Same treatment as the upstream-rejection path below: force Ready False and drop
+		// the stale endpoint/replica counts. Otherwise a previously-Running deployment whose
+		// spec is edited into something unrenderable reports Failed while still advertising
+		// a live endpoint and "1/1 ready" — the contradiction strict validation exists to surface.
 		r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "TransformFailed", err.Error())
+		r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "TransformFailed", err.Error())
+		md.Status.Endpoint = nil
+		md.Status.Replicas = nil
 		md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 		md.Status.Message = fmt.Sprintf("Failed to generate KAITO resources: %s", err.Error())
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
@@ -172,15 +214,60 @@ func (r *KaitoProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
+			// Strict field validation rejected the write: the cluster does not accept a field
+			// this provider renders. Give it its own reason so an operator can tell it apart
+			// from a generic create failure, and keep requeueing — the remedy is
+			// an out-of-band upstream upgrade, and nothing else would re-trigger this
+			// reconcile. The provider-config watch fires only on Spec/Ready changes, and no
+			// upstream object exists to watch, so without a requeue the deployment would sit
+			// Failed until the ~10h resync even after the cluster is fixed.
+			//
+			// Ready is forced False here because the failure it catches is precisely a
+			// deployment that reports healthy while being unable to serve. Note this deliberately does NOT
+			// touch ProviderCompatible: that is set True earlier in this same reconcile, so
+			// flipping it here would rewrite LastTransitionTime on every requeue and the
+			// condition would never settle.
+			if isUpstreamSchemaRejection(err) {
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "IncompatibleUpstream", err.Error())
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "IncompatibleUpstream", err.Error())
+				// Clear the Running-era endpoint and replica counts. This branch returns
+				// before syncStatus, so on an update rejection they would otherwise keep
+				// their previous values and the object would report Failed alongside a live
+				// endpoint and "1/1 ready" — the same contradiction described above.
+				md.Status.Endpoint = nil
+				md.Status.Replicas = nil
+				md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
+				md.Status.Message = fmt.Sprintf("Incompatible with the installed upstream: the installed KAITO CRD does not declare a field this provider renders. This usually means the cluster's KAITO is older than this provider requires, or that spec.provider.overrides sets a key it does not support. %s", err.Error())
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			}
 			reason := "CreateFailed"
 			if isResourceConflict(err) {
+				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
-				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "ResourceConflict", err.Error())
 			}
+			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
+			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
+			// Leaving this branch alone would make the most common failure the one that
+			// still reports healthy — the same shape.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, err.Error())
+			md.Status.Endpoint = nil
+			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create Workspace: %s", err.Error())
-			return ctrl.Result{}, r.Status().Update(ctx, &md)
+			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
+			// leader change, a momentary 500 — and it is the case that most needs a retry.
+			// Without one the second pass writes identical status, which the API server
+			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
+			// its endpoint cleared until the ~10h resync even though the workload may still
+			// be serving.
+			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
 		}
 	}
 
@@ -285,7 +372,7 @@ func (r *KaitoProviderReconciler) createOrUpdateResource(ctx context.Context, re
 	if errors.IsNotFound(err) {
 		// Create new resource
 		logger.Info("Creating resource", "kind", resource.GetKind(), "name", resource.GetName())
-		return r.Create(ctx, resource)
+		return r.Create(ctx, resource, strictFieldValidation)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get existing resource: %w", err)
@@ -353,7 +440,7 @@ func (r *KaitoProviderReconciler) updateManagedWorkspaceFields(ctx context.Conte
 	}
 	mergeManagedMetadata(updated, desired, lastAppliedLabels, lastAppliedAnnotations)
 
-	return r.Patch(ctx, updated, client.MergeFrom(base))
+	return r.Patch(ctx, updated, client.MergeFrom(base), strictFieldValidation)
 }
 
 func mergeManagedTopLevelMap(target, desired *unstructured.Unstructured, lastApplied map[string]interface{}, field string) error {

--- a/providers/kaito/transformer.go
+++ b/providers/kaito/transformer.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
@@ -399,9 +400,34 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		}
 	}
 
+	// Reject any root key the Workspace schema does not declare. Note KAITO is unusual: it
+	// puts `resource` and `inference` at the OBJECT ROOT rather than under `spec`, so the
+	// allowlist here is not "spec" as it is for the other providers.
+	//
+	// Before strict field validation an unknown root key was pruned silently, so a typo'd
+	// override was invisible — the same silent-no-op issue #308 is about. Sorted so the
+	// message is stable: an unstable status.message re-enqueues the object on every
+	// reconcile (the ModelDeployment watch has no GenerationChangedPredicate).
+	var unsupported []string
+	for key := range overrides {
+		if !workspaceRootKeys[key] {
+			unsupported = append(unsupported, key)
+		}
+	}
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		return fmt.Errorf("unsupported provider.overrides key(s) %q: this provider supports "+
+			"\"resource\" and \"inference\", which the KAITO Workspace places at the object "+
+			"root rather than under \"spec\"", unsupported)
+	}
+
 	obj.Object = deepMerge(obj.Object, overrides)
 	return nil
 }
+
+// workspaceRootKeys are the root keys a KAITO Workspace declares and this transformer
+// renders. KAITO does not nest them under `spec`, unlike the other providers' upstreams.
+var workspaceRootKeys = map[string]bool{"resource": true, "inference": true}
 
 // deepMerge recursively merges src into dst.
 // For maps, values are merged recursively. A nil src value deletes the field.

--- a/providers/kaito/transformer.go
+++ b/providers/kaito/transformer.go
@@ -400,7 +400,7 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		}
 	}
 
-	// Reject any root key the Workspace schema does not declare. Note KAITO is unusual: it
+	// Reject any root key this transformer does not render. Note KAITO is unusual: it
 	// puts `resource` and `inference` at the OBJECT ROOT rather than under `spec`, so the
 	// allowlist here is not "spec" as it is for the other providers.
 	//
@@ -416,17 +416,23 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 	}
 	if len(unsupported) > 0 {
 		sort.Strings(unsupported)
-		return fmt.Errorf("unsupported provider.overrides key(s) %q: this provider supports "+
-			"\"resource\" and \"inference\", which the KAITO Workspace places at the object "+
-			"root rather than under \"spec\"", unsupported)
+		return fmt.Errorf("unsupported provider.overrides key(s) %q: this provider renders "+
+			"inference workloads and supports only \"resource\" and \"inference\", which the "+
+			"KAITO Workspace places at the object root rather than under \"spec\"", unsupported)
 	}
 
 	obj.Object = deepMerge(obj.Object, overrides)
 	return nil
 }
 
-// workspaceRootKeys are the root keys a KAITO Workspace declares and this transformer
-// renders. KAITO does not nest them under `spec`, unlike the other providers' upstreams.
+// workspaceRootKeys are the root keys this transformer renders. KAITO does not nest them
+// under `spec`, unlike the other providers' upstreams.
+//
+// Deliberately NARROWER than the Workspace schema, which also declares a root `tuning`:
+// a ModelDeployment describes an inference deployment, and the status translator reads
+// inference conditions. Nothing in the CRD stops `inference` and `tuning` both being set,
+// so admitting `tuning` would let an override produce a Workspace whose status this
+// provider cannot interpret — the report-healthy-but-cannot-serve failure #308 is about.
 var workspaceRootKeys = map[string]bool{"resource": true, "inference": true}
 
 // deepMerge recursively merges src into dst.

--- a/providers/kaito/transformer.go
+++ b/providers/kaito/transformer.go
@@ -392,6 +392,15 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		return fmt.Errorf("failed to unmarshal overrides: %w", err)
 	}
 
+	// KAITO calls its replica field resource.count. Reject that exact path so a
+	// caller that bypasses the validating webhook still cannot override the
+	// replica count derived from the bounded unified scaling field.
+	if resourceOverride, ok := overrides["resource"].(map[string]interface{}); ok {
+		if _, exists := resourceOverride["count"]; exists {
+			return fmt.Errorf("overriding %q is not allowed because it can bypass admission replica limits; use spec.scaling.replicas instead", "resource.count")
+		}
+	}
+
 	// Block dangerous top-level keys to prevent privilege escalation
 	blockedKeys := []string{"apiVersion", "kind", "metadata", "status"}
 	for _, key := range blockedKeys {

--- a/providers/kaito/transformer_test.go
+++ b/providers/kaito/transformer_test.go
@@ -3,6 +3,7 @@ package kaito
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
@@ -1054,7 +1055,7 @@ func TestTransformWithHFSecret(t *testing.T) {
 	}
 }
 
-func TestTransformOverrideCanSetRootFields(t *testing.T) {
+func TestTransformOverrideRejectsResourceCount(t *testing.T) {
 	tr := NewTransformer()
 	md := newTestMD("test-model", "default")
 	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
@@ -1067,21 +1068,12 @@ func TestTransformOverrideCanSetRootFields(t *testing.T) {
 		},
 	}
 
-	results, err := tr.Transform(context.Background(), md)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := tr.Transform(context.Background(), md)
+	if err == nil {
+		t.Fatal("expected resource.count override to be rejected")
 	}
-
-	ws := results[0]
-	// Overrides should set resource.count (KAITO has resource at root level)
-	count, found, _ := unstructured.NestedFloat64(ws.Object, "resource", "count")
-	if !found || count != 10 {
-		t.Errorf("expected overridden count 10, got %v", count)
-	}
-	// labelSelector should still be present (deep merge preserves it)
-	_, found, _ = unstructured.NestedMap(ws.Object, "resource", "labelSelector")
-	if !found {
-		t.Error("expected labelSelector to be preserved after override merge")
+	if !strings.Contains(err.Error(), "spec.scaling.replicas") {
+		t.Fatalf("error %q does not direct the caller to spec.scaling.replicas", err)
 	}
 }
 

--- a/providers/kaito/upstream_strict_validation_test.go
+++ b/providers/kaito/upstream_strict_validation_test.go
@@ -192,6 +192,21 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			}),
 			want: false,
 		},
+		{
+			// The needle requires BOTH halves. An Invalid status echoes the offending value
+			// back, so a user-supplied string containing only the prefix must not match.
+			name: "not ours: 'strict decoding error' echoed without an unknown-field cause",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=strict decoding error probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
+			name: "not ours: typed-object wrapper without the schema diagnostic",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
+			want: false,
+		},
 		{name: "nil", err: nil, want: false},
 	}
 	for _, tc := range cases {

--- a/providers/kaito/upstream_strict_validation_test.go
+++ b/providers/kaito/upstream_strict_validation_test.go
@@ -1,0 +1,547 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kaito
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
+)
+
+// Regression test for upstream schema compatibility.
+//
+// Every write to the upstream Workspace must carry fieldValidation=Strict, so the API
+// server rejects fields the installed KAITO CRD does not declare instead of silently
+// pruning them. Without it the shim can render a field the cluster drops without any
+// error, leaving a workload that reports healthy but cannot serve.
+//
+// This asserts the option reaches the client. It deliberately does NOT assert the API
+// server's behaviour — the fake client has no structural schema and cannot prune, which
+// is exactly why no pre-existing test caught this bug.
+//
+// KAITO writes via Create on first reconcile and a merge Patch thereafter (rather than a
+// full replace), so both paths are covered.
+
+func kaitoTestOwner() []metav1.OwnerReference {
+	return []metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "test",
+		UID:        types.UID("test-uid"),
+	}}
+}
+
+func kaitoTestMD() *airunwayv1alpha1.ModelDeployment {
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.UID = types.UID("test-uid")
+	return md
+}
+
+// kaitoDesiredWorkspace builds a Workspace with the shim-managed subtrees. Note KAITO
+// puts `resource` and `inference` at the object root, not under `spec`.
+func kaitoDesiredWorkspace(instanceType string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	setWorkspaceGVK(u)
+	u.SetName("test")
+	u.SetNamespace("default")
+	u.SetOwnerReferences(kaitoTestOwner())
+	u.Object["resource"] = map[string]interface{}{
+		"count":        int64(1),
+		"instanceType": instanceType,
+	}
+	u.Object["inference"] = map[string]interface{}{
+		"preset": map[string]interface{}{"name": "phi-3-mini-4k-instruct"},
+	}
+	return u
+}
+
+func TestUpstreamCreateUsesStrictFieldValidation(t *testing.T) {
+	scheme := newSchemeWithWorkspace()
+
+	var got string
+	var called bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			called = true
+			o := &client.CreateOptions{}
+			for _, opt := range opts {
+				opt.ApplyToCreate(o)
+			}
+			got = o.FieldValidation
+			return nil
+		},
+	}).Build()
+
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
+
+	if err := r.createOrUpdateResource(context.Background(), kaitoDesiredWorkspace("Standard_NC6s_v3"), kaitoTestMD()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("Create was never called — test is not exercising the create path")
+	}
+	if got != metav1.FieldValidationStrict {
+		t.Errorf("create fieldValidation = %q, want %q (unknown fields must be rejected, not pruned)",
+			got, metav1.FieldValidationStrict)
+	}
+}
+
+func TestUpstreamPatchUsesStrictFieldValidation(t *testing.T) {
+	scheme := newSchemeWithWorkspace()
+
+	// Existing workspace differs from desired in a shim-managed field, so
+	// createOrUpdateResource takes the merge-patch path rather than no-oping.
+	existing := kaitoDesiredWorkspace("Standard_NC12s_v3")
+
+	var got string
+	var called bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				called = true
+				o := &client.PatchOptions{}
+				for _, opt := range opts {
+					opt.ApplyToPatch(o)
+				}
+				got = o.FieldValidation
+				return nil
+			},
+		}).Build()
+
+	r := NewKaitoProviderReconciler(c, scheme, c, record.NewFakeRecorder(10))
+
+	if err := r.createOrUpdateResource(context.Background(), kaitoDesiredWorkspace("Standard_NC6s_v3"), kaitoTestMD()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("Patch was never called — test is not exercising the update path")
+	}
+	if got != metav1.FieldValidationStrict {
+		t.Errorf("patch fieldValidation = %q, want %q (unknown fields must be rejected, not pruned)",
+			got, metav1.FieldValidationStrict)
+	}
+}
+
+// TestIsUpstreamSchemaRejection pins the matcher to error strings observed against a live
+// cluster. The API server's response class varies by write path — custom-resource create is
+// 400, merge patch is 422, and server-side apply on a built-in type is **500** (the error
+// comes from the field manager, not from field validation) — which is why this matches on
+// message rather than status code.
+//
+// The negative cases are the point: gating on IsInvalid would capture ordinary CEL and type
+// violations and report them as an upstream version mismatch, sending an operator off to
+// upgrade a cluster that is already fine.
+func TestIsUpstreamSchemaRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "observed: custom resource create against an older CRD (400)",
+			err:  apierrors.NewBadRequest(`strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`),
+			want: true,
+		},
+		{
+			name: "observed: server-side apply on a built-in type (500)",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.bogus: field not declared in schema"),
+			want: true,
+		},
+		{
+			name: "not ours: CEL or type validation failure the user must fix",
+			err:  apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", nil),
+			want: false,
+		},
+		{
+			// The reason the needle is "strict decoding error" and not the bare
+			// "unknown field": an Invalid status echoes the offending value back, so a
+			// user-supplied string can contain the bare phrase. Classifying this as an
+			// upstream mismatch would tell an operator to upgrade a cluster that is fine,
+			// and retry every 30s forever.
+			name: "not ours: Invalid echoing a user value that contains the bare phrase",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=unknown field probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
+				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReconcileRequeuesOnStrictRejection covers the recovery path for the failure mode
+// strict validation introduces. A schema rejection is terminal from the controller's point
+// of view — the remedy is an out-of-band upstream upgrade — and nothing in the watch set
+// re-triggers this reconcile afterwards, so without an explicit requeue the deployment
+// would sit Failed until the ~10h resync even after the cluster is fixed.
+func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
+	// KAITO probes upstream health through a SEPARATE direct client before it writes. That
+	// probe needs the workspace GVK resolvable by the RESTMapper and a ready KAITO
+	// controller Deployment, or it refuses first — and since the refusal path ALSO returns
+	// a RequeueAfter, asserting only on that would pass vacuously.
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Seed the Running-era status. Without this the clearing below is a no-op the
+	// assertions cannot observe, and deleting it from the controller would not fail
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	rejection := apierrors.NewBadRequest(`strict decoding error: unknown field "spec.someNewerField"`)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					return rejection
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a strict-validation rejection")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reasons := map[string]string{}
+	statuses := map[string]metav1.ConditionStatus{}
+	for _, cond := range updated.Status.Conditions {
+		reasons[cond.Type] = cond.Reason
+		statuses[cond.Type] = cond.Status
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "IncompatibleUpstream" {
+		t.Errorf("ResourceCreated reason = %q, want %q", got, "IncompatibleUpstream")
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False — #308 is about reporting healthy while broken", got)
+	}
+	// docs/providers.md promises BOTH conditions carry this reason.
+	if got := reasons[airunwayv1alpha1.ConditionTypeReady]; got != "IncompatibleUpstream" {
+		t.Errorf("Ready reason = %q, want IncompatibleUpstream", got)
+	}
+	// ProviderCompatible is deliberately NOT touched here: it is set True earlier in the same
+	// reconcile, so flipping it would rewrite LastTransitionTime on every 30s requeue and the
+	// condition would never settle — a permanent status-write loop.
+	if got := statuses[airunwayv1alpha1.ConditionTypeProviderCompatible]; got != metav1.ConditionTrue {
+		t.Errorf("ProviderCompatible = %q, want True — flipping it here causes permanent churn", got)
+	}
+
+	// docs/providers.md promises this provider names the offending field in status.message.
+	if !strings.Contains(updated.Status.Message, "someNewerField") {
+		t.Errorf("status.message does not name the offending field: %q", updated.Status.Message)
+	}
+
+	// Stale endpoint/replicas must be cleared. Reporting Failed alongside a live endpoint
+	// and "1/1 ready" is the same contradiction.
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil — a Failed deployment must not still advertise an endpoint", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+}
+
+// TestReconcileTransformFailureClearsStaleStatus covers the OTHER failure branch: a spec the
+// transformer refuses to render (here, an unsupported provider.overrides root key).
+//
+// It must get the same treatment as an upstream rejection — Ready forced False and the
+// Running-era endpoint/replica counts dropped. Without that, a previously-Running deployment
+// edited into something unrenderable reports Failed while still advertising a live endpoint
+// and "1/1 ready", which is the contradiction this guards against.
+func TestReconcileTransformFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name:      md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{Raw: []byte(`{"totallyBogusRootKey":{"a":1}}`)},
+	}
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason, readyReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "TransformFailed" {
+		t.Errorf("ResourceCreated reason = %q, want TransformFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if readyReason != "TransformFailed" {
+		t.Errorf("Ready reason = %q, want TransformFailed", readyReason)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
+// write failure that is neither a transform error nor a schema rejection.
+//
+// It is the most common of the three, and it must not be the one that still reports healthy.
+// Without the clearing, a previously-Running deployment hitting a transient upstream error
+// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
+// this guards against.
+func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	// A generic write failure is usually transient, so it must retry. Without a requeue the
+	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
+	// deployment sits Failed with no endpoint until the default resync.
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a transient write failure")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestUnsupportedOverrideErrorIsDeterministic guards against a status-write loop.
+//
+// Go randomises map iteration, so returning on the first unsupported key yields a different
+// message per call for the same spec. That message lands in status.message, and because the
+// ModelDeployment watch has no GenerationChangedPredicate, a changing message means every
+// reconcile writes status, which re-enqueues the object.
+func TestUnsupportedOverrideErrorIsDeterministic(t *testing.T) {
+	newMD := func() *airunwayv1alpha1.ModelDeployment {
+		md := newMDForController("test", "default")
+		md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+			Name:      md.Status.Provider.Name,
+			Overrides: &runtime.RawExtension{Raw: []byte(`{"zeta":{},"alpha":{},"mu":{}}`)},
+		}
+		return md
+	}
+	var first string
+	for i := 0; i < 100; i++ {
+		_, err := NewTransformer().Transform(context.Background(), newMD())
+		if err == nil {
+			t.Fatal("expected an error for unsupported override keys")
+		}
+		if i == 0 {
+			first = err.Error()
+			continue
+		}
+		if err.Error() != first {
+			t.Fatalf("override rejection message is nondeterministic:\n  %q\n  %q", first, err.Error())
+		}
+	}
+	for _, want := range []string{"alpha", "mu", "zeta"} {
+		if !strings.Contains(first, want) {
+			t.Errorf("error %q does not name offending key %q", first, want)
+		}
+	}
+}
+
+// TestOverrideRootKeyComparisonIsCaseSensitive pins a deliberate choice: the accepted root
+// key is matched case-sensitively, so "Resource" is rejected rather than merged. KAITO has no
+// "spec" root key at all — its accepted keys are "resource" and "inference". encoding/json
+// would not decode it into anything meaningful, and merging it would push a key no upstream
+// schema declares into the rendered object.
+func TestOverrideRootKeyComparisonIsCaseSensitive(t *testing.T) {
+	md := newMDForController("test", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name:      md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{Raw: []byte(`{"Resource":{"x":1}}`)},
+	}
+	if _, err := NewTransformer().Transform(context.Background(), md); err == nil {
+		t.Error("a capitalised root key was accepted; it must be rejected, not merged")
+	}
+}
+
+// TestReconcileOwnershipConflictUsesItsOwnReason covers the ownership-collision branch.
+//
+// An upstream object of the right name already exists but belongs to someone else. That is
+// terminal — unlike a transient API 409 — so it is reported under its own reason rather than
+// the generic CreateFailed.
+func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
+	scheme := newSchemeWithWorkspace()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Same name, different owner.
+	foreign := &unstructured.Unstructured{}
+	setWorkspaceGVK(foreign)
+	foreign.SetName("test")
+	foreign.SetNamespace("default")
+	foreign.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "someone-else",
+		UID:        types.UID("a-different-uid"),
+	}})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var reason, readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			reason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyReason = cond.Reason
+		}
+	}
+	// The branch comment claims "Ready is set below unconditionally with this same reason".
+	// Hold it: an operator alerting on Ready.reason=ResourceConflict needs to distinguish a
+	// collision needing manual intervention from a transient CreateFailed that will retry.
+	if readyReason != "ResourceConflict" {
+		t.Errorf("Ready reason = %q, want ResourceConflict", readyReason)
+	}
+	if reason != "ResourceConflict" {
+		t.Errorf("ResourceCreated reason = %q, want ResourceConflict — an ownership collision "+
+			"must be distinguishable from a generic create failure", reason)
+	}
+}
+
+// TestWorkspaceRootKeysExcludesSpec pins the one allowlist entry that would otherwise have no
+// negative test. A KAITO Workspace has no "spec" root key — that is the whole reason this
+// provider's allowlist differs from every other provider's — so admitting one would push a
+// field no Workspace declares into the rendered object.
+func TestWorkspaceRootKeysExcludesSpec(t *testing.T) {
+	if workspaceRootKeys["spec"] {
+		t.Error(`workspaceRootKeys admits "spec"; a KAITO Workspace has no spec root key`)
+	}
+	for _, want := range []string{"resource", "inference"} {
+		if !workspaceRootKeys[want] {
+			t.Errorf("workspaceRootKeys is missing %q, which this provider renders", want)
+		}
+	}
+}

--- a/providers/kaito/upstream_strict_validation_test.go
+++ b/providers/kaito/upstream_strict_validation_test.go
@@ -13,8 +13,11 @@ package kaito
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -203,6 +206,17 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			want: false,
 		},
 		{
+			// Even the complete diagnostic can occur inside an echoed value. The real
+			// strict-decoding cause is terminal; this value is followed by its validation
+			// reason and must not be classified as an upstream mismatch.
+			name: "not ours: full strict diagnostic echoed inside a user value",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					`--served-model-name=strict decoding error: unknown field "spec.fake"`, "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
 			name: "not ours: typed-object wrapper without the schema diagnostic",
 			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
 			want: false,
@@ -213,6 +227,25 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
 				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableUpstreamWriteErrorRecognizesWrappedEOF(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "EOF", err: io.EOF},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF},
+		{name: "broken pipe", err: syscall.EPIPE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !isRetryableUpstreamWriteError(wrapResourceWriteError(tt.err, true)) {
+				t.Errorf("wrapped %v was not classified as retryable", tt.err)
 			}
 		})
 	}
@@ -259,8 +292,9 @@ func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
 	}
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a strict-validation rejection")
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a strict-validation rejection",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -369,25 +403,414 @@ func TestReconcileTransformFailureClearsStaleStatus(t *testing.T) {
 	}
 }
 
-// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
-// write failure that is neither a transform error nor a schema rejection.
-//
-// It is the most common of the three, and it must not be the one that still reports healthy.
-// Without the clearing, a previously-Running deployment hitting a transient upstream error
-// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
-// this guards against.
-func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+// TestReconcileTransientWriteFailurePreservesLastKnownStatus covers a retryable patch
+// failure after the controller has observed an owned upstream resource. The ambiguous write
+// does not prove that existing workload stopped serving, so last-known status is retained.
+func TestReconcileTransientWriteFailurePreservesLastKnownStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, int64(2), "resource", "count"); err != nil {
+		t.Fatalf("mutate existing resource: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, "Ready", "status", "state"); err != nil {
+		t.Fatalf("mark existing Workspace ready: %v", err)
+	}
+
+	var patchCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					patchCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.RequeueAfter != RequeueInterval {
+		t.Errorf("RequeueAfter = %s, want %s", res.RequeueAfter, RequeueInterval)
+	}
+	if !patchCalled {
+		t.Fatal("Patch was never called; test did not exercise the existing-resource path")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var createdStatus metav1.ConditionStatus
+	var readyStatus metav1.ConditionStatus
+	var readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+			createdStatus = cond.Status
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if createdStatus != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", createdStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+		t.Errorf("Status.Phase = %q, want Running", updated.Status.Phase)
+	}
+	if readyStatus != metav1.ConditionTrue || readyReason != "DeploymentReady" {
+		t.Errorf("Ready = %q reason %q, want True reason DeploymentReady", readyStatus, readyReason)
+	}
+	if updated.Status.Endpoint == nil || updated.Status.Endpoint.Service != "stale-svc" || updated.Status.Endpoint.Port != 8000 {
+		t.Errorf("Status.Endpoint = %+v, want stale-svc:8000", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas == nil || updated.Status.Replicas.Desired != 1 || updated.Status.Replicas.Ready != 1 || updated.Status.Replicas.Available != 1 {
+		t.Errorf("Status.Replicas = %+v, want 1 desired/ready/available", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileTransientWriteFailureOnUnreadyWorkspaceFailsClosed proves that an active,
+// owned Workspace must also be serving before stale ModelDeployment status can be retained.
+func TestReconcileTransientWriteFailureOnUnreadyWorkspaceFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedKaitoStaleServingStatus(md)
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, int64(2), "resource", "count"); err != nil {
+		t.Fatalf("mutate existing resource: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, "NotReady", "status", "state"); err != nil {
+		t.Fatalf("mark existing Workspace unready: %v", err)
+	}
+
+	var patchCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					patchCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if !patchCalled {
+		t.Fatal("Patch was never called; test did not exercise the active unready-Workspace path")
+	}
+	assertKaitoPromptRetryFailedClosed(t, c, res)
+}
+
+// TestReconcileTerminatingWorkspaceTransientPatchFailsClosed distinguishes an active owned
+// Workspace from one already being deleted. Even though the object was observed and the patch
+// failure is retryable, a terminating Workspace cannot support stale Ready=True serving status.
+func TestReconcileTerminatingWorkspaceTransientPatchFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedKaitoStaleServingStatus(md)
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, int64(2), "resource", "count"); err != nil {
+		t.Fatalf("mutate existing resource: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, "Ready", "status", "state"); err != nil {
+		t.Fatalf("mark existing Workspace ready: %v", err)
+	}
+	deletionTimestamp := metav1.Now()
+	existing.SetFinalizers([]string{"test.airunway.ai/hold"})
+	existing.SetDeletionTimestamp(&deletionTimestamp)
+
+	var patchCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					patchCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Workspace patch failure"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the patch failure should be reported in status: %v", err)
+	}
+	if !patchCalled {
+		t.Fatal("Patch was never called; test did not exercise the terminating existing-resource path")
+	}
+	assertKaitoPromptRetryFailedClosed(t, c, res)
+}
+
+// TestReconcileTransientWorkspaceGetFailureFailsClosed covers a retryable read failure before
+// the controller has verified whether the Workspace exists, is owned, or is active. Without a
+// trustworthy observation there is no basis for preserving stale serving status.
+func TestReconcileTransientWorkspaceGetFailureFailsClosed(t *testing.T) {
+	scheme := newSchemeWithWorkspace()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedKaitoStaleServingStatus(md)
+
+	var getCalled, writeCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					getCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Workspace get failure"))
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					writeCalled = true
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					writeCalled = true
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the get failure should be reported in status: %v", err)
+	}
+	if !getCalled {
+		t.Fatal("Workspace Get was never called; test did not exercise the unverified-observation path")
+	}
+	if writeCalled {
+		t.Fatal("Workspace write was called after its Get failed")
+	}
+	assertKaitoPromptRetryFailedClosed(t, c, res)
+}
+
+func seedKaitoStaleServingStatus(md *airunwayv1alpha1.ModelDeployment) {
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+}
+
+func assertKaitoPromptRetryFailedClosed(t *testing.T, c client.Client, res ctrl.Result) {
+	t.Helper()
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s", res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var ready, created *metav1.Condition
+	for i := range updated.Status.Conditions {
+		condition := &updated.Status.Conditions[i]
+		switch condition.Type {
+		case airunwayv1alpha1.ConditionTypeReady:
+			ready = condition
+		case airunwayv1alpha1.ConditionTypeResourceCreated:
+			created = condition
+		}
+	}
+	if ready == nil || ready.Status != metav1.ConditionFalse {
+		t.Errorf("Ready = %+v, want False", ready)
+	}
+	if created == nil || created.Status != metav1.ConditionFalse || created.Reason != "CreateFailed" {
+		t.Errorf("ResourceCreated = %+v, want False reason CreateFailed", created)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileOwnedPatchConflictRetriesPromptly covers a resourceVersion race after the
+// controller has read and ownership-checked an existing Workspace. A 409 from KAITO's
+// managed-field merge patch should trigger a fresh read promptly, while preserving the
+// last-known serving status.
+func TestReconcileOwnedPatchConflictRetriesPromptly(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "live-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, int64(2), "resource", "count"); err != nil {
+		t.Fatalf("mutate existing resource: %v", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, "Ready", "status", "state"); err != nil {
+		t.Fatalf("mark existing Workspace ready: %v", err)
+	}
+
+	var patchCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					patchCalled = true
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: KaitoAPIGroup, Resource: "workspaces"},
+						obj.GetName(), fmt.Errorf("the object has been modified"),
+					)
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; a conflict should requeue: %v", err)
+	}
+	if !patchCalled {
+		t.Fatal("Patch was never called; test did not exercise the owned existing-resource path")
+	}
+	if res.Requeue || res.RequeueAfter != time.Second {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a patch conflict",
+			res.Requeue, res.RequeueAfter, time.Second)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+		t.Errorf("Status.Phase = %q, want Running", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint == nil || updated.Status.Endpoint.Service != "live-svc" {
+		t.Errorf("Status.Endpoint = %+v, want live-svc", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas == nil || updated.Status.Replicas.Ready != 1 {
+		t.Errorf("Status.Replicas = %+v, want last-known ready count preserved", updated.Status.Replicas)
+	}
+	var created, ready *metav1.Condition
+	for i := range updated.Status.Conditions {
+		condition := &updated.Status.Conditions[i]
+		switch condition.Type {
+		case airunwayv1alpha1.ConditionTypeResourceCreated:
+			created = condition
+		case airunwayv1alpha1.ConditionTypeReady:
+			ready = condition
+		}
+	}
+	if created == nil || created.Reason != "ResourceConflict" {
+		t.Errorf("ResourceCreated = %+v, want reason ResourceConflict", created)
+	}
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Errorf("Ready = %+v, want last-known True condition preserved", ready)
+	}
+}
+
+// TestReconcileTransientCreateFailureClearsStaleStatus covers the same retryable API error
+// when the controller has just observed that no upstream resource exists. There is no known
+// workload to preserve, so stale serving status must be cleared while retrying promptly.
+func TestReconcileTransientCreateFailureClearsStaleStatus(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
 	controllerutil.AddFinalizer(md, FinalizerName)
 	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
 	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
-	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
 
+	var createCalled bool
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					createCalled = true
 					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
 				}
 				return cl.Create(ctx, obj, opts...)
@@ -402,32 +825,182 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
 	}
-	// A generic write failure is usually transient, so it must retry. Without a requeue the
-	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
-	// deployment sits Failed with no endpoint until the default resync.
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a transient write failure")
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a transient create failure",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+	if !createCalled {
+		t.Fatal("Create was never called; test did not exercise the absent-resource path")
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	var createdReason string
 	var readyStatus metav1.ConditionStatus
-	for _, cond := range updated.Status.Conditions {
-		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
-			createdReason = cond.Reason
+	for _, condition := range updated.Status.Conditions {
+		if condition.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = condition.Status
 		}
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileNotFoundWriteFailureClearsStaleStatus covers a definite API-server 404.
+// Unlike an ambiguous 5xx or transport failure, a 404 proves this write did not update an
+// existing workload, so stale serving status must be cleared while retrying promptly.
+func TestReconcileNotFoundWriteFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					return apierrors.NewNotFound(
+						schema.GroupResource{Group: KaitoAPIGroup, Resource: "workspaces"},
+						obj.GetName(),
+					)
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the 404 should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a 404",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var readyStatus metav1.ConditionStatus
+	var createdReason string
+	for _, cond := range updated.Status.Conditions {
 		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
 			readyStatus = cond.Status
 		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
 	}
 	if createdReason != "CreateFailed" {
 		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
 	}
-	if readyStatus != metav1.ConditionFalse {
-		t.Errorf("Ready = %q, want False", readyStatus)
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileValidationFailureIsTerminal distinguishes deterministic admission failures
+// from retryable transport errors and schema-version mismatches. It fails closed and retries
+// slowly so an out-of-band policy or CRD repair can recover it without a spec edit.
+func TestReconcileValidationFailureIsTerminal(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+
+	rejection := apierrors.NewInvalid(
+		schema.GroupKind{Group: KaitoAPIGroup, Kind: WorkspaceKind},
+		"test",
+		field.ErrorList{field.Invalid(
+			field.NewPath("resource", "count"),
+			int64(0),
+			"must be greater than zero",
+		)},
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == WorkspaceKind {
+					return rejection
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
+	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the validation failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s for a deterministic validation failure",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
+	for _, cond := range updated.Status.Conditions {
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeResourceCreated]; got != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
 	}
 	if updated.Status.Endpoint != nil {
 		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
@@ -545,10 +1118,15 @@ func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
 	directC := probeClientBuilderWithWorkspace(t).WithObjects(newReadyKaitoDeployment()).Build()
 	r := NewKaitoProviderReconciler(c, scheme, directC, record.NewFakeRecorder(10))
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile returned an error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s for an ownership conflict",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment

--- a/providers/kaito/upstream_strict_validation_test.go
+++ b/providers/kaito/upstream_strict_validation_test.go
@@ -489,6 +489,36 @@ func TestOverrideRootKeyComparisonIsCaseSensitive(t *testing.T) {
 	}
 }
 
+// TestOverrideRejectsTuningDeliberately pins a policy that is narrower than the upstream
+// schema, so it reads as a decision rather than an oversight.
+//
+// The pinned KAITO Workspace CRD (v0.10.0) declares four root properties beyond metadata:
+// resource, inference, tuning and status. This transformer accepts only the first two. That
+// is intentional: a ModelDeployment describes an inference deployment, the status translator
+// reads inference conditions, and nothing in the CRD prevents inference and tuning both
+// being set — so a tuning override would yield a Workspace whose status this provider cannot
+// interpret. Admitting `tuning` here would need a status-translation story first.
+func TestOverrideRejectsTuningDeliberately(t *testing.T) {
+	md := newMDForController("test", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name: md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{
+			Raw: []byte(`{"inference":null,"tuning":{"input":{},"output":{}}}`),
+		},
+	}
+	_, err := NewTransformer().Transform(context.Background(), md)
+	if err == nil {
+		t.Fatal("tuning override was accepted; this provider renders inference workloads only")
+	}
+	// The message must explain the policy, not imply the field is absent from the schema.
+	if !strings.Contains(err.Error(), "tuning") {
+		t.Errorf("error %q does not name the offending key", err.Error())
+	}
+	if !strings.Contains(err.Error(), "inference workloads") {
+		t.Errorf("error %q does not state the inference-only policy that motivates it", err.Error())
+	}
+}
+
 // TestReconcileOwnershipConflictUsesItsOwnReason covers the ownership-collision branch.
 //
 // An upstream object of the right name already exists but belongs to someone else. That is

--- a/providers/kuberay/controller.go
+++ b/providers/kuberay/controller.go
@@ -91,8 +91,25 @@ func isUpstreamSchemaRejection(err error) bool {
 		return false
 	}
 	msg := err.Error()
-	return strings.Contains(msg, "strict decoding error") ||
-		strings.Contains(msg, "field not declared in schema")
+
+	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
+	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
+	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
+	// containing either phrase on its own must not be misclassified as a version mismatch
+	// and retried forever.
+	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+		return true
+	}
+
+	// Server-side apply on built-in types: the rejection comes from the field manager's
+	// typed conversion, not from field validation, so it carries a different wrapper and a
+	// different status class. Bind the diagnostic to that wrapper for the same reason.
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return strings.Contains(msg, "field not declared in schema")
+	}
+
+	return false
 }
 
 // KubeRayProviderReconciler reconciles ModelDeployment resources for the KubeRay provider
@@ -224,7 +241,9 @@ func (r *KubeRayProviderReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				md.Status.Endpoint = nil
 				md.Status.Replicas = nil
 				md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
-				md.Status.Message = fmt.Sprintf("Incompatible with the installed upstream: the installed KubeRay CRD does not declare a field this provider renders. This usually means the cluster's KubeRay is older than this provider requires, or that spec.provider.overrides sets a key it does not support. %s", err.Error())
+				// No mention of provider.overrides here: this provider does not read them, so
+				// pointing an operator at a setting it ignores would send them the wrong way.
+				md.Status.Message = fmt.Sprintf("Incompatible with the installed upstream: the installed KubeRay CRD does not declare a field this provider renders. This usually means the cluster's KubeRay is older than this provider requires. %s", err.Error())
 				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 					return ctrl.Result{}, statusErr
 				}

--- a/providers/kuberay/controller.go
+++ b/providers/kuberay/controller.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
+	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -31,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,6 +61,10 @@ const (
 	// RequeueInterval is the default requeue interval for periodic reconciliation
 	RequeueInterval = 30 * time.Second
 
+	// ExternalRecoveryInterval retries failures that require an out-of-band fix without
+	// hot-looping while the installed upstream or resource ownership remains unchanged.
+	ExternalRecoveryInterval = 5 * time.Minute
+
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
 )
@@ -66,6 +74,13 @@ const (
 // compatibility" section of docs/providers.md. kubectl sends strict validation by default;
 // Go clients do not, so it must be set explicitly on every upstream write.
 var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// strictUnknownFieldRejection matches the terminal diagnostic emitted by apimachinery's
+// strict decoder. Anchoring the diagnostic at the end keeps an ordinary validation error
+// from matching when its echoed user value contains the same words.
+var strictUnknownFieldRejection = regexp.MustCompile(
+	`(^|: )strict decoding error: unknown field "(\\.|[^"\\])*"(, unknown field "(\\.|[^"\\])*")*$`,
+)
 
 // isUpstreamSchemaRejection reports whether err is the API server refusing a field the
 // installed upstream does not declare, as opposed to any other rejection.
@@ -92,12 +107,11 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 	msg := err.Error()
 
-	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
-	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
-	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
-	// containing either phrase on its own must not be misclassified as a version mismatch
-	// and retried forever.
-	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+	// Custom-resource paths: match the complete terminal diagnostic, not independent
+	// substrings. An Invalid status echoes the offending value back, so a user-supplied
+	// string may itself contain both phrases and must not be misclassified as a version
+	// mismatch and retried forever.
+	if strictUnknownFieldRejection.MatchString(msg) {
 		return true
 	}
 
@@ -110,6 +124,56 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 
 	return false
+}
+
+// isRetryableUpstreamWriteError reports failures that can recover without changing the
+// ModelDeployment or cluster configuration. These must not erase last-known serving status:
+// a failed or ambiguous API response does not mean the existing workload stopped serving.
+func isRetryableUpstreamWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.IsConflict(err) || errors.IsAlreadyExists(err) ||
+		errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsTooManyRequests(err) ||
+		errors.IsServiceUnavailable(err) || errors.IsInternalError(err) {
+		return true
+	}
+
+	var status errors.APIStatus
+	if stderrors.As(err, &status) && status.Status().Code >= 500 {
+		return true
+	}
+
+	return stderrors.Is(err, context.DeadlineExceeded) ||
+		stderrors.Is(err, io.EOF) || stderrors.Is(err, io.ErrUnexpectedEOF) ||
+		stderrors.Is(err, syscall.EPIPE) ||
+		utilnet.IsTimeout(err) || utilnet.IsProbableEOF(err) ||
+		utilnet.IsConnectionReset(err) || utilnet.IsConnectionRefused(err) ||
+		utilnet.IsHTTP2ConnectionLost(err)
+}
+
+// resourceWriteError records whether the target was observed as owned, active, and serving
+// before its write. A transient update failure can retain last-known serving status only after
+// that safe observation; create failures, terminating or unready resources, and unverified
+// read failures cannot.
+type resourceWriteError struct {
+	err                              error
+	resourceWasOwnedActiveAndServing bool
+}
+
+func (e *resourceWriteError) Error() string { return e.err.Error() }
+func (e *resourceWriteError) Unwrap() error { return e.err }
+
+func wrapResourceWriteError(err error, resourceWasOwnedActiveAndServing bool) error {
+	if err == nil {
+		return nil
+	}
+	return &resourceWriteError{err: err, resourceWasOwnedActiveAndServing: resourceWasOwnedActiveAndServing}
+}
+
+func canPreserveLastKnownStatus(err error) bool {
+	var writeErr *resourceWriteError
+	return stderrors.As(err, &writeErr) && writeErr.resourceWasOwnedActiveAndServing
 }
 
 // KubeRayProviderReconciler reconciles ModelDeployment resources for the KubeRay provider
@@ -206,18 +270,6 @@ func (r *KubeRayProviderReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	for _, resource := range resources {
 		if err := r.createOrUpdateResource(ctx, resource, &md); err != nil {
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
-			// A 409 is transient: the KubeRay operator writes RayService status frequently,
-			// so the Get→Update window can lose a race. Requeue rather than marking the
-			// deployment Failed — otherwise a still-serving workload loses its endpoint and
-			// replica counts to a race that resolves itself. The other four providers already
-			// guard this; kuberay did not, which made the status clearing below more harmful.
-			if errors.IsConflict(err) {
-				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "ResourceConflict", err.Error())
-				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
-					return ctrl.Result{}, statusErr
-				}
-				return ctrl.Result{RequeueAfter: time.Second}, nil
-			}
 			// Strict field validation rejected the write: the cluster does not accept a field
 			// this provider renders. Give it its own reason so an operator can tell it apart
 			// from a generic create failure, and keep requeueing — the remedy is
@@ -247,33 +299,56 @@ func (r *KubeRayProviderReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 					return ctrl.Result{}, statusErr
 				}
-				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+				return ctrl.Result{RequeueAfter: ExternalRecoveryInterval}, nil
+			}
+			// Conflicts, throttling, server failures, and transport interruptions say nothing
+			// about whether the existing workload is still serving. Record the failed write,
+			// but preserve last-known Phase/Ready/Endpoint/Replicas until a successful read can
+			// replace them.
+			retryableWriteError := isRetryableUpstreamWriteError(err)
+			if retryableWriteError && canPreserveLastKnownStatus(err) {
+				reason := "CreateFailed"
+				if errors.IsConflict(err) || errors.IsAlreadyExists(err) {
+					reason = "ResourceConflict"
+				}
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				requeueAfter := RequeueInterval
+				if errors.IsConflict(err) {
+					// The KubeRay operator updates RayService status frequently. Retry
+					// resourceVersion races promptly with a fresh read.
+					requeueAfter = time.Second
+				}
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
 			}
 			reason := "CreateFailed"
+			// A definite NotFound means the prior workload cannot be assumed to still
+			// exist, so fail closed but retry promptly. Other deterministic API-side
+			// rejections may recover after an admission-policy or cluster change; retry
+			// them at the slower external-recovery cadence.
+			requeueAfter := ExternalRecoveryInterval
+			if errors.IsConflict(err) {
+				requeueAfter = time.Second
+			} else if errors.IsNotFound(err) || retryableWriteError {
+				requeueAfter = RequeueInterval
+			}
 			if isResourceConflict(err) {
-				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
 			}
-			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
-			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
-			// Leaving this branch alone would make the most common failure the one that
-			// still reports healthy — the same shape.
+			// Validation/admission errors and ownership conflicts need an external change.
+			// Fail closed and poll slowly so recovery does not depend on another watched event.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, err.Error())
 			md.Status.Endpoint = nil
 			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create RayService: %s", err.Error())
-			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
-			// leader change, a momentary 500 — and it is the case that most needs a retry.
-			// Without one the second pass writes identical status, which the API server
-			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
-			// its endpoint cleared until the ~10h resync even though the workload may still
-			// be serving.
 			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
-			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 	}
 
@@ -376,7 +451,7 @@ func (r *KubeRayProviderReconciler) createOrUpdateResource(ctx context.Context, 
 	if errors.IsNotFound(err) {
 		// Create new resource
 		logger.Info("Creating resource", "kind", resource.GetKind(), "name", resource.GetName())
-		return r.Create(ctx, resource, strictFieldValidation)
+		return wrapResourceWriteError(r.Create(ctx, resource, strictFieldValidation), false)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get existing resource: %w", err)
@@ -386,6 +461,11 @@ func (r *KubeRayProviderReconciler) createOrUpdateResource(ctx context.Context, 
 	if err := verifyOwnerReference(existing, md.UID); err != nil {
 		return err
 	}
+	resourceWasOwnedActiveAndServing := false
+	if existing.GetDeletionTimestamp() == nil && r.StatusTranslator != nil {
+		statusResult, statusErr := r.StatusTranslator.TranslateStatus(existing)
+		resourceWasOwnedActiveAndServing = statusErr == nil && statusResult.Phase == airunwayv1alpha1.DeploymentPhaseRunning
+	}
 
 	// Update existing resource if spec has changed
 	existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
@@ -394,7 +474,7 @@ func (r *KubeRayProviderReconciler) createOrUpdateResource(ctx context.Context, 
 	if !equality.Semantic.DeepEqual(existingSpec, newSpec) {
 		logger.Info("Updating resource", "kind", resource.GetKind(), "name", resource.GetName())
 		resource.SetResourceVersion(existing.GetResourceVersion())
-		return r.Update(ctx, resource, strictFieldValidation)
+		return wrapResourceWriteError(r.Update(ctx, resource, strictFieldValidation), resourceWasOwnedActiveAndServing)
 	}
 
 	return nil

--- a/providers/kuberay/controller.go
+++ b/providers/kuberay/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -59,6 +60,40 @@ const (
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
 )
+
+// strictFieldValidation makes the API server reject fields the installed upstream does
+// not declare, instead of silently pruning them — see issue #308 and the "Upstream
+// compatibility" section of docs/providers.md. kubectl sends strict validation by default;
+// Go clients do not, so it must be set explicitly on every upstream write.
+var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// isUpstreamSchemaRejection reports whether err is the API server refusing a field the
+// installed upstream does not declare, as opposed to any other rejection.
+//
+// Matching on the message rather than the status class is deliberate, because the class
+// varies by write path:
+//   - custom resource create/update -> 400 BadRequest, "strict decoding error: unknown field"
+//   - custom resource merge patch   -> 422 Invalid,    same prefix (verified live)
+//   - server-side apply on built-in types -> 500, "field not declared in schema"
+//     (verified against a live cluster: the error is a plain error from the field manager,
+//     so it is neither IsBadRequest nor IsInvalid)
+//
+// Gating on IsInvalid alone would also swallow every CEL and OpenAPI type violation, which
+// are user configuration errors that no upstream upgrade would fix — reporting those as an
+// upstream version mismatch would send operators down the wrong path entirely.
+//
+// The needle is the "strict decoding error" prefix rather than the bare "unknown field"
+// cause it wraps, because an Invalid status echoes the offending value back and a
+// user-supplied string (a model id, an image, an engine arg) could otherwise contain the
+// bare phrase and be misclassified.
+func isUpstreamSchemaRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "strict decoding error") ||
+		strings.Contains(msg, "field not declared in schema")
+}
 
 // KubeRayProviderReconciler reconciles ModelDeployment resources for the KubeRay provider
 type KubeRayProviderReconciler struct {
@@ -137,7 +172,14 @@ func (r *KubeRayProviderReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	resources, err := r.Transformer.Transform(ctx, &md)
 	if err != nil {
 		logger.Error(err, "Failed to transform ModelDeployment", "name", md.Name)
+		// Same treatment as the upstream-rejection path below: force Ready False and drop
+		// the stale endpoint/replica counts. Otherwise a previously-Running deployment whose
+		// spec is edited into something unrenderable reports Failed while still advertising
+		// a live endpoint and "1/1 ready" — the contradiction strict validation exists to surface.
 		r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "TransformFailed", err.Error())
+		r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "TransformFailed", err.Error())
+		md.Status.Endpoint = nil
+		md.Status.Replicas = nil
 		md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 		md.Status.Message = fmt.Sprintf("Failed to generate KubeRay resources: %s", err.Error())
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
@@ -147,15 +189,72 @@ func (r *KubeRayProviderReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	for _, resource := range resources {
 		if err := r.createOrUpdateResource(ctx, resource, &md); err != nil {
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
+			// A 409 is transient: the KubeRay operator writes RayService status frequently,
+			// so the Get→Update window can lose a race. Requeue rather than marking the
+			// deployment Failed — otherwise a still-serving workload loses its endpoint and
+			// replica counts to a race that resolves itself. The other four providers already
+			// guard this; kuberay did not, which made the status clearing below more harmful.
+			if errors.IsConflict(err) {
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "ResourceConflict", err.Error())
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				return ctrl.Result{RequeueAfter: time.Second}, nil
+			}
+			// Strict field validation rejected the write: the cluster does not accept a field
+			// this provider renders. Give it its own reason so an operator can tell it apart
+			// from a generic create failure, and keep requeueing — the remedy is
+			// an out-of-band upstream upgrade, and nothing else would re-trigger this
+			// reconcile. The provider-config watch fires only on Spec/Ready changes, and no
+			// upstream object exists to watch, so without a requeue the deployment would sit
+			// Failed until the ~10h resync even after the cluster is fixed.
+			//
+			// Ready is forced False here because the failure it catches is precisely a
+			// deployment that reports healthy while being unable to serve. Note this deliberately does NOT
+			// touch ProviderCompatible: that is set True earlier in this same reconcile, so
+			// flipping it here would rewrite LastTransitionTime on every requeue and the
+			// condition would never settle.
+			if isUpstreamSchemaRejection(err) {
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "IncompatibleUpstream", err.Error())
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "IncompatibleUpstream", err.Error())
+				// Clear the Running-era endpoint and replica counts. This branch returns
+				// before syncStatus, so on an update rejection they would otherwise keep
+				// their previous values and the object would report Failed alongside a live
+				// endpoint and "1/1 ready" — the same contradiction described above.
+				md.Status.Endpoint = nil
+				md.Status.Replicas = nil
+				md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
+				md.Status.Message = fmt.Sprintf("Incompatible with the installed upstream: the installed KubeRay CRD does not declare a field this provider renders. This usually means the cluster's KubeRay is older than this provider requires, or that spec.provider.overrides sets a key it does not support. %s", err.Error())
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			}
 			reason := "CreateFailed"
 			if isResourceConflict(err) {
+				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
-				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "ResourceConflict", err.Error())
 			}
+			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
+			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
+			// Leaving this branch alone would make the most common failure the one that
+			// still reports healthy — the same shape.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, err.Error())
+			md.Status.Endpoint = nil
+			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create RayService: %s", err.Error())
-			return ctrl.Result{}, r.Status().Update(ctx, &md)
+			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
+			// leader change, a momentary 500 — and it is the case that most needs a retry.
+			// Without one the second pass writes identical status, which the API server
+			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
+			// its endpoint cleared until the ~10h resync even though the workload may still
+			// be serving.
+			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
 		}
 	}
 
@@ -258,7 +357,7 @@ func (r *KubeRayProviderReconciler) createOrUpdateResource(ctx context.Context, 
 	if errors.IsNotFound(err) {
 		// Create new resource
 		logger.Info("Creating resource", "kind", resource.GetKind(), "name", resource.GetName())
-		return r.Create(ctx, resource)
+		return r.Create(ctx, resource, strictFieldValidation)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get existing resource: %w", err)
@@ -276,7 +375,7 @@ func (r *KubeRayProviderReconciler) createOrUpdateResource(ctx context.Context, 
 	if !equality.Semantic.DeepEqual(existingSpec, newSpec) {
 		logger.Info("Updating resource", "kind", resource.GetKind(), "name", resource.GetName())
 		resource.SetResourceVersion(existing.GetResourceVersion())
-		return r.Update(ctx, resource)
+		return r.Update(ctx, resource, strictFieldValidation)
 	}
 
 	return nil

--- a/providers/kuberay/upstream_strict_validation_test.go
+++ b/providers/kuberay/upstream_strict_validation_test.go
@@ -13,8 +13,11 @@ package kuberay
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +33,20 @@ import (
 
 	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
 )
+
+func ownedRayServiceNeedingUpdate(t *testing.T, md *airunwayv1alpha1.ModelDeployment) *unstructured.Unstructured {
+	t.Helper()
+
+	resources, err := NewTransformer().Transform(context.Background(), md)
+	if err != nil {
+		t.Fatalf("transform existing RayService: %v", err)
+	}
+	existing := resources[0].DeepCopy()
+	if err := unstructured.SetNestedField(existing.Object, "stale", "spec", "serveConfigV2"); err != nil {
+		t.Fatalf("make existing RayService differ from desired: %v", err)
+	}
+	return existing
+}
 
 // Regression test for upstream schema compatibility.
 //
@@ -184,6 +201,17 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			want: false,
 		},
 		{
+			// Even the complete diagnostic can occur inside an echoed value. The real
+			// strict-decoding cause is terminal; this value is followed by its validation
+			// reason and must not be classified as an upstream mismatch.
+			name: "not ours: full strict diagnostic echoed inside a user value",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					`--served-model-name=strict decoding error: unknown field "spec.fake"`, "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
 			name: "not ours: typed-object wrapper without the schema diagnostic",
 			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
 			want: false,
@@ -194,6 +222,25 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
 				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRetryableUpstreamWriteErrorRecognizesWrappedEOF(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "EOF", err: io.EOF},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF},
+		{name: "broken pipe", err: syscall.EPIPE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !isRetryableUpstreamWriteError(wrapResourceWriteError(tt.err, true)) {
+				t.Errorf("wrapped %v was not classified as retryable", tt.err)
 			}
 		})
 	}
@@ -235,8 +282,9 @@ func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
 	}
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a strict-validation rejection")
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a strict-validation rejection",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -293,20 +341,289 @@ func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
 // transformer cannot actually produce. Recorded here so its absence reads as a decision
 // rather than an oversight.
 
-// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
-// write failure that is neither a transform error nor a schema rejection.
-//
-// It is the most common of the three, and it must not be the one that still reports healthy.
-// Without the clearing, a previously-Running deployment hitting a transient upstream error
-// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
-// this guards against.
-func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+// TestReconcileTransientUpdateFailurePreservesLastKnownStatus covers retryable API failures
+// after the provider observed an owned RayService. A failed update does not prove that the
+// existing workload stopped serving, so its last-known operational status is retained.
+func TestReconcileTransientUpdateFailurePreservesLastKnownStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
+	existing := ownedRayServiceNeedingUpdate(t, md)
+	if err := unstructured.SetNestedSlice(existing.Object, []interface{}{
+		map[string]interface{}{"type": conditionRayServiceReady, "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("mark existing RayService ready: %v", err)
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.RequeueAfter != RequeueInterval {
+		t.Errorf("RequeueAfter = %s, want %s", res.RequeueAfter, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var createdStatus metav1.ConditionStatus
+	var readyStatus metav1.ConditionStatus
+	var readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+			createdStatus = cond.Status
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if createdStatus != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", createdStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+		t.Errorf("Status.Phase = %q, want Running", updated.Status.Phase)
+	}
+	if readyStatus != metav1.ConditionTrue || readyReason != "DeploymentReady" {
+		t.Errorf("Ready = %q reason %q, want True reason DeploymentReady", readyStatus, readyReason)
+	}
+	if updated.Status.Endpoint == nil || updated.Status.Endpoint.Service != "stale-svc" || updated.Status.Endpoint.Port != 8000 {
+		t.Errorf("Status.Endpoint = %+v, want stale-svc:8000", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas == nil || updated.Status.Replicas.Desired != 1 || updated.Status.Replicas.Ready != 1 || updated.Status.Replicas.Available != 1 {
+		t.Errorf("Status.Replicas = %+v, want 1 desired/ready/available", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileTransientUpdateFailureOnUnreadyResourceFailsClosed proves that an active,
+// owned RayService must also be serving before stale ModelDeployment status can be retained.
+func TestReconcileTransientUpdateFailureOnUnreadyResourceFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedKubeRayStaleServingStatus(md)
+
+	existing := ownedRayServiceNeedingUpdate(t, md)
+	if err := unstructured.SetNestedSlice(existing.Object, []interface{}{
+		map[string]interface{}{"type": conditionRayServiceReady, "status": "False"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("mark existing RayService unready: %v", err)
+	}
+
+	var updateCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					updateCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if !updateCalled {
+		t.Fatal("RayService Update was never called; test did not exercise the active unready-resource path")
+	}
+	assertKubeRayPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientUpdateFailureOnTerminatingResourceFailsClosed proves that presence
+// alone is not enough to preserve status. A RayService with a deletion timestamp is no longer
+// a verified serving workload, so an ambiguous update failure must clear stale Ready state and
+// retry normally even when the object is still owned by this ModelDeployment.
+func TestReconcileTransientUpdateFailureOnTerminatingResourceFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedKubeRayStaleServingStatus(md)
+
+	existing := ownedRayServiceNeedingUpdate(t, md)
+	if err := unstructured.SetNestedSlice(existing.Object, []interface{}{
+		map[string]interface{}{"type": conditionRayServiceReady, "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("mark existing RayService ready: %v", err)
+	}
+	existing.SetFinalizers([]string{"test.airunway.ai/hold"})
+	deletingAt := metav1.Now()
+	existing.SetDeletionTimestamp(&deletingAt)
+	updateCalled := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					updateCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient update failure"))
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the update failure should be reported in status: %v", err)
+	}
+	if !updateCalled {
+		t.Fatal("RayService Update was never called")
+	}
+	assertKubeRayPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientGetFailureFailsClosed proves an API read failure cannot preserve
+// stale status: the provider never verified that an active, owned RayService exists. The read
+// error is retryable, but status must fail closed until a later successful observation.
+func TestReconcileTransientGetFailureFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedKubeRayStaleServingStatus(md)
+
+	rayServiceGetCalled := false
+	writeCalled := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					rayServiceGetCalled = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient get failure"))
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					writeCalled = true
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					writeCalled = true
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the read failure should be reported in status: %v", err)
+	}
+	if !rayServiceGetCalled {
+		t.Fatal("RayService Get was never called")
+	}
+	if writeCalled {
+		t.Fatal("RayService write was attempted after its Get failed")
+	}
+	assertKubeRayPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+func seedKubeRayStaleServingStatus(md *airunwayv1alpha1.ModelDeployment) {
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+}
+
+func assertKubeRayPromptRetryFailedClosed(t *testing.T, c client.Client, res ctrl.Result, key types.NamespacedName) {
+	t.Helper()
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s", res, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), key, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
+	for _, cond := range updated.Status.Conditions {
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeResourceCreated]; got != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileTransientCreateFailureFailsClosed covers a retryable write failure after the
+// provider observed that no RayService exists. There is no known serving workload to preserve,
+// so status must fail closed while the provider retries promptly.
+func TestReconcileTransientCreateFailureFailsClosed(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
 	controllerutil.AddFinalizer(md, FinalizerName)
 	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
 	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
-	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
@@ -323,34 +640,180 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
 	})
 	if err != nil {
-		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+		t.Fatalf("reconcile returned an error; the create failure should be reported in status: %v", err)
 	}
-	// A generic write failure is usually transient, so it must retry. Without a requeue the
-	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
-	// deployment sits Failed with no endpoint until the default resync.
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a transient write failure")
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a transient create failure",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
 	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	var createdReason string
-	var readyStatus metav1.ConditionStatus
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
 	for _, cond := range updated.Status.Conditions {
-		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
-			createdReason = cond.Reason
-		}
-		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
-			readyStatus = cond.Status
-		}
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
 	}
-	if createdReason != "CreateFailed" {
-		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
 	}
-	if readyStatus != metav1.ConditionFalse {
-		t.Errorf("Ready = %q, want False", readyStatus)
+	if got := statuses[airunwayv1alpha1.ConditionTypeResourceCreated]; got != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileNotFoundFailsClosedAndRetries distinguishes an explicit missing-resource
+// response from an ambiguous transport failure. NotFound disproves the stale serving state,
+// but a prompt retry can recreate the resource once the API race or dependency resolves.
+func TestReconcileNotFoundFailsClosedAndRetries(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	notFound := apierrors.NewNotFound(
+		schema.GroupResource{Group: RayAPIGroup, Resource: "rayservices"},
+		"test",
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					return notFound
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; NotFound should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after NotFound",
+			res.Requeue, res.RequeueAfter, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
+	for _, cond := range updated.Status.Conditions {
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileValidationFailureFailsClosedAndRetriesSlowly distinguishes deterministic
+// admission failures from retryable transport errors and schema-version mismatches. It fails
+// closed and polls slowly so an external admission-policy fix can recover without another event.
+func TestReconcileValidationFailureFailsClosedAndRetriesSlowly(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	rejection := apierrors.NewInvalid(
+		schema.GroupKind{Group: RayAPIGroup, Kind: RayServiceKind},
+		"test",
+		field.ErrorList{field.Invalid(
+			field.NewPath("spec", "rayClusterConfig", "workerGroupSpecs").Index(0).Child("replicas"),
+			int64(0),
+			"must be greater than zero",
+		)},
+	)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					return rejection
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the validation failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s for a deterministic validation failure",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
+	for _, cond := range updated.Status.Conditions {
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeResourceCreated]; got != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
 	}
 	if updated.Status.Endpoint != nil {
 		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
@@ -370,20 +833,34 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 func TestReconcileRequeuesOnConflictWithoutClearingStatus(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
 	controllerutil.AddFinalizer(md, FinalizerName)
 	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
 	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "live-svc", Port: 8000}
 	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+	existing := ownedRayServiceNeedingUpdate(t, md)
+	if err := unstructured.SetNestedSlice(existing.Object, []interface{}{
+		map[string]interface{}{"type": conditionRayServiceReady, "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("mark existing RayService ready: %v", err)
+	}
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+	var updateCalled bool
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, existing).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
 				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					updateCalled = true
 					return apierrors.NewConflict(
 						schema.GroupResource{Group: "ray.io", Resource: "rayservices"}, "test",
 						fmt.Errorf("the object has been modified"))
 				}
-				return cl.Create(ctx, obj, opts...)
+				return cl.Update(ctx, obj, opts...)
 			},
 		}).Build()
 
@@ -395,8 +872,12 @@ func TestReconcileRequeuesOnConflictWithoutClearingStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; a conflict should requeue: %v", err)
 	}
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a transient conflict")
+	if !updateCalled {
+		t.Fatal("Update was never called; test did not exercise the owned existing-resource path")
+	}
+	if res.Requeue || res.RequeueAfter != time.Second {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s after a transient conflict",
+			res.Requeue, res.RequeueAfter, time.Second)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -411,6 +892,11 @@ func TestReconcileRequeuesOnConflictWithoutClearingStatus(t *testing.T) {
 	}
 	if updated.Status.Replicas == nil {
 		t.Error("a transient conflict must not clear replica counts")
+	}
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady && cond.Status != metav1.ConditionTrue {
+			t.Errorf("Ready = %q, want True after transient update conflict", cond.Status)
+		}
 	}
 }
 
@@ -439,10 +925,15 @@ func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
 	r := NewKubeRayProviderReconciler(c, scheme)
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile returned an error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %v, RequeueAfter = %s; want false and %s for an ownership conflict",
+			res.Requeue, res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment

--- a/providers/kuberay/upstream_strict_validation_test.go
+++ b/providers/kuberay/upstream_strict_validation_test.go
@@ -173,6 +173,21 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			}),
 			want: false,
 		},
+		{
+			// The needle requires BOTH halves. An Invalid status echoes the offending value
+			// back, so a user-supplied string containing only the prefix must not match.
+			name: "not ours: 'strict decoding error' echoed without an unknown-field cause",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=strict decoding error probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
+			name: "not ours: typed-object wrapper without the schema diagnostic",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
+			want: false,
+		},
 		{name: "nil", err: nil, want: false},
 	}
 	for _, tc := range cases {

--- a/providers/kuberay/upstream_strict_validation_test.go
+++ b/providers/kuberay/upstream_strict_validation_test.go
@@ -1,0 +1,456 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package kuberay
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
+)
+
+// Regression test for upstream schema compatibility.
+//
+// Every write to the upstream resource must carry fieldValidation=Strict, so the API
+// server rejects fields the installed upstream does not declare instead of silently
+// pruning them. Without it the shim can render a field the cluster drops without any
+// error, leaving a workload that reports healthy but cannot serve.
+//
+// This asserts the option reaches the client. It deliberately does NOT assert the API
+// server's behaviour — the fake client has no structural schema and cannot prune, which
+// is exactly why no pre-existing test caught this bug.
+
+func TestUpstreamWritesUseStrictFieldValidation(t *testing.T) {
+	owner := []metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "test",
+		UID:        types.UID("test-uid"),
+	}}
+
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.UID = types.UID("test-uid")
+
+	desired := func() *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		setRayServiceGVK(u)
+		u.SetName("test")
+		u.SetNamespace("default")
+		u.SetOwnerReferences(owner)
+		u.Object["spec"] = map[string]interface{}{"serveConfigV2": "desired"}
+		return u
+	}
+
+	t.Run("create", func(t *testing.T) {
+		var got string
+		var called bool
+		c := fake.NewClientBuilder().WithScheme(newScheme()).WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				called = true
+				o := &client.CreateOptions{}
+				for _, opt := range opts {
+					opt.ApplyToCreate(o)
+				}
+				got = o.FieldValidation
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+		r := NewKubeRayProviderReconciler(c, newScheme())
+		if err := r.createOrUpdateResource(context.Background(), desired(), md); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("Create was never called")
+		}
+		if got != metav1.FieldValidationStrict {
+			t.Errorf("create fieldValidation = %q, want %q", got, metav1.FieldValidationStrict)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		existing := &unstructured.Unstructured{}
+		setRayServiceGVK(existing)
+		existing.SetName("test")
+		existing.SetNamespace("default")
+		existing.SetOwnerReferences(owner)
+		existing.Object["spec"] = map[string]interface{}{"serveConfigV2": "stale"}
+
+		var got string
+		var called bool
+		c := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(existing).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+					called = true
+					o := &client.UpdateOptions{}
+					for _, opt := range opts {
+						opt.ApplyToUpdate(o)
+					}
+					got = o.FieldValidation
+					return cl.Update(ctx, obj, opts...)
+				},
+			}).Build()
+
+		r := NewKubeRayProviderReconciler(c, newScheme())
+		if err := r.createOrUpdateResource(context.Background(), desired(), md); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("Update was never called")
+		}
+		if got != metav1.FieldValidationStrict {
+			t.Errorf("update fieldValidation = %q, want %q", got, metav1.FieldValidationStrict)
+		}
+	})
+}
+
+// TestIsUpstreamSchemaRejection pins the matcher to error strings observed against a live
+// cluster. The API server's response class varies by write path — custom-resource create is
+// 400, merge patch is 422, and server-side apply on a built-in type is **500** (the error
+// comes from the field manager, not from field validation) — which is why this matches on
+// message rather than status code.
+//
+// The negative cases are the point: gating on IsInvalid would capture ordinary CEL and type
+// violations and report them as an upstream version mismatch, sending an operator off to
+// upgrade a cluster that is already fine.
+func TestIsUpstreamSchemaRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "observed: custom resource create against an older CRD (400)",
+			err:  apierrors.NewBadRequest(`strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`),
+			want: true,
+		},
+		{
+			// kuberay itself never uses server-side apply; kept so the shared matcher
+			// behaves identically across providers if the write path ever changes.
+			name: "server-side apply on a built-in type (500) — not a path kuberay takes",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.bogus: field not declared in schema"),
+			want: true,
+		},
+		{
+			name: "not ours: CEL or type validation failure the user must fix",
+			err:  apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", nil),
+			want: false,
+		},
+		{
+			// The reason the needle is "strict decoding error" and not the bare
+			// "unknown field": an Invalid status echoes the offending value back, so a
+			// user-supplied string can contain the bare phrase. Classifying this as an
+			// upstream mismatch would tell an operator to upgrade a cluster that is fine,
+			// and retry every 30s forever.
+			name: "not ours: Invalid echoing a user value that contains the bare phrase",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=unknown field probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
+				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReconcileRequeuesOnStrictRejection covers the recovery path for the failure mode
+// strict validation introduces. A schema rejection is terminal from the controller's point
+// of view — the remedy is an out-of-band upstream upgrade — and nothing in the watch set
+// re-triggers this reconcile afterwards, so without an explicit requeue the deployment
+// would sit Failed until the ~10h resync even after the cluster is fixed.
+func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Seed the Running-era status. Without this the clearing below is a no-op the
+	// assertions cannot observe, and deleting it from the controller would not fail
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	rejection := apierrors.NewBadRequest(`strict decoding error: unknown field "spec.someNewerField"`)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					return rejection
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a strict-validation rejection")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reasons := map[string]string{}
+	statuses := map[string]metav1.ConditionStatus{}
+	for _, cond := range updated.Status.Conditions {
+		reasons[cond.Type] = cond.Reason
+		statuses[cond.Type] = cond.Status
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "IncompatibleUpstream" {
+		t.Errorf("ResourceCreated reason = %q, want %q", got, "IncompatibleUpstream")
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False — #308 is about reporting healthy while broken", got)
+	}
+	// docs/providers.md promises BOTH conditions carry this reason.
+	if got := reasons[airunwayv1alpha1.ConditionTypeReady]; got != "IncompatibleUpstream" {
+		t.Errorf("Ready reason = %q, want IncompatibleUpstream", got)
+	}
+	// ProviderCompatible is deliberately NOT touched here: it is set True earlier in the same
+	// reconcile, so flipping it would rewrite LastTransitionTime on every 30s requeue and the
+	// condition would never settle — a permanent status-write loop.
+	if got := statuses[airunwayv1alpha1.ConditionTypeProviderCompatible]; got != metav1.ConditionTrue {
+		t.Errorf("ProviderCompatible = %q, want True — flipping it here causes permanent churn", got)
+	}
+
+	// docs/providers.md promises this provider names the offending field in status.message.
+	if !strings.Contains(updated.Status.Message, "someNewerField") {
+		t.Errorf("status.message does not name the offending field: %q", updated.Status.Message)
+	}
+
+	// Stale endpoint/replicas must be cleared. Reporting Failed alongside a live endpoint
+	// and "1/1 ready" is the same contradiction.
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil — a Failed deployment must not still advertise an endpoint", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+}
+
+// NOTE: there is deliberately no TestReconcileTransformFailureClearsStaleStatus here.
+//
+// The other four providers can be driven into the Transform-error branch with an unsupported
+// provider.overrides root key. KubeRay does not read spec.provider.overrides at all, and
+// buildRayClusterConfig/buildSpec have no error returns reachable from a ModelDeployment
+// spec — so that branch is defensive only, and any test would have to fake a failure the
+// transformer cannot actually produce. Recorded here so its absence reads as a decision
+// rather than an oversight.
+
+// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
+// write failure that is neither a transform error nor a schema rejection.
+//
+// It is the most common of the three, and it must not be the one that still reports healthy.
+// Without the clearing, a previously-Running deployment hitting a transient upstream error
+// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
+// this guards against.
+func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	// A generic write failure is usually transient, so it must retry. Without a requeue the
+	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
+	// deployment sits Failed with no endpoint until the default resync.
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a transient write failure")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileRequeuesOnConflictWithoutClearingStatus covers the 409 guard.
+//
+// The KubeRay operator writes RayService status frequently, so this provider's
+// Get-then-Update window can lose a race. A 409 is transient and must NOT be treated as a
+// failure: before this guard existed a lost race would clear the endpoint and replica counts
+// and mark a still-serving workload Failed with no requeue. The other four providers already
+// had this guard; kuberay did not.
+func TestReconcileRequeuesOnConflictWithoutClearingStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "live-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == RayServiceKind {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "ray.io", Resource: "rayservices"}, "test",
+						fmt.Errorf("the object has been modified"))
+				}
+				return cl.Create(ctx, obj, opts...)
+			},
+		}).Build()
+
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; a conflict should requeue: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a transient conflict")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status.Phase == airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Error("a transient conflict must not mark the deployment Failed")
+	}
+	if updated.Status.Endpoint == nil {
+		t.Error("a transient conflict must not clear the endpoint of a still-serving workload")
+	}
+	if updated.Status.Replicas == nil {
+		t.Error("a transient conflict must not clear replica counts")
+	}
+}
+
+// TestReconcileOwnershipConflictUsesItsOwnReason covers the ownership-collision branch.
+//
+// An upstream object of the right name already exists but belongs to someone else. That is
+// terminal — unlike a transient API 409 — so it is reported under its own reason rather than
+// the generic CreateFailed.
+func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Same name, different owner.
+	foreign := &unstructured.Unstructured{}
+	setRayServiceGVK(foreign)
+	foreign.SetName("test")
+	foreign.SetNamespace("default")
+	foreign.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "someone-else",
+		UID:        types.UID("a-different-uid"),
+	}})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
+	r := NewKubeRayProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var reason, readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			reason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyReason = cond.Reason
+		}
+	}
+	// The branch comment claims "Ready is set below unconditionally with this same reason".
+	// Hold it: an operator alerting on Ready.reason=ResourceConflict needs to distinguish a
+	// collision needing manual intervention from a transient CreateFailed that will retry.
+	if readyReason != "ResourceConflict" {
+		t.Errorf("Ready reason = %q, want ResourceConflict", readyReason)
+	}
+	if reason != "ResourceConflict" {
+		t.Errorf("ResourceCreated reason = %q, want ResourceConflict — an ownership collision "+
+			"must be distinguishable from a generic create failure", reason)
+	}
+}

--- a/providers/llmd/controller.go
+++ b/providers/llmd/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +55,83 @@ const (
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
 )
+
+// strictFieldValidation makes the API server reject fields the target schema does not
+// declare, instead of silently pruning them — see issue #308 and the "Upstream
+// compatibility" section of docs/providers.md.
+//
+// This provider renders built-in apps/v1 and v1 types via server-side apply, where the
+// field manager ALREADY rejects unknown fields during typed conversion regardless of this
+// option (verified: an SSA apply with validation explicitly ignored still fails with
+// "field not declared in schema"). So here this mainly adds duplicate-key detection and
+// keeps one uniform rule across all five providers; the providers that write third-party
+// CRDs are the ones it genuinely protects.
+var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// statusSafeRejectionDetail returns a form of err that is stable across identical calls, for
+// storing in status.
+//
+// Server-side apply reports only the FIRST unknown field it encounters, and with more than
+// one it picks a different field each time. Two independent confirmations:
+//   - mechanism: structured-merge-diff's typed/validate.go appends one error and returns out
+//     of the map walk, and value/mapunstructured.go iterates a plain Go map, so the field
+//     chosen is whichever the randomised iteration reached first;
+//   - observed: against a live API server, three unknown fields on one Deployment produced
+//     three different messages across twelve identical apply calls. Putting that straight into
+//
+// status.message — or into a condition Message, which is status too — would rewrite status on
+// every reconcile, and since the ModelDeployment watch has no GenerationChangedPredicate each
+// write re-enqueues the object: an unbounded loop.
+//
+// Custom-resource strict decoding does not have this problem: apimachinery sorts the unknown
+// field paths and lists them all, so those messages pass through unchanged.
+//
+// Applied on the generic-failure path too: a server-side apply TYPE mismatch carries the same
+// wrapper without the unknown-field needle, so it lands there rather than in the rejection
+// branch — and structured-merge-diff accumulates type errors without sorting them, so their
+// concatenation order follows map iteration and is just as volatile.
+//
+// The full error is always logged; only the stored copy is normalised.
+func statusSafeRejectionDetail(err error) string {
+	msg := err.Error()
+	// These are the two wrappers apimachinery's structuredmerge can produce on the APPLY
+	// path. It has two more ("failed to convert new/live object … to smd typed") carrying the
+	// same payload on the non-apply Update path, which this provider never takes — add them
+	// here if that ever changes, or the volatile detail gets through and the loop returns.
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return "the offending field and the exact reason are in the controller logs"
+	}
+	return msg
+}
+
+// isUpstreamSchemaRejection reports whether err is the API server refusing a field the
+// installed upstream does not declare, as opposed to any other rejection.
+//
+// Matching on the message rather than the status class is deliberate, because the class
+// varies by write path:
+//   - custom resource create/update -> 400 BadRequest, "strict decoding error: unknown field"
+//   - custom resource merge patch   -> 422 Invalid,    same prefix (verified live)
+//   - server-side apply on built-in types -> 500, "field not declared in schema"
+//     (verified against a live cluster: the error is a plain error from the field manager,
+//     so it is neither IsBadRequest nor IsInvalid)
+//
+// Gating on IsInvalid alone would also swallow every CEL and OpenAPI type violation, which
+// are user configuration errors that no upstream upgrade would fix — reporting those as an
+// upstream version mismatch would send operators down the wrong path entirely.
+//
+// The needle is the "strict decoding error" prefix rather than the bare "unknown field"
+// cause it wraps, because an Invalid status echoes the offending value back and a
+// user-supplied string (a model id, an image, an engine arg) could otherwise contain the
+// bare phrase and be misclassified.
+func isUpstreamSchemaRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "strict decoding error") ||
+		strings.Contains(msg, "field not declared in schema")
+}
 
 var (
 	deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
@@ -138,7 +216,14 @@ func (r *LLMDProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	resources, err := r.Transformer.Transform(ctx, &md)
 	if err != nil {
 		logger.Error(err, "Failed to transform ModelDeployment", "name", md.Name)
+		// Same treatment as the upstream-rejection path below: force Ready False and drop
+		// the stale endpoint/replica counts. Otherwise a previously-Running deployment whose
+		// spec is edited into something unrenderable reports Failed while still advertising
+		// a live endpoint and "1/1 ready" — the contradiction strict validation exists to surface.
 		r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "TransformFailed", err.Error())
+		r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "TransformFailed", err.Error())
+		md.Status.Endpoint = nil
+		md.Status.Replicas = nil
 		md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 		md.Status.Message = fmt.Sprintf("Failed to generate llm-d resources: %s", err.Error())
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
@@ -153,15 +238,61 @@ func (r *LLMDProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				return ctrl.Result{Requeue: true}, nil
 			}
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
+			// Strict field validation rejected the write: the cluster does not accept a field
+			// this provider renders. Give it its own reason so an operator can tell it apart
+			// from a generic create failure, and keep requeueing — the remedy is
+			// an out-of-band upstream upgrade, and nothing else would re-trigger this
+			// reconcile. The provider-config watch fires only on Spec/Ready changes, and no
+			// upstream object exists to watch, so without a requeue the deployment would sit
+			// Failed until the ~10h resync even after the cluster is fixed.
+			//
+			// Ready is forced False here because the failure it catches is precisely a
+			// deployment that reports healthy while being unable to serve. Note this deliberately does NOT
+			// touch ProviderCompatible: that is set True earlier in this same reconcile, so
+			// flipping it here would rewrite LastTransitionTime on every requeue and the
+			// condition would never settle.
+			if isUpstreamSchemaRejection(err) {
+				detail := statusSafeRejectionDetail(err)
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "IncompatibleUpstream", detail)
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "IncompatibleUpstream", detail)
+				// Clear the Running-era endpoint and replica counts. This branch returns
+				// before syncStatus, so on an update rejection they would otherwise keep
+				// their previous values and the object would report Failed alongside a live
+				// endpoint and "1/1 ready" — the same contradiction described above.
+				md.Status.Endpoint = nil
+				md.Status.Replicas = nil
+				md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
+				md.Status.Message = fmt.Sprintf("Incompatible with the installed upstream: the cluster rejected a field in the rendered resource. This provider renders built-in Kubernetes types, so it usually means spec.provider.overrides sets a field that does not exist, or the cluster's Kubernetes version predates a field this provider uses. %s", detail)
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			}
 			reason := "CreateFailed"
 			if isResourceConflict(err) {
+				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
-				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "ResourceConflict", err.Error())
 			}
-			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
+			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
+			// Leaving this branch alone would make the most common failure the one that
+			// still reports healthy — the same shape.
+			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
+			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
+			md.Status.Endpoint = nil
+			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
-			md.Status.Message = fmt.Sprintf("Failed to create/update resource %s: %s", resource.GetName(), err.Error())
-			return ctrl.Result{}, r.Status().Update(ctx, &md)
+			md.Status.Message = fmt.Sprintf("Failed to create/update resource %s: %s", resource.GetName(), statusSafeRejectionDetail(err))
+			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
+			// leader change, a momentary 500 — and it is the case that most needs a retry.
+			// Without one the second pass writes identical status, which the API server
+			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
+			// its endpoint cleared until the ~10h resync even though the workload may still
+			// be serving.
+			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
 		}
 	}
 
@@ -278,7 +409,7 @@ func (r *LLMDProviderReconciler) createOrUpdateResource(ctx context.Context, res
 	// Server-side apply: handles both create and update without needing resourceVersion.
 	// ForceOwnership ensures our field manager wins over any conflicting field managers.
 	logger.Info("Applying resource", "kind", resource.GetKind(), "name", resource.GetName())
-	return r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership)
+	return r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership, strictFieldValidation)
 }
 
 // syncStatus fetches the primary Deployment and syncs its status to the ModelDeployment

--- a/providers/llmd/controller.go
+++ b/providers/llmd/controller.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"strings"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -51,6 +54,10 @@ const (
 
 	// RequeueInterval is the default requeue interval for periodic reconciliation
 	RequeueInterval = 30 * time.Second
+
+	// ExternalRecoveryInterval retries failures that require an out-of-band fix without
+	// hot-looping while the installed upstream or resource ownership remains unchanged.
+	ExternalRecoveryInterval = 5 * time.Minute
 
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
@@ -135,6 +142,63 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 
 	return false
+}
+
+// isRetryableUpstreamWriteError reports failures that can recover without changing the
+// ModelDeployment or cluster configuration. These must not erase last-known serving status:
+// a failed or ambiguous API response does not mean the existing workload stopped serving.
+func isRetryableUpstreamWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// The API server may wrap deterministic structured-merge-diff conversion failures in
+	// an HTTP 500. Retrying the identical rendered object cannot make those succeed; schema
+	// unknown-field errors are classified separately before this helper is called.
+	msg := err.Error()
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return false
+	}
+	if errors.IsConflict(err) || errors.IsAlreadyExists(err) ||
+		errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsTooManyRequests(err) ||
+		errors.IsServiceUnavailable(err) || errors.IsInternalError(err) {
+		return true
+	}
+
+	var status errors.APIStatus
+	if stderrors.As(err, &status) && status.Status().Code >= 500 {
+		return true
+	}
+
+	return stderrors.Is(err, context.DeadlineExceeded) ||
+		stderrors.Is(err, io.EOF) || stderrors.Is(err, io.ErrUnexpectedEOF) ||
+		stderrors.Is(err, syscall.EPIPE) ||
+		utilnet.IsTimeout(err) || utilnet.IsProbableEOF(err) ||
+		utilnet.IsConnectionReset(err) || utilnet.IsConnectionRefused(err) ||
+		utilnet.IsHTTP2ConnectionLost(err)
+}
+
+// resourceWriteError records whether the target was observed before its write. A transient
+// update failure can retain last-known serving status; a transient create failure cannot,
+// because the controller had just observed that the required resource was absent.
+type resourceWriteError struct {
+	err             error
+	resourceExisted bool
+}
+
+func (e *resourceWriteError) Error() string { return e.err.Error() }
+func (e *resourceWriteError) Unwrap() error { return e.err }
+
+func wrapResourceWriteError(err error, resourceExisted bool) error {
+	if err == nil {
+		return nil
+	}
+	return &resourceWriteError{err: err, resourceExisted: resourceExisted}
+}
+
+func canPreserveLastKnownStatus(err error) bool {
+	var writeErr *resourceWriteError
+	return !stderrors.As(err, &writeErr) || writeErr.resourceExisted
 }
 
 var (
@@ -233,14 +297,14 @@ func (r *LLMDProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
 	}
 
+	// Status may be preserved after an ambiguous update failure only when every required
+	// resource existed before this write pass. Otherwise a successfully recreated earlier
+	// resource followed by a failed later update could leave stale Ready=True status.
+	preserveLastKnownStatusSafe := r.allRequiredResourcesAreOwnedActiveAndServing(ctx, resources, md.UID)
+
 	// Create or update all resources
 	for _, resource := range resources {
 		if err := r.createOrUpdateResource(ctx, resource, &md); err != nil {
-			// Transient API conflict — requeue instead of marking as failed
-			if errors.IsConflict(err) {
-				logger.Info("Resource conflict during reconcile, requeueing", "name", resource.GetName())
-				return ctrl.Result{Requeue: true}, nil
-			}
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
 			// Strict field validation rejected the write: the cluster does not accept a field
 			// this provider renders. Give it its own reason so an operator can tell it apart
@@ -270,34 +334,59 @@ func (r *LLMDProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 					return ctrl.Result{}, statusErr
 				}
-				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+				return ctrl.Result{RequeueAfter: ExternalRecoveryInterval}, nil
+			}
+			// Conflicts, throttling, server failures, and transport interruptions say nothing
+			// about whether the existing workload is still serving. Record the failed write,
+			// but preserve last-known Phase/Ready/Endpoint/Replicas until a successful read can
+			// replace them.
+			retryableWriteError := isRetryableUpstreamWriteError(err)
+			if retryableWriteError && preserveLastKnownStatusSafe && canPreserveLastKnownStatus(err) {
+				reason := "CreateFailed"
+				if errors.IsConflict(err) || errors.IsAlreadyExists(err) {
+					reason = "ResourceConflict"
+				}
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				requeueAfter := RequeueInterval
+				if errors.IsConflict(err) {
+					requeueAfter = time.Second
+				}
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
 			}
 			reason := "CreateFailed"
+			// A definite NotFound means the prior workload cannot be assumed to still
+			// exist, so fail closed but retry promptly. Other deterministic API-side
+			// rejections may recover after an admission-policy or cluster change; retry
+			// them at the slower external-recovery cadence.
+			requeueAfter := ExternalRecoveryInterval
+			if errors.IsConflict(err) {
+				requeueAfter = time.Second
+			} else if errors.IsNotFound(err) || retryableWriteError {
+				requeueAfter = RequeueInterval
+			}
 			if isResourceConflict(err) {
-				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
 			}
-			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
-			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
-			// Leaving this branch alone would make the most common failure the one that
-			// still reports healthy — the same shape.
+			// Validation/admission errors and ownership conflicts need an external change.
+			// Fail closed and poll slowly so recovery does not depend on another watched event.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
 			md.Status.Endpoint = nil
 			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create/update resource %s: %s", resource.GetName(), statusSafeRejectionDetail(err))
-			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
-			// leader change, a momentary 500 — and it is the case that most needs a retry.
-			// Without one the second pass writes identical status, which the API server
-			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
-			// its endpoint cleared until the ~10h resync even though the workload may still
-			// be serving.
 			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
-			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
+		// Once any earlier resource write succeeds, the pre-write serving snapshot no
+		// longer proves the complete resource set is still serving. A later ambiguous
+		// failure must therefore fail closed instead of retaining stale Ready status.
+		preserveLastKnownStatusSafe = false
 	}
 
 	r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionTrue, "ResourceCreated", "Deployments and Services created successfully")
@@ -402,7 +491,8 @@ func (r *LLMDProviderReconciler) createOrUpdateResource(ctx context.Context, res
 		Name:      resource.GetName(),
 		Namespace: resource.GetNamespace(),
 	}, existing)
-	if err == nil {
+	resourceExisted := err == nil
+	if resourceExisted {
 		if err := verifyOwnerReference(existing, md.UID); err != nil {
 			return err
 		}
@@ -413,7 +503,49 @@ func (r *LLMDProviderReconciler) createOrUpdateResource(ctx context.Context, res
 	// Server-side apply: handles both create and update without needing resourceVersion.
 	// ForceOwnership ensures our field manager wins over any conflicting field managers.
 	logger.Info("Applying resource", "kind", resource.GetKind(), "name", resource.GetName())
-	return r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership, strictFieldValidation)
+	return wrapResourceWriteError(
+		r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership, strictFieldValidation),
+		resourceExisted,
+	)
+}
+
+// allRequiredResourcesAreOwnedActiveAndServing snapshots whether the complete rendered
+// resource set was present, owned by this ModelDeployment, and not terminating before
+// reconciliation starts mutating it. Every Deployment must also be Running; otherwise stale
+// serving status is unsafe to preserve if a later write fails ambiguously.
+func (r *LLMDProviderReconciler) allRequiredResourcesAreOwnedActiveAndServing(
+	ctx context.Context,
+	resources []*unstructured.Unstructured,
+	mdUID types.UID,
+) bool {
+	if r.StatusTranslator == nil {
+		return false
+	}
+	foundDeployment := false
+	for _, resource := range resources {
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(resource.GroupVersionKind())
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      resource.GetName(),
+			Namespace: resource.GetNamespace(),
+		}, existing); err != nil {
+			return false
+		}
+		if existing.GetDeletionTimestamp() != nil {
+			return false
+		}
+		if err := verifyOwnerReference(existing, mdUID); err != nil {
+			return false
+		}
+		if existing.GroupVersionKind() == deploymentGVK {
+			foundDeployment = true
+			statusResult, err := r.StatusTranslator.TranslateStatus(existing)
+			if err != nil || statusResult.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+				return false
+			}
+		}
+	}
+	return foundDeployment
 }
 
 // syncStatus fetches the primary Deployment and syncs its status to the ModelDeployment

--- a/providers/llmd/controller.go
+++ b/providers/llmd/controller.go
@@ -129,8 +129,25 @@ func isUpstreamSchemaRejection(err error) bool {
 		return false
 	}
 	msg := err.Error()
-	return strings.Contains(msg, "strict decoding error") ||
-		strings.Contains(msg, "field not declared in schema")
+
+	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
+	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
+	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
+	// containing either phrase on its own must not be misclassified as a version mismatch
+	// and retried forever.
+	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+		return true
+	}
+
+	// Server-side apply on built-in types: the rejection comes from the field manager's
+	// typed conversion, not from field validation, so it carries a different wrapper and a
+	// different status class. Bind the diagnostic to that wrapper for the same reason.
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return strings.Contains(msg, "field not declared in schema")
+	}
+
+	return false
 }
 
 var (

--- a/providers/llmd/controller.go
+++ b/providers/llmd/controller.go
@@ -108,40 +108,27 @@ func statusSafeRejectionDetail(err error) string {
 // isUpstreamSchemaRejection reports whether err is the API server refusing a field the
 // installed upstream does not declare, as opposed to any other rejection.
 //
-// Matching on the message rather than the status class is deliberate, because the class
-// varies by write path:
-//   - custom resource create/update -> 400 BadRequest, "strict decoding error: unknown field"
-//   - custom resource merge patch   -> 422 Invalid,    same prefix (verified live)
-//   - server-side apply on built-in types -> 500, "field not declared in schema"
-//     (verified against a live cluster: the error is a plain error from the field manager,
-//     so it is neither IsBadRequest nor IsInvalid)
+// This provider renders only built-in types — apps/v1 Deployment and v1 Service — and writes
+// them through server-side apply, so that is the only rejection shape it can receive. It
+// arrives as a plain error from the field manager's typed conversion
+// (structured-merge-diff, typed/validate.go), neither IsBadRequest nor IsInvalid, which is
+// why the match is on the message rather than the status class. Gating on IsInvalid would
+// additionally swallow every CEL and OpenAPI type violation — user configuration errors no
+// upstream upgrade would fix.
 //
-// Gating on IsInvalid alone would also swallow every CEL and OpenAPI type violation, which
-// are user configuration errors that no upstream upgrade would fix — reporting those as an
-// upstream version mismatch would send operators down the wrong path entirely.
-//
-// The needle is the "strict decoding error" prefix rather than the bare "unknown field"
-// cause it wraps, because an Invalid status echoes the offending value back and a
-// user-supplied string (a model id, an image, an engine arg) could otherwise contain the
-// bare phrase and be misclassified.
+// The custom-resource shape ("strict decoding error: unknown field", 400 on create/update and
+// 422 on merge patch) is deliberately NOT matched here: it is unreachable for this provider,
+// and matching it would only create a way to misclassify an ordinary validation error whose
+// echoed value happens to contain that phrasing — reported as a version mismatch and retried
+// forever. The providers that do write custom resources match it in their own copy.
 func isUpstreamSchemaRejection(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := err.Error()
 
-	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
-	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
-	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
-	// containing either phrase on its own must not be misclassified as a version mismatch
-	// and retried forever.
-	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
-		return true
-	}
-
-	// Server-side apply on built-in types: the rejection comes from the field manager's
-	// typed conversion, not from field validation, so it carries a different wrapper and a
-	// different status class. Bind the diagnostic to that wrapper for the same reason.
+	// Bind the diagnostic to the wrapper, so an error that merely echoes the phrase back
+	// cannot match on the phrase alone.
 	if strings.Contains(msg, "failed to create typed patch object") ||
 		strings.Contains(msg, "failed to create typed live object") {
 		return strings.Contains(msg, "field not declared in schema")

--- a/providers/llmd/controller.go
+++ b/providers/llmd/controller.go
@@ -576,6 +576,10 @@ func (r *LLMDProviderReconciler) syncStatus(ctx context.Context, md *airunwayv1a
 		// The translator reports no message for a healthy Deployment; replace the
 		// stale "waiting for pods" message so status reflects the Running phase.
 		md.Status.Message = "Deployments created, pods are ready"
+	} else {
+		// Do not retain a prior healthy message when current replica evidence
+		// downgrades the Deployment to an in-progress state.
+		md.Status.Message = "Deployments created, waiting for pods to be ready"
 	}
 	md.Status.Replicas = statusResult.Replicas
 	md.Status.Endpoint = statusResult.Endpoint

--- a/providers/llmd/controller_test.go
+++ b/providers/llmd/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -285,7 +286,10 @@ func TestSyncStatusRunningUpdatesMessage(t *testing.T) {
 	deploy.SetKind("Deployment")
 	deploy.SetName("test")
 	deploy.SetNamespace("default")
+	deploy.Object["spec"] = map[string]interface{}{"replicas": int64(1)}
 	deploy.Object["status"] = map[string]interface{}{
+		"readyReplicas":     int64(1),
+		"availableReplicas": int64(1),
 		"conditions": []interface{}{
 			map[string]interface{}{"type": "Available", "status": "True"},
 		},
@@ -314,5 +318,49 @@ func TestSyncStatusRunningUpdatesMessage(t *testing.T) {
 	}
 	if md.Status.Message == "" {
 		t.Errorf("expected a non-empty status message in Running phase")
+	}
+}
+
+func TestSyncStatusStaleAvailableConditionIsNotReady(t *testing.T) {
+	scheme := newScheme()
+
+	deploy := &unstructured.Unstructured{}
+	deploy.SetAPIVersion("apps/v1")
+	deploy.SetKind("Deployment")
+	deploy.SetName("test")
+	deploy.SetNamespace("default")
+	deploy.Object["spec"] = map[string]interface{}{"replicas": int64(1)}
+	deploy.Object["status"] = map[string]interface{}{
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "Available", "status": "True"},
+			map[string]interface{}{"type": "Progressing", "status": "True"},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Message = "Deployments created, pods are ready"
+
+	desired := &unstructured.Unstructured{}
+	desired.SetAPIVersion("apps/v1")
+	desired.SetKind("Deployment")
+	desired.SetName("test")
+	desired.SetNamespace("default")
+
+	if err := r.syncStatus(context.Background(), md, desired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if md.Status.Phase != airunwayv1alpha1.DeploymentPhaseDeploying {
+		t.Fatalf("expected Deploying phase, got %s", md.Status.Phase)
+	}
+	if strings.Contains(md.Status.Message, "pods are ready") {
+		t.Errorf("status retained a stale healthy message: %q", md.Status.Message)
+	}
+	ready := meta.FindStatusCondition(md.Status.Conditions, airunwayv1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "DeploymentInProgress" {
+		t.Errorf("Ready = %+v, want False with reason DeploymentInProgress", ready)
 	}
 }

--- a/providers/llmd/status.go
+++ b/providers/llmd/status.go
@@ -71,9 +71,9 @@ func (t *StatusTranslator) TranslateStatus(upstream *unstructured.Unstructured) 
 	}
 
 	condMap := t.parseConditions(conditions)
-
-	result.Phase, result.Message = t.mapConditionsToPhase(condMap)
 	result.Replicas = t.extractReplicas(upstream)
+
+	result.Phase, result.Message = t.mapConditionsToPhase(condMap, result.Replicas)
 	result.Endpoint = t.extractEndpoint(upstream)
 
 	return result, nil
@@ -110,16 +110,19 @@ func (t *StatusTranslator) parseConditions(conditions []interface{}) map[string]
 // mapConditionsToPhase maps Kubernetes Deployment conditions to a ModelDeployment phase.
 //
 // Mapping logic:
-//   - Available=True → Running
+//   - Available=True with all desired replicas currently ready and available → Running
 //   - Available=False AND Progressing=True → Deploying
 //   - Progressing=False (DeadlineExceeded) OR Available=False with reason → Failed
 //   - else → Pending
-func (t *StatusTranslator) mapConditionsToPhase(condMap map[string]conditionInfo) (airunwayv1alpha1.DeploymentPhase, string) {
+func (t *StatusTranslator) mapConditionsToPhase(condMap map[string]conditionInfo, replicas *airunwayv1alpha1.ReplicaStatus) (airunwayv1alpha1.DeploymentPhase, string) {
 	avail, hasAvail := condMap[conditionAvailable]
 	prog, hasProg := condMap[conditionProgressing]
 
-	// Available = True means all desired replicas are up
-	if hasAvail && avail.Status == "True" {
+	// Available=True guarantees only minimum availability, and Deployment status
+	// can lag the underlying Pods. Require full current counts before advertising
+	// that all replicas are ready.
+	if hasAvail && avail.Status == "True" && replicas != nil && replicas.Desired > 0 &&
+		replicas.Ready >= replicas.Desired && replicas.Available >= replicas.Desired {
 		return airunwayv1alpha1.DeploymentPhaseRunning, ""
 	}
 

--- a/providers/llmd/status_test.go
+++ b/providers/llmd/status_test.go
@@ -76,6 +76,45 @@ func TestTranslateStatusAvailableTrue(t *testing.T) {
 	}
 }
 
+func TestTranslateStatusAvailableTrueRequiresCurrentReplicas(t *testing.T) {
+	tests := []struct {
+		name        string
+		desired     int64
+		ready       int64
+		available   int64
+		setReplicas bool
+	}{
+		{name: "ready count is stale", desired: 1, ready: 0, available: 1, setReplicas: true},
+		{name: "available count is stale", desired: 1, ready: 1, available: 0, setReplicas: true},
+		{name: "both counts are stale", desired: 1, ready: 0, available: 0, setReplicas: true},
+		{name: "counts are below desired", desired: 2, ready: 1, available: 1, setReplicas: true},
+		{name: "scaled to zero is not serving", desired: 0, ready: 0, available: 0, setReplicas: true},
+		{name: "replica fields are missing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := NewStatusTranslator()
+			d := newTestDeployment("test", "default")
+			if tt.setReplicas {
+				setDeploymentReplicas(d, tt.desired, tt.ready, tt.available)
+			}
+			setDeploymentConditions(d, []map[string]interface{}{
+				{"type": "Available", "status": "True"},
+				{"type": "Progressing", "status": "True"},
+			})
+
+			result, err := st.TranslateStatus(d)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Phase != airunwayv1alpha1.DeploymentPhaseDeploying {
+				t.Errorf("expected Deploying phase, got %s", result.Phase)
+			}
+		})
+	}
+}
+
 func TestTranslateStatusProgressingDeadlineExceeded(t *testing.T) {
 	st := NewStatusTranslator()
 	d := newTestDeployment("test", "default")

--- a/providers/llmd/transformer.go
+++ b/providers/llmd/transformer.go
@@ -605,6 +605,23 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		return fmt.Errorf("overriding %q is not allowed", "spec.template.spec")
 	}
 
+	// Reject any root key other than "spec". These objects declare only
+	// apiVersion/kind/metadata/spec/status at the root, so anything else is a field no API
+	// server will store. Before strict field validation it was pruned silently, which meant
+	// a typo'd override was invisible — the same silent-no-op issue #308 is about. Sorted so
+	// the message is stable: an unstable status.message re-enqueues the object every
+	// reconcile (the ModelDeployment watch has no GenerationChangedPredicate).
+	var unsupported []string
+	for key := range overrides {
+		if key != "spec" {
+			unsupported = append(unsupported, key)
+		}
+	}
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		return fmt.Errorf("unsupported provider.overrides key(s) %q: only \"spec\" is supported", unsupported)
+	}
+
 	obj.Object = deepMerge(obj.Object, overrides)
 	return nil
 }

--- a/providers/llmd/upstream_strict_validation_test.go
+++ b/providers/llmd/upstream_strict_validation_test.go
@@ -99,9 +99,14 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "observed: custom resource create against an older CRD (400)",
+			// Unreachable for this provider: it writes only apps/v1 Deployment and v1 Service,
+			// both through server-side apply, so a custom-resource strict-decoding error can
+			// never arrive. Not matching it is deliberate — the phrase would otherwise be a
+			// way for an ordinary validation error echoing a user value to be misread as a
+			// version mismatch and retried forever.
+			name: "not ours: custom-resource strict decoding (this provider writes no CRs)",
 			err:  apierrors.NewBadRequest(`strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`),
-			want: true,
+			want: false,
 		},
 		{
 			// The sibling wrapper. structuredmerge emits this one when the LIVE object
@@ -121,12 +126,10 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			want: false,
 		},
 		{
-			// The reason the needle is "strict decoding error" and not the bare
-			// "unknown field": an Invalid status echoes the offending value back, so a
-			// user-supplied string can contain the bare phrase. Classifying this as an
-			// upstream mismatch would tell an operator to upgrade a cluster that is fine,
-			// and retry every 30s forever.
-			name: "not ours: Invalid echoing a user value that contains the bare phrase",
+			// An Invalid status echoes the offending value back, so a user-supplied string can
+			// carry any phrasing at all. This provider matches no bare phrase, so none of the
+			// three cases below can be misread as an upstream mismatch and retried every 30s.
+			name: "not ours: Invalid echoing a user value containing 'unknown field'",
 			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
 				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
 					"--served-model-name=unknown field probe", "must be a valid flag"),
@@ -134,12 +137,22 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			want: false,
 		},
 		{
-			// The needle requires BOTH halves. An Invalid status echoes the offending value
-			// back, so a user-supplied string containing only the prefix must not match.
-			name: "not ours: 'strict decoding error' echoed without an unknown-field cause",
+			name: "not ours: Invalid echoing a user value containing 'strict decoding error'",
 			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
 				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
 					"--served-model-name=strict decoding error probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
+			// The adversarial case: both phrases inside one user-supplied value. A provider
+			// that matches the custom-resource shape has to weigh this against the false
+			// negative of a stricter match; this one writes no custom resources, so the
+			// question does not arise and the answer is simply no.
+			name: "not ours: Invalid echoing a value containing both phrases at once",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=strict decoding error unknown field", "must be a valid flag"),
 			}),
 			want: false,
 		},

--- a/providers/llmd/upstream_strict_validation_test.go
+++ b/providers/llmd/upstream_strict_validation_test.go
@@ -13,7 +13,9 @@ package llmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"syscall"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -172,6 +174,80 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 	}
 }
 
+func TestIsRetryableUpstreamWriteError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "conflict",
+			err:  apierrors.NewConflict(schema.GroupResource{Resource: "deployments"}, "test", fmt.Errorf("stale resource version")),
+			want: true,
+		},
+		{
+			name: "arbitrary 5xx status",
+			err:  &apierrors.StatusError{ErrStatus: metav1.Status{Code: 502}},
+			want: true,
+		},
+		{
+			name: "deterministic SSA conversion failure wrapped as 500",
+			err: apierrors.NewInternalError(fmt.Errorf("failed to create typed patch object " +
+				"(default/test; apps/v1, Kind=Deployment): .spec.replicas: expected numeric, got string")),
+			want: false,
+		},
+		{
+			name: "throttled",
+			err:  apierrors.NewTooManyRequests("slow down", 1),
+			want: true,
+		},
+		{
+			name: "wrapped deadline",
+			err:  fmt.Errorf("apply: %w", context.DeadlineExceeded),
+			want: true,
+		},
+		{
+			name: "wrapped resource write EOF",
+			err:  wrapResourceWriteError(io.EOF, true),
+			want: true,
+		},
+		{
+			name: "wrapped resource write unexpected EOF",
+			err:  wrapResourceWriteError(io.ErrUnexpectedEOF, true),
+			want: true,
+		},
+		{
+			name: "wrapped resource write broken pipe",
+			err:  wrapResourceWriteError(syscall.EPIPE, true),
+			want: true,
+		},
+		{
+			name: "validation failure",
+			err:  apierrors.NewInvalid(schema.GroupKind{Kind: "Deployment"}, "test", nil),
+			want: false,
+		},
+		{
+			name: "not found fails closed",
+			err:  apierrors.NewNotFound(schema.GroupResource{Resource: "deployments"}, "test"),
+			want: false,
+		},
+		{
+			name: "ownership conflict needs external recovery",
+			err:  &resourceConflictError{namespace: "default", name: "test"},
+			want: false,
+		},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableUpstreamWriteError(tc.err); got != tc.want {
+				t.Errorf("isRetryableUpstreamWriteError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestReconcileRequeuesOnStrictRejection covers the recovery path for the failure mode
 // strict validation introduces. A schema rejection is terminal from the controller's point
 // of view — the remedy is an out-of-band upstream upgrade — and nothing in the watch set
@@ -215,8 +291,8 @@ func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
 	}
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a strict-validation rejection")
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s", res, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -240,7 +316,7 @@ func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
 		t.Errorf("Ready reason = %q, want IncompatibleUpstream", got)
 	}
 	// ProviderCompatible is deliberately NOT touched here: it is set True earlier in the same
-	// reconcile, so flipping it would rewrite LastTransitionTime on every 30s requeue and the
+	// reconcile, so flipping it would rewrite LastTransitionTime on every recovery requeue and the
 	// condition would never settle — a permanent status-write loop.
 	if got := statuses[airunwayv1alpha1.ConditionTypeProviderCompatible]; got != metav1.ConditionTrue {
 		t.Errorf("ProviderCompatible = %q, want True — flipping it here causes permanent churn", got)
@@ -384,22 +460,28 @@ func TestStatusSafeRejectionDetailIsStable(t *testing.T) {
 	}
 }
 
-// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
-// write failure that is neither a transform error nor a schema rejection.
-//
-// It is the most common of the three, and it must not be the one that still reports healthy.
-// Without the clearing, a previously-Running deployment hitting a transient upstream error
-// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
-// this guards against.
-func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+// TestReconcileTransientFailurePreservesServingStatus covers ambiguous write failures. A 5xx
+// on an observed existing resource does not prove that workload stopped serving, so the
+// controller must retain its last-known health while scheduling a prompt retry.
+func TestReconcileTransientFailurePreservesServingStatus(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
 	controllerutil.AddFinalizer(md, FinalizerName)
 	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
-	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Message = "deployment is serving"
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "live-svc", Port: 8000}
 	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
@@ -416,11 +498,8 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
 	}
-	// A generic write failure is usually transient, so it must retry. Without a requeue the
-	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
-	// deployment sits Failed with no endpoint until the default resync.
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a transient write failure")
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s", res, RequeueInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -440,8 +519,540 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 	if createdReason != "CreateFailed" {
 		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
 	}
-	if readyStatus != metav1.ConditionFalse {
-		t.Errorf("Ready = %q, want False", readyStatus)
+	if readyStatus != metav1.ConditionTrue {
+		t.Errorf("Ready = %q, want True — a transient write failure cannot disprove serving health", readyStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseRunning)
+	}
+	if updated.Status.Message != "deployment is serving" {
+		t.Errorf("message = %q, want last-known serving message", updated.Status.Message)
+	}
+	if updated.Status.Endpoint == nil || updated.Status.Endpoint.Service != "live-svc" || updated.Status.Endpoint.Port != 8000 {
+		t.Errorf("Status.Endpoint = %+v, want live-svc:8000", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas == nil || updated.Status.Replicas.Desired != 1 || updated.Status.Replicas.Ready != 1 {
+		t.Errorf("Status.Replicas = %+v, want 1/1", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed proves that existence,
+// ownership, and a non-terminating object are not enough to retain stale serving health. The
+// pre-write Deployment snapshot is explicitly Deploying, so a retryable apply failure must
+// use the prompt retry cadence while clearing the stale Ready/endpoint/replica status.
+func TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedUnreadyDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	deploymentPatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					deploymentPatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Deployment apply failure"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the apply failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched {
+		t.Fatal("Deployment Patch was never called")
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientLaterServiceFailureAfterSuccessfulDeploymentApplyFailsClosed proves
+// that the pre-write serving snapshot becomes stale as soon as an earlier resource write
+// succeeds. Even when every required resource was initially ready, a later ambiguous Service
+// failure cannot retain Ready because the Deployment apply may already have started a rollout.
+func TestReconcileTransientLaterServiceFailureAfterSuccessfulDeploymentApplyFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	var patchOrder []string
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				kind := obj.GetObjectKind().GroupVersionKind().Kind
+				switch kind {
+				case "Deployment":
+					patchOrder = append(patchOrder, kind)
+					return nil
+				case "Service":
+					patchOrder = append(patchOrder, kind)
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Service apply failure"))
+				default:
+					return cl.Patch(ctx, obj, patch, opts...)
+				}
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the later apply failure should be reported in status: %v", err)
+	}
+	if len(patchOrder) != 2 || patchOrder[0] != "Deployment" || patchOrder[1] != "Service" {
+		t.Fatalf("patch order = %v, want [Deployment Service]", patchOrder)
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientCreateFailureFailsClosed covers an ambiguous write failure after the
+// controller successfully observed that the primary Deployment was absent. There is no
+// workload whose health can be preserved, so stale Running status must be cleared even though
+// the 5xx gets the prompt transient retry cadence.
+func TestReconcileTransientCreateFailureFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deploymentPatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					deploymentPatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient create failure"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the create failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched {
+		t.Fatal("Deployment Patch was never called")
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientMissingServiceFailureFailsClosed covers a partially present resource
+// set: the primary Deployment exists, but its required Service does not. A successful
+// Deployment update cannot justify retaining Ready when creation of the missing child fails.
+func TestReconcileTransientMissingServiceFailureFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	deploymentPatched := false
+	servicePatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				switch obj.GetObjectKind().GroupVersionKind().Kind {
+				case "Deployment":
+					deploymentPatched = true
+					return nil
+				case "Service":
+					servicePatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Service create failure"))
+				default:
+					return cl.Patch(ctx, obj, patch, opts...)
+				}
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the create failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched || !servicePatched {
+		t.Fatalf("patch calls: Deployment=%v Service=%v, want both", deploymentPatched, servicePatched)
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientExistingServiceFailureAfterMissingDeploymentFailsClosed covers the
+// reverse partial-resource ordering: the primary Deployment is absent and its apply succeeds,
+// then patching an owned existing Service fails transiently. The later resource's existence
+// must not hide that the required Deployment was missing at the start of this reconcile.
+func TestReconcileTransientExistingServiceFailureAfterMissingDeploymentFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	service := ownedServiceForMD(md)
+	deploymentPatched := false
+	servicePatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				switch obj.GetObjectKind().GroupVersionKind().Kind {
+				case "Deployment":
+					deploymentPatched = true
+					return nil
+				case "Service":
+					servicePatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Service patch failure"))
+				default:
+					return cl.Patch(ctx, obj, patch, opts...)
+				}
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the patch failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched || !servicePatched {
+		t.Fatalf("patch calls: Deployment=%v Service=%v, want both", deploymentPatched, servicePatched)
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientEarlierWriteFailureWithUnsafeLaterResourceFailsClosed guards the
+// preservation preflight across the complete rendered resource set. The Deployment is written
+// first and fails transiently, before the normal write loop can ownership-check the Service.
+// A foreign-owned or terminating Service means the last-known serving state is unsafe to
+// preserve even though both objects existed when reconciliation began.
+func TestReconcileTransientEarlierWriteFailureWithUnsafeLaterResourceFailsClosed(t *testing.T) {
+	tests := []struct {
+		name          string
+		mutateService func(*unstructured.Unstructured)
+	}{
+		{
+			name: "foreign-owned Service",
+			mutateService: func(service *unstructured.Unstructured) {
+				service.SetOwnerReferences([]metav1.OwnerReference{{
+					APIVersion: airunwayv1alpha1.GroupVersion.String(),
+					Kind:       "ModelDeployment",
+					Name:       "someone-else",
+					UID:        types.UID("foreign-uid"),
+				}})
+			},
+		},
+		{
+			name: "terminating Service",
+			mutateService: func(service *unstructured.Unstructured) {
+				deletionTimestamp := metav1.Now()
+				service.SetFinalizers([]string{"test.airunway.ai/hold"})
+				service.SetDeletionTimestamp(&deletionTimestamp)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newScheme()
+			md := newMDForController("test", "default")
+			md.UID = types.UID("test-uid")
+			controllerutil.AddFinalizer(md, FinalizerName)
+			seedStaleServingStatus(md)
+
+			deployment := ownedDeploymentForMD(md)
+			seedRunningDeploymentStatus(t, deployment)
+			service := ownedServiceForMD(md)
+			tc.mutateService(service)
+
+			var deploymentPatched, servicePatched bool
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						switch obj.GetObjectKind().GroupVersionKind().Kind {
+						case "Deployment":
+							deploymentPatched = true
+							return apierrors.NewInternalError(fmt.Errorf("simulated transient Deployment update failure"))
+						case "Service":
+							servicePatched = true
+							return cl.Patch(ctx, obj, patch, opts...)
+						default:
+							return cl.Patch(ctx, obj, patch, opts...)
+						}
+					},
+				}).Build()
+			r := NewLLMDProviderReconciler(c, scheme)
+
+			res, err := r.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatalf("reconcile returned an error; the write failure should be reported in status: %v", err)
+			}
+			if !deploymentPatched {
+				t.Fatal("Deployment Patch was never called; test did not reach the earlier transient write failure")
+			}
+			if servicePatched {
+				t.Fatal("Service Patch was called; the earlier Deployment failure should stop the write loop")
+			}
+			assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+		})
+	}
+}
+
+func ownedDeploymentForMD(md *airunwayv1alpha1.ModelDeployment) *unstructured.Unstructured {
+	deployment := &unstructured.Unstructured{}
+	deployment.SetGroupVersionKind(deploymentGVK)
+	deployment.SetName(md.Name)
+	deployment.SetNamespace(md.Namespace)
+	deployment.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       md.Name,
+		UID:        md.UID,
+	}})
+	return deployment
+}
+
+func seedRunningDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured) {
+	t.Helper()
+	seedDeploymentStatus(t, deployment, "True", int64(1), int64(1))
+}
+
+func seedUnreadyDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured) {
+	t.Helper()
+	seedDeploymentStatus(t, deployment, "False", int64(0), int64(0))
+	if err := unstructured.SetNestedSlice(deployment.Object, []interface{}{
+		map[string]interface{}{"type": conditionAvailable, "status": "False"},
+		map[string]interface{}{"type": conditionProgressing, "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("set unready Deployment conditions: %v", err)
+	}
+}
+
+func seedDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured, available string, readyReplicas, availableReplicas int64) {
+	t.Helper()
+	if err := unstructured.SetNestedField(deployment.Object, int64(1), "spec", "replicas"); err != nil {
+		t.Fatalf("set Deployment desired replicas: %v", err)
+	}
+	if err := unstructured.SetNestedField(deployment.Object, readyReplicas, "status", "readyReplicas"); err != nil {
+		t.Fatalf("set Deployment ready replicas: %v", err)
+	}
+	if err := unstructured.SetNestedField(deployment.Object, availableReplicas, "status", "availableReplicas"); err != nil {
+		t.Fatalf("set Deployment available replicas: %v", err)
+	}
+	if err := unstructured.SetNestedSlice(deployment.Object, []interface{}{
+		map[string]interface{}{"type": conditionAvailable, "status": available},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("set Deployment conditions: %v", err)
+	}
+}
+
+func ownedServiceForMD(md *airunwayv1alpha1.ModelDeployment) *unstructured.Unstructured {
+	service := &unstructured.Unstructured{}
+	service.SetGroupVersionKind(serviceGVK)
+	service.SetName(md.Name)
+	service.SetNamespace(md.Namespace)
+	service.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       md.Name,
+		UID:        md.UID,
+	}})
+	return service
+}
+
+func seedStaleServingStatus(md *airunwayv1alpha1.ModelDeployment) {
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+}
+
+func assertPromptRetryFailedClosed(t *testing.T, c client.Client, res ctrl.Result, key types.NamespacedName) {
+	t.Helper()
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s", res, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), key, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
+	for _, cond := range updated.Status.Conditions {
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeResourceCreated]; got != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileNotFoundFailsClosedAndRetries distinguishes an explicit missing-resource
+// response from an ambiguous transport failure. NotFound disproves the stale serving state,
+// but a prompt retry can recreate the resource once the API race or dependency resolves.
+func TestReconcileNotFoundFailsClosedAndRetries(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	notFound := apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, "test")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return notFound
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; NotFound should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s after NotFound", res, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
+	for _, cond := range updated.Status.Conditions {
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileValidationFailureFailsClosedAndRetriesSlowly distinguishes deterministic
+// admission failures from transient API failures. It fails closed and polls slowly so an
+// external admission-policy fix can recover without another watched event.
+func TestReconcileValidationFailureFailsClosedAndRetriesSlowly(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	validationErr := apierrors.NewInvalid(schema.GroupKind{Group: "apps", Kind: "Deployment"}, "test", field.ErrorList{
+		field.Invalid(field.NewPath("spec", "replicas"), -1, "must be non-negative"),
+	})
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return validationErr
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s for deterministic validation failure", res, ExternalRecoveryInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reasons := map[string]string{}
+	statuses := map[string]metav1.ConditionStatus{}
+	for _, cond := range updated.Status.Conditions {
+		reasons[cond.Type] = cond.Reason
+		statuses[cond.Type] = cond.Status
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
 	}
 	if updated.Status.Endpoint != nil {
 		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
@@ -504,13 +1115,16 @@ func TestOverrideRootKeyComparisonIsCaseSensitive(t *testing.T) {
 
 // TestReconcileOwnershipConflictUsesItsOwnReason covers the ownership-collision branch.
 //
-// A Deployment of the right name already exists but belongs to someone else. That is terminal
-// — unlike a transient API 409 — so it is reported under its own reason rather than the
-// generic CreateFailed.
+// A Deployment of the right name already exists but belongs to someone else. It needs an
+// external actor to remove or transfer the object, so it clears health, uses its own reason,
+// and retries at the slower external-recovery cadence.
 func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
 	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
 
 	foreign := &unstructured.Unstructured{}
 	foreign.SetAPIVersion("apps/v1")
@@ -527,10 +1141,14 @@ func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
 	r := NewLLMDProviderReconciler(c, scheme)
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile returned an error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s", res, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -538,23 +1156,34 @@ func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
 		t.Fatalf("get: %v", err)
 	}
 	var reason, readyReason string
+	var readyStatus metav1.ConditionStatus
 	for _, cond := range updated.Status.Conditions {
 		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
 			reason = cond.Reason
 		}
 		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
 			readyReason = cond.Reason
+			readyStatus = cond.Status
 		}
 	}
-	// The branch comment claims "Ready is set below unconditionally with this same reason".
-	// Hold it: an operator alerting on Ready.reason=ResourceConflict needs to distinguish a
-	// collision needing manual intervention from a transient CreateFailed that will retry.
 	if readyReason != "ResourceConflict" {
 		t.Errorf("Ready reason = %q, want ResourceConflict", readyReason)
 	}
 	if reason != "ResourceConflict" {
 		t.Errorf("ResourceCreated reason = %q, want ResourceConflict — an ownership collision "+
 			"must be distinguishable from a generic create failure", reason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
 	}
 }
 
@@ -565,14 +1194,23 @@ func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
 // wrapper but NOT the unknown-field needle, so isUpstreamSchemaRejection returns false and it
 // lands in the generic branch rather than the rejection branch. structured-merge-diff
 // accumulates type errors without sorting them, so their concatenation order follows Go map
-// iteration — just as volatile as the unknown-field case, and with a 30s requeue on top.
+// iteration — just as volatile as the unknown-field case. The normalised deterministic failure
+// must fail closed and retry only at the external-recovery cadence.
 func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
 	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
 
-	typeMismatch := fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
-		"Kind=Deployment): .spec.replicas: expected numeric, got string")
+	typeMismatch := apierrors.NewInternalError(fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
+		"Kind=Deployment): .spec.replicas: expected numeric, got string"))
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
@@ -586,10 +1224,14 @@ func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
 
 	r := NewLLMDProviderReconciler(c, scheme)
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile returned an error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s for deterministic SSA validation failure", res, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -619,5 +1261,23 @@ func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
 		if strings.Contains(cond.Message, "expected numeric") {
 			t.Errorf("condition %s retains the volatile SSA detail: %q", cond.Type, cond.Message)
 		}
+	}
+	readyStatus := metav1.ConditionUnknown
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+		}
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
 	}
 }

--- a/providers/llmd/upstream_strict_validation_test.go
+++ b/providers/llmd/upstream_strict_validation_test.go
@@ -1,0 +1,595 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package llmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
+)
+
+// Regression test for upstream schema compatibility.
+//
+// Every write to the upstream resource must carry fieldValidation=Strict, so the API
+// server rejects fields the installed upstream does not declare instead of silently
+// pruning them. Without it the shim can render a field the cluster drops without any
+// error, leaving a workload that reports healthy but cannot serve.
+//
+// This asserts the option reaches the client. It deliberately does NOT assert the API
+// server's behaviour — the fake client has no structural schema and cannot prune, which
+// is exactly why no pre-existing test caught this bug.
+
+func TestUpstreamApplyUsesStrictFieldValidation(t *testing.T) {
+	var got string
+	var called bool
+	c := fake.NewClientBuilder().WithScheme(newScheme()).WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			called = true
+			o := &client.PatchOptions{}
+			for _, opt := range opts {
+				opt.ApplyToPatch(o)
+			}
+			got = o.FieldValidation
+			return nil
+		},
+	}).Build()
+
+	r := NewLLMDProviderReconciler(c, newScheme())
+
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.UID = types.UID("test-uid")
+
+	desired := &unstructured.Unstructured{}
+	desired.SetAPIVersion("apps/v1")
+	desired.SetKind("Deployment")
+	desired.SetName("test")
+	desired.SetNamespace("default")
+	desired.Object["spec"] = map[string]interface{}{"replicas": int64(1)}
+
+	if err := r.createOrUpdateResource(context.Background(), desired, md); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("Patch was never called")
+	}
+	if got != metav1.FieldValidationStrict {
+		t.Errorf("apply fieldValidation = %q, want %q", got, metav1.FieldValidationStrict)
+	}
+}
+
+// TestIsUpstreamSchemaRejection pins the matcher to error strings observed against a live
+// cluster. The API server's response class varies by write path — custom-resource create is
+// 400, merge patch is 422, and server-side apply on a built-in type is **500** (the error
+// comes from the field manager, not from field validation) — which is why this matches on
+// message rather than status code.
+//
+// The negative cases are the point: gating on IsInvalid would capture ordinary CEL and type
+// violations and report them as an upstream version mismatch, sending an operator off to
+// upgrade a cluster that is already fine.
+func TestIsUpstreamSchemaRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "observed: custom resource create against an older CRD (400)",
+			err:  apierrors.NewBadRequest(`strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`),
+			want: true,
+		},
+		{
+			// The sibling wrapper. structuredmerge emits this one when the LIVE object
+			// carries a field the current schema no longer declares.
+			name: "server-side apply, live-object wrapper (500)",
+			err:  fmt.Errorf("failed to create typed live object (default/x; apps/v1, Kind=Deployment): .spec.legacy: field not declared in schema"),
+			want: true,
+		},
+		{
+			name: "observed: server-side apply on a built-in type (500)",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.bogus: field not declared in schema"),
+			want: true,
+		},
+		{
+			name: "not ours: CEL or type validation failure the user must fix",
+			err:  apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", nil),
+			want: false,
+		},
+		{
+			// The reason the needle is "strict decoding error" and not the bare
+			// "unknown field": an Invalid status echoes the offending value back, so a
+			// user-supplied string can contain the bare phrase. Classifying this as an
+			// upstream mismatch would tell an operator to upgrade a cluster that is fine,
+			// and retry every 30s forever.
+			name: "not ours: Invalid echoing a user value that contains the bare phrase",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=unknown field probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
+				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReconcileRequeuesOnStrictRejection covers the recovery path for the failure mode
+// strict validation introduces. A schema rejection is terminal from the controller's point
+// of view — the remedy is an out-of-band upstream upgrade — and nothing in the watch set
+// re-triggers this reconcile afterwards, so without an explicit requeue the deployment
+// would sit Failed until the ~10h resync even after the cluster is fixed.
+func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Seed the Running-era status. Without this the clearing below is a no-op the
+	// assertions cannot observe, and deleting it from the controller would not fail
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	// The shape this provider can actually receive. It renders built-in types through
+	// server-side apply, where the rejection comes from the field manager as a plain error
+	// naming ONE arbitrarily-chosen unknown field — never the custom-resource
+	// "strict decoding error" wording.
+	rejection := fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
+		"Kind=Deployment): .spec.someNewerField: field not declared in schema")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				// Gated on Kind so this cannot pass for the wrong reason if a future
+				// refactor adds an earlier Patch to the reconcile path.
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return rejection
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a strict-validation rejection")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reasons := map[string]string{}
+	statuses := map[string]metav1.ConditionStatus{}
+	for _, cond := range updated.Status.Conditions {
+		reasons[cond.Type] = cond.Reason
+		statuses[cond.Type] = cond.Status
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "IncompatibleUpstream" {
+		t.Errorf("ResourceCreated reason = %q, want %q", got, "IncompatibleUpstream")
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False — #308 is about reporting healthy while broken", got)
+	}
+	// docs/providers.md promises BOTH conditions carry this reason.
+	if got := reasons[airunwayv1alpha1.ConditionTypeReady]; got != "IncompatibleUpstream" {
+		t.Errorf("Ready reason = %q, want IncompatibleUpstream", got)
+	}
+	// ProviderCompatible is deliberately NOT touched here: it is set True earlier in the same
+	// reconcile, so flipping it would rewrite LastTransitionTime on every 30s requeue and the
+	// condition would never settle — a permanent status-write loop.
+	if got := statuses[airunwayv1alpha1.ConditionTypeProviderCompatible]; got != metav1.ConditionTrue {
+		t.Errorf("ProviderCompatible = %q, want True — flipping it here causes permanent churn", got)
+	}
+
+	// The volatile field path must be normalised out of anything stored. SSA names only one
+	// of possibly several unknown fields and picks a different one per call, so storing it
+	// raw would rewrite status every reconcile and re-enqueue the object each time.
+	if strings.Contains(updated.Status.Message, "someNewerField") {
+		t.Errorf("status.message retains the volatile field path: %q", updated.Status.Message)
+	}
+	if !strings.Contains(updated.Status.Message, "controller logs") {
+		t.Errorf("status.message is not the normalised form: %q", updated.Status.Message)
+	}
+
+	// Condition messages are status too. meta.SetStatusCondition propagates a changed
+	// Message unconditionally, so a volatile field path here mutates the object on every
+	// requeue and re-enqueues it — the same loop, with status.message looking stable.
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type != airunwayv1alpha1.ConditionTypeReady &&
+			cond.Type != airunwayv1alpha1.ConditionTypeResourceCreated {
+			continue
+		}
+		if strings.Contains(cond.Message, "someNewerField") {
+			t.Errorf("condition %s retains the volatile field path: %q", cond.Type, cond.Message)
+		}
+		if !strings.Contains(cond.Message, "controller logs") {
+			t.Errorf("condition %s is not the normalised form: %q", cond.Type, cond.Message)
+		}
+	}
+
+	// Stale endpoint/replicas must be cleared. Reporting Failed alongside a live endpoint
+	// and "1/1 ready" is the same contradiction.
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil — a Failed deployment must not still advertise an endpoint", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+}
+
+// TestReconcileTransformFailureClearsStaleStatus covers the OTHER failure branch: a spec the
+// transformer refuses to render (here, an unsupported provider.overrides root key).
+//
+// It must get the same treatment as an upstream rejection — Ready forced False and the
+// Running-era endpoint/replica counts dropped. Without that, a previously-Running deployment
+// edited into something unrenderable reports Failed while still advertising a live endpoint
+// and "1/1 ready", which is the contradiction this guards against.
+func TestReconcileTransformFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name:      md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{Raw: []byte(`{"totallyBogusRootKey":{"a":1}}`)},
+	}
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason, readyReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "TransformFailed" {
+		t.Errorf("ResourceCreated reason = %q, want TransformFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if readyReason != "TransformFailed" {
+		t.Errorf("Ready reason = %q, want TransformFailed", readyReason)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestStatusSafeRejectionDetailIsStable guards against a hot reconcile loop.
+//
+// Server-side apply reports only the first unknown field it hits, and picks a different one
+// per call when several are unknown — measured against a live API server: three unknown
+// fields produced three different messages across twelve calls. Storing that raw would
+// rewrite status.message every reconcile, and each status write re-enqueues the object
+// because the ModelDeployment watch has no GenerationChangedPredicate.
+func TestStatusSafeRejectionDetailIsStable(t *testing.T) {
+	// The same rejection, as the API server might word it on successive calls.
+	variants := []error{
+		fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.alphaUnknown: field not declared in schema"),
+		fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.midUnknown: field not declared in schema"),
+		fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.zebraUnknown: field not declared in schema"),
+	}
+	first := statusSafeRejectionDetail(variants[0])
+	for _, v := range variants[1:] {
+		if got := statusSafeRejectionDetail(v); got != first {
+			t.Errorf("detail differs between equivalent rejections:\n  %q\n  %q\n"+
+				"an unstable status.message re-enqueues the object on every write", first, got)
+		}
+	}
+
+	// The live-object wrapper must normalise too, or the volatile detail leaks through.
+	liveVariants := []error{
+		fmt.Errorf("failed to create typed live object (default/x; apps/v1, Kind=Deployment): .spec.alpha: field not declared in schema"),
+		fmt.Errorf("failed to create typed live object (default/x; apps/v1, Kind=Deployment): .spec.zeta: field not declared in schema"),
+	}
+	if a, b := statusSafeRejectionDetail(liveVariants[0]), statusSafeRejectionDetail(liveVariants[1]); a != b {
+		t.Errorf("live-object wrapper detail is not normalised:\n  %q\n  %q", a, b)
+	}
+
+	// Custom-resource strict decoding lists every unknown field in sorted order, so those
+	// messages are already stable and must pass through with their detail intact.
+	crErr := fmt.Errorf(`strict decoding error: unknown field "spec.a", unknown field "spec.b"`)
+	if got := statusSafeRejectionDetail(crErr); got != crErr.Error() {
+		t.Errorf("strict-decoding detail should pass through unchanged, got %q", got)
+	}
+}
+
+// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
+// write failure that is neither a transform error nor a schema rejection.
+//
+// It is the most common of the three, and it must not be the one that still reports healthy.
+// Without the clearing, a previously-Running deployment hitting a transient upstream error
+// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
+// this guards against.
+func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	// A generic write failure is usually transient, so it must retry. Without a requeue the
+	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
+	// deployment sits Failed with no endpoint until the default resync.
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a transient write failure")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestUnsupportedOverrideErrorIsDeterministic guards against a status-write loop.
+//
+// Go randomises map iteration, so returning on the first unsupported key yields a different
+// message per call for the same spec. That message lands in status.message, and because the
+// ModelDeployment watch has no GenerationChangedPredicate, a changing message means every
+// reconcile writes status, which re-enqueues the object.
+func TestUnsupportedOverrideErrorIsDeterministic(t *testing.T) {
+	newMD := func() *airunwayv1alpha1.ModelDeployment {
+		md := newMDForController("test", "default")
+		md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+			Name:      md.Status.Provider.Name,
+			Overrides: &runtime.RawExtension{Raw: []byte(`{"zeta":{},"alpha":{},"mu":{}}`)},
+		}
+		return md
+	}
+	var first string
+	for i := 0; i < 100; i++ {
+		_, err := NewTransformer().Transform(context.Background(), newMD())
+		if err == nil {
+			t.Fatal("expected an error for unsupported override keys")
+		}
+		if i == 0 {
+			first = err.Error()
+			continue
+		}
+		if err.Error() != first {
+			t.Fatalf("override rejection message is nondeterministic:\n  %q\n  %q", first, err.Error())
+		}
+	}
+	for _, want := range []string{"alpha", "mu", "zeta"} {
+		if !strings.Contains(first, want) {
+			t.Errorf("error %q does not name offending key %q", first, want)
+		}
+	}
+}
+
+// TestOverrideRootKeyComparisonIsCaseSensitive pins a deliberate choice: the accepted root
+// key is matched case-sensitively, so "Spec" is rejected rather than merged. encoding/json
+// would not decode it into anything meaningful, and merging it would push a key no upstream
+// schema declares into the rendered object.
+func TestOverrideRootKeyComparisonIsCaseSensitive(t *testing.T) {
+	md := newMDForController("test", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name:      md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{Raw: []byte(`{"Spec":{"x":1}}`)},
+	}
+	if _, err := NewTransformer().Transform(context.Background(), md); err == nil {
+		t.Error("a capitalised root key was accepted; it must be rejected, not merged")
+	}
+}
+
+// TestReconcileOwnershipConflictUsesItsOwnReason covers the ownership-collision branch.
+//
+// A Deployment of the right name already exists but belongs to someone else. That is terminal
+// — unlike a transient API 409 — so it is reported under its own reason rather than the
+// generic CreateFailed.
+func TestReconcileOwnershipConflictUsesItsOwnReason(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	foreign := &unstructured.Unstructured{}
+	foreign.SetAPIVersion("apps/v1")
+	foreign.SetKind("Deployment")
+	foreign.SetName("test")
+	foreign.SetNamespace("default")
+	foreign.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "someone-else",
+		UID:        types.UID("a-different-uid"),
+	}})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var reason, readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			reason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyReason = cond.Reason
+		}
+	}
+	// The branch comment claims "Ready is set below unconditionally with this same reason".
+	// Hold it: an operator alerting on Ready.reason=ResourceConflict needs to distinguish a
+	// collision needing manual intervention from a transient CreateFailed that will retry.
+	if readyReason != "ResourceConflict" {
+		t.Errorf("Ready reason = %q, want ResourceConflict", readyReason)
+	}
+	if reason != "ResourceConflict" {
+		t.Errorf("ResourceCreated reason = %q, want ResourceConflict — an ownership collision "+
+			"must be distinguishable from a generic create failure", reason)
+	}
+}
+
+// TestGenericFailureNormalisesVolatileSSADetail closes the one hole in this change's own
+// invariant.
+//
+// A server-side apply TYPE mismatch carries the same "failed to create typed patch object"
+// wrapper but NOT the unknown-field needle, so isUpstreamSchemaRejection returns false and it
+// lands in the generic branch rather than the rejection branch. structured-merge-diff
+// accumulates type errors without sorting them, so their concatenation order follows Go map
+// iteration — just as volatile as the unknown-field case, and with a 30s requeue on top.
+func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	typeMismatch := fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
+		"Kind=Deployment): .spec.replicas: expected numeric, got string")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return typeMismatch
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+	r := NewLLMDProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// It must NOT reach the rejection branch...
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated && cond.Reason != "CreateFailed" {
+			t.Errorf("ResourceCreated reason = %q, want CreateFailed — a type mismatch is not a schema rejection", cond.Reason)
+		}
+	}
+	// ...and the volatile per-call detail must still be normalised out of stored status.
+	if strings.Contains(updated.Status.Message, "expected numeric") {
+		t.Errorf("status.message retains the volatile SSA detail: %q", updated.Status.Message)
+	}
+	// The normalised wording must stay cause-neutral. This branch is reached precisely when
+	// the error is NOT an unknown-field rejection, so claiming "not declared in its schema"
+	// would send an operator hunting for a field that exists and is merely mistyped.
+	if strings.Contains(updated.Status.Message, "not declared") {
+		t.Errorf("generic-failure message asserts a cause this branch cannot know: %q", updated.Status.Message)
+	}
+	if !strings.Contains(updated.Status.Message, "controller logs") {
+		t.Errorf("generic-failure message does not point at the logs: %q", updated.Status.Message)
+	}
+	for _, cond := range updated.Status.Conditions {
+		if strings.Contains(cond.Message, "expected numeric") {
+			t.Errorf("condition %s retains the volatile SSA detail: %q", cond.Type, cond.Message)
+		}
+	}
+}

--- a/providers/llmd/upstream_strict_validation_test.go
+++ b/providers/llmd/upstream_strict_validation_test.go
@@ -538,8 +538,9 @@ func TestReconcileTransientFailurePreservesServingStatus(t *testing.T) {
 
 // TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed proves that existence,
 // ownership, and a non-terminating object are not enough to retain stale serving health. The
-// pre-write Deployment snapshot is explicitly Deploying, so a retryable apply failure must
-// use the prompt retry cadence while clearing the stale Ready/endpoint/replica status.
+// pre-write Deployment snapshot has a stale Available=True condition but zero current replica
+// counts, so a retryable apply failure must use the prompt retry cadence while clearing the
+// stale Ready/endpoint/replica status.
 func TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
@@ -842,9 +843,9 @@ func seedRunningDeploymentStatus(t *testing.T, deployment *unstructured.Unstruct
 
 func seedUnreadyDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured) {
 	t.Helper()
-	seedDeploymentStatus(t, deployment, "False", int64(0), int64(0))
+	seedDeploymentStatus(t, deployment, "True", int64(0), int64(0))
 	if err := unstructured.SetNestedSlice(deployment.Object, []interface{}{
-		map[string]interface{}{"type": conditionAvailable, "status": "False"},
+		map[string]interface{}{"type": conditionAvailable, "status": "True"},
 		map[string]interface{}{"type": conditionProgressing, "status": "True"},
 	}, "status", "conditions"); err != nil {
 		t.Fatalf("set unready Deployment conditions: %v", err)

--- a/providers/llmd/upstream_strict_validation_test.go
+++ b/providers/llmd/upstream_strict_validation_test.go
@@ -133,6 +133,21 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			}),
 			want: false,
 		},
+		{
+			// The needle requires BOTH halves. An Invalid status echoes the offending value
+			// back, so a user-supplied string containing only the prefix must not match.
+			name: "not ours: 'strict decoding error' echoed without an unknown-field cause",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=strict decoding error probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
+			name: "not ours: typed-object wrapper without the schema diagnostic",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
+			want: false,
+		},
 		{name: "nil", err: nil, want: false},
 	}
 	for _, tc := range cases {

--- a/providers/vllm/controller.go
+++ b/providers/vllm/controller.go
@@ -140,8 +140,25 @@ func isUpstreamSchemaRejection(err error) bool {
 		return false
 	}
 	msg := err.Error()
-	return strings.Contains(msg, "strict decoding error") ||
-		strings.Contains(msg, "field not declared in schema")
+
+	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
+	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
+	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
+	// containing either phrase on its own must not be misclassified as a version mismatch
+	// and retried forever.
+	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
+		return true
+	}
+
+	// Server-side apply on built-in types: the rejection comes from the field manager's
+	// typed conversion, not from field validation, so it carries a different wrapper and a
+	// different status class. Bind the diagnostic to that wrapper for the same reason.
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return strings.Contains(msg, "field not declared in schema")
+	}
+
+	return false
 }
 
 var (

--- a/providers/vllm/controller.go
+++ b/providers/vllm/controller.go
@@ -621,6 +621,10 @@ func (r *VLLMProviderReconciler) syncStatus(ctx context.Context, md *airunwayv1a
 		// The translator reports no message for a healthy Deployment; replace the
 		// stale "waiting for pods" message so status reflects the Running phase.
 		md.Status.Message = "Deployments created, pods are ready"
+	} else {
+		// Do not retain a prior healthy message when current replica evidence
+		// downgrades the Deployment to an in-progress state.
+		md.Status.Message = "Deployments created, waiting for pods to be ready"
 	}
 	md.Status.Replicas = statusResult.Replicas
 	md.Status.Endpoint = statusResult.Endpoint

--- a/providers/vllm/controller.go
+++ b/providers/vllm/controller.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"strings"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -62,6 +65,10 @@ const (
 
 	// RequeueInterval is the default requeue interval for periodic reconciliation
 	RequeueInterval = 30 * time.Second
+
+	// ExternalRecoveryInterval retries failures that require an out-of-band fix without
+	// hot-looping while the installed schema or resource ownership remains unchanged.
+	ExternalRecoveryInterval = 5 * time.Minute
 
 	// FinalizerTimeout is the timeout for finalizer cleanup
 	FinalizerTimeout = 5 * time.Minute
@@ -146,6 +153,66 @@ func isUpstreamSchemaRejection(err error) bool {
 	}
 
 	return false
+}
+
+// isRetryableUpstreamWriteError reports failures that can recover without changing the
+// ModelDeployment or cluster configuration. These must not erase last-known serving status:
+// a failed or ambiguous API response does not mean the existing workload stopped serving.
+func isRetryableUpstreamWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// The API server reports deterministic structured-merge conversion failures as HTTP
+	// 500 even though retrying cannot change the result. Unknown-field variants are handled
+	// by isUpstreamSchemaRejection before this function; the remaining typed-object errors
+	// (wrong scalar/list/map shapes) must reach the terminal validation branch.
+	msg := err.Error()
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return false
+	}
+
+	if errors.IsConflict(err) || errors.IsAlreadyExists(err) ||
+		errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsTooManyRequests(err) ||
+		errors.IsServiceUnavailable(err) || errors.IsInternalError(err) {
+		return true
+	}
+
+	var status errors.APIStatus
+	if stderrors.As(err, &status) && status.Status().Code >= 500 {
+		return true
+	}
+
+	return stderrors.Is(err, context.DeadlineExceeded) ||
+		stderrors.Is(err, io.EOF) || stderrors.Is(err, io.ErrUnexpectedEOF) ||
+		stderrors.Is(err, syscall.EPIPE) ||
+		utilnet.IsTimeout(err) || utilnet.IsProbableEOF(err) ||
+		utilnet.IsConnectionReset(err) || utilnet.IsConnectionRefused(err) ||
+		utilnet.IsHTTP2ConnectionLost(err)
+}
+
+// resourceWriteError records whether the target was observed before its write. A transient
+// update failure can retain last-known serving status; a transient create failure cannot,
+// because the controller had just observed that the required resource was absent.
+type resourceWriteError struct {
+	err             error
+	resourceExisted bool
+}
+
+func (e *resourceWriteError) Error() string { return e.err.Error() }
+func (e *resourceWriteError) Unwrap() error { return e.err }
+
+func wrapResourceWriteError(err error, resourceExisted bool) error {
+	if err == nil {
+		return nil
+	}
+	return &resourceWriteError{err: err, resourceExisted: resourceExisted}
+}
+
+func canPreserveLastKnownStatus(err error) bool {
+	var writeErr *resourceWriteError
+	return !stderrors.As(err, &writeErr) || writeErr.resourceExisted
 }
 
 var (
@@ -255,14 +322,14 @@ func (r *VLLMProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
 	}
 
+	// Status may be preserved after an ambiguous update failure only when every required
+	// resource existed before this write pass. Otherwise a successfully recreated earlier
+	// resource followed by a failed later update could leave stale Ready=True status.
+	preserveLastKnownStatusSafe := r.allRequiredResourcesAreOwnedActiveAndServing(ctx, resources, md.UID)
+
 	// Create or update all resources
 	for _, resource := range resources {
 		if err := r.createOrUpdateResource(ctx, resource, &md); err != nil {
-			// Transient API conflict — requeue instead of marking as failed
-			if errors.IsConflict(err) {
-				logger.Info("Resource conflict during reconcile, requeueing", "name", resource.GetName())
-				return ctrl.Result{Requeue: true}, nil
-			}
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
 			// Strict field validation rejected the write: the cluster does not accept a field
 			// this provider renders. Give it its own reason so an operator can tell it apart
@@ -292,34 +359,60 @@ func (r *VLLMProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 					return ctrl.Result{}, statusErr
 				}
-				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+				return ctrl.Result{RequeueAfter: ExternalRecoveryInterval}, nil
+			}
+			// Conflicts, throttling, server failures, and transport interruptions say nothing
+			// about whether the existing workload is still serving. Record the failed write,
+			// but preserve last-known Phase/Ready/Endpoint/Replicas until a successful read can
+			// replace them.
+			retryableWriteError := isRetryableUpstreamWriteError(err)
+			if retryableWriteError && preserveLastKnownStatusSafe && canPreserveLastKnownStatus(err) {
+				reason := "CreateFailed"
+				if errors.IsConflict(err) || errors.IsAlreadyExists(err) {
+					reason = "ResourceConflict"
+				}
+				detail := statusSafeRejectionDetail(err)
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, detail)
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				requeueAfter := RequeueInterval
+				if errors.IsConflict(err) {
+					requeueAfter = time.Second
+				}
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
 			}
 			reason := "CreateFailed"
+			// A definite NotFound means the prior workload cannot be assumed to still
+			// exist, so fail closed but retry promptly. Other deterministic API-side
+			// rejections may recover after an admission-policy or cluster change; retry
+			// them at the slower external-recovery cadence.
+			requeueAfter := ExternalRecoveryInterval
+			if errors.IsConflict(err) {
+				requeueAfter = time.Second
+			} else if errors.IsNotFound(err) || retryableWriteError {
+				requeueAfter = RequeueInterval
+			}
 			if isResourceConflict(err) {
-				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
 			}
-			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
-			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
-			// Leaving this branch alone would make the most common failure the one that
-			// still reports healthy — the same shape.
+			// Validation/admission errors and ownership conflicts need an external change.
+			// Fail closed and poll slowly so recovery does not depend on another watched event.
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
 			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
 			md.Status.Endpoint = nil
 			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 			md.Status.Message = fmt.Sprintf("Failed to create/update resource %s: %s", resource.GetName(), statusSafeRejectionDetail(err))
-			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
-			// leader change, a momentary 500 — and it is the case that most needs a retry.
-			// Without one the second pass writes identical status, which the API server
-			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
-			// its endpoint cleared until the ~10h resync even though the workload may still
-			// be serving.
 			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
-			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
+		// Once any earlier resource write succeeds, the pre-write serving snapshot no
+		// longer proves the complete resource set is still serving. A later ambiguous
+		// failure must therefore fail closed instead of retaining stale Ready status.
+		preserveLastKnownStatusSafe = false
 	}
 
 	r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionTrue, "ResourceCreated", "Deployments and Services created successfully")
@@ -443,7 +536,8 @@ func (r *VLLMProviderReconciler) createOrUpdateResource(ctx context.Context, res
 		Name:      resource.GetName(),
 		Namespace: resource.GetNamespace(),
 	}, existing)
-	if err == nil {
+	resourceExisted := err == nil
+	if resourceExisted {
 		if err := verifyOwnerReference(existing, md.UID); err != nil {
 			return err
 		}
@@ -454,7 +548,49 @@ func (r *VLLMProviderReconciler) createOrUpdateResource(ctx context.Context, res
 	// Server-side apply: handles both create and update without needing resourceVersion.
 	// ForceOwnership ensures our field manager wins over any conflicting field managers.
 	logger.Info("Applying resource", "kind", resource.GetKind(), "name", resource.GetName())
-	return r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership, strictFieldValidation)
+	return wrapResourceWriteError(
+		r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership, strictFieldValidation),
+		resourceExisted,
+	)
+}
+
+// allRequiredResourcesAreOwnedActiveAndServing snapshots whether the complete rendered
+// resource set was present, owned by this ModelDeployment, and not terminating before
+// reconciliation starts mutating it. Every Deployment must also be Running; otherwise stale
+// serving status is unsafe to preserve if a later write fails ambiguously.
+func (r *VLLMProviderReconciler) allRequiredResourcesAreOwnedActiveAndServing(
+	ctx context.Context,
+	resources []*unstructured.Unstructured,
+	mdUID types.UID,
+) bool {
+	if r.StatusTranslator == nil {
+		return false
+	}
+	foundDeployment := false
+	for _, resource := range resources {
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(resource.GroupVersionKind())
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      resource.GetName(),
+			Namespace: resource.GetNamespace(),
+		}, existing); err != nil {
+			return false
+		}
+		if existing.GetDeletionTimestamp() != nil {
+			return false
+		}
+		if err := verifyOwnerReference(existing, mdUID); err != nil {
+			return false
+		}
+		if existing.GroupVersionKind() == deploymentGVK {
+			foundDeployment = true
+			statusResult, err := r.StatusTranslator.TranslateStatus(existing)
+			if err != nil || statusResult.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+				return false
+			}
+		}
+	}
+	return foundDeployment
 }
 
 // syncStatus fetches the primary Deployment and syncs its status to the ModelDeployment

--- a/providers/vllm/controller.go
+++ b/providers/vllm/controller.go
@@ -119,40 +119,27 @@ func statusSafeRejectionDetail(err error) string {
 // isUpstreamSchemaRejection reports whether err is the API server refusing a field the
 // installed upstream does not declare, as opposed to any other rejection.
 //
-// Matching on the message rather than the status class is deliberate, because the class
-// varies by write path:
-//   - custom resource create/update -> 400 BadRequest, "strict decoding error: unknown field"
-//   - custom resource merge patch   -> 422 Invalid,    same prefix (verified live)
-//   - server-side apply on built-in types -> 500, "field not declared in schema"
-//     (verified against a live cluster: the error is a plain error from the field manager,
-//     so it is neither IsBadRequest nor IsInvalid)
+// This provider renders only built-in types — apps/v1 Deployment and v1 Service — and writes
+// them through server-side apply, so that is the only rejection shape it can receive. It
+// arrives as a plain error from the field manager's typed conversion
+// (structured-merge-diff, typed/validate.go), neither IsBadRequest nor IsInvalid, which is
+// why the match is on the message rather than the status class. Gating on IsInvalid would
+// additionally swallow every CEL and OpenAPI type violation — user configuration errors no
+// upstream upgrade would fix.
 //
-// Gating on IsInvalid alone would also swallow every CEL and OpenAPI type violation, which
-// are user configuration errors that no upstream upgrade would fix — reporting those as an
-// upstream version mismatch would send operators down the wrong path entirely.
-//
-// The needle is the "strict decoding error" prefix rather than the bare "unknown field"
-// cause it wraps, because an Invalid status echoes the offending value back and a
-// user-supplied string (a model id, an image, an engine arg) could otherwise contain the
-// bare phrase and be misclassified.
+// The custom-resource shape ("strict decoding error: unknown field", 400 on create/update and
+// 422 on merge patch) is deliberately NOT matched here: it is unreachable for this provider,
+// and matching it would only create a way to misclassify an ordinary validation error whose
+// echoed value happens to contain that phrasing — reported as a version mismatch and retried
+// forever. The providers that do write custom resources match it in their own copy.
 func isUpstreamSchemaRejection(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := err.Error()
 
-	// Custom-resource paths: apimachinery wraps the unknown-field cause in a
-	// "strict decoding error" prefix. Require BOTH parts. An Invalid status echoes the
-	// offending value back, so a user-supplied string (a model id, an image, an engine arg)
-	// containing either phrase on its own must not be misclassified as a version mismatch
-	// and retried forever.
-	if strings.Contains(msg, "strict decoding error") && strings.Contains(msg, "unknown field") {
-		return true
-	}
-
-	// Server-side apply on built-in types: the rejection comes from the field manager's
-	// typed conversion, not from field validation, so it carries a different wrapper and a
-	// different status class. Bind the diagnostic to that wrapper for the same reason.
+	// Bind the diagnostic to the wrapper, so an error that merely echoes the phrase back
+	// cannot match on the phrase alone.
 	if strings.Contains(msg, "failed to create typed patch object") ||
 		strings.Contains(msg, "failed to create typed live object") {
 		return strings.Contains(msg, "field not declared in schema")

--- a/providers/vllm/controller.go
+++ b/providers/vllm/controller.go
@@ -67,6 +67,83 @@ const (
 	FinalizerTimeout = 5 * time.Minute
 )
 
+// strictFieldValidation makes the API server reject fields the target schema does not
+// declare, instead of silently pruning them — see issue #308 and the "Upstream
+// compatibility" section of docs/providers.md.
+//
+// This provider renders built-in apps/v1 and v1 types via server-side apply, where the
+// field manager ALREADY rejects unknown fields during typed conversion regardless of this
+// option (verified: an SSA apply with validation explicitly ignored still fails with
+// "field not declared in schema"). So here this mainly adds duplicate-key detection and
+// keeps one uniform rule across all five providers; the providers that write third-party
+// CRDs are the ones it genuinely protects.
+var strictFieldValidation = client.FieldValidation(metav1.FieldValidationStrict)
+
+// statusSafeRejectionDetail returns a form of err that is stable across identical calls, for
+// storing in status.
+//
+// Server-side apply reports only the FIRST unknown field it encounters, and with more than
+// one it picks a different field each time. Two independent confirmations:
+//   - mechanism: structured-merge-diff's typed/validate.go appends one error and returns out
+//     of the map walk, and value/mapunstructured.go iterates a plain Go map, so the field
+//     chosen is whichever the randomised iteration reached first;
+//   - observed: against a live API server, three unknown fields on one Deployment produced
+//     three different messages across twelve identical apply calls. Putting that straight into
+//
+// status.message — or into a condition Message, which is status too — would rewrite status on
+// every reconcile, and since the ModelDeployment watch has no GenerationChangedPredicate each
+// write re-enqueues the object: an unbounded loop.
+//
+// Custom-resource strict decoding does not have this problem: apimachinery sorts the unknown
+// field paths and lists them all, so those messages pass through unchanged.
+//
+// Applied on the generic-failure path too: a server-side apply TYPE mismatch carries the same
+// wrapper without the unknown-field needle, so it lands there rather than in the rejection
+// branch — and structured-merge-diff accumulates type errors without sorting them, so their
+// concatenation order follows map iteration and is just as volatile.
+//
+// The full error is always logged; only the stored copy is normalised.
+func statusSafeRejectionDetail(err error) string {
+	msg := err.Error()
+	// These are the two wrappers apimachinery's structuredmerge can produce on the APPLY
+	// path. It has two more ("failed to convert new/live object … to smd typed") carrying the
+	// same payload on the non-apply Update path, which this provider never takes — add them
+	// here if that ever changes, or the volatile detail gets through and the loop returns.
+	if strings.Contains(msg, "failed to create typed patch object") ||
+		strings.Contains(msg, "failed to create typed live object") {
+		return "the offending field and the exact reason are in the controller logs"
+	}
+	return msg
+}
+
+// isUpstreamSchemaRejection reports whether err is the API server refusing a field the
+// installed upstream does not declare, as opposed to any other rejection.
+//
+// Matching on the message rather than the status class is deliberate, because the class
+// varies by write path:
+//   - custom resource create/update -> 400 BadRequest, "strict decoding error: unknown field"
+//   - custom resource merge patch   -> 422 Invalid,    same prefix (verified live)
+//   - server-side apply on built-in types -> 500, "field not declared in schema"
+//     (verified against a live cluster: the error is a plain error from the field manager,
+//     so it is neither IsBadRequest nor IsInvalid)
+//
+// Gating on IsInvalid alone would also swallow every CEL and OpenAPI type violation, which
+// are user configuration errors that no upstream upgrade would fix — reporting those as an
+// upstream version mismatch would send operators down the wrong path entirely.
+//
+// The needle is the "strict decoding error" prefix rather than the bare "unknown field"
+// cause it wraps, because an Invalid status echoes the offending value back and a
+// user-supplied string (a model id, an image, an engine arg) could otherwise contain the
+// bare phrase and be misclassified.
+func isUpstreamSchemaRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "strict decoding error") ||
+		strings.Contains(msg, "field not declared in schema")
+}
+
 var (
 	deploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
 	serviceGVK    = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
@@ -161,7 +238,14 @@ func (r *VLLMProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	resources, err := r.Transformer.Transform(ctx, &md)
 	if err != nil {
 		logger.Error(err, "Failed to transform ModelDeployment", "name", md.Name)
+		// Same treatment as the upstream-rejection path below: force Ready False and drop
+		// the stale endpoint/replica counts. Otherwise a previously-Running deployment whose
+		// spec is edited into something unrenderable reports Failed while still advertising
+		// a live endpoint and "1/1 ready" — the contradiction strict validation exists to surface.
 		r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "TransformFailed", err.Error())
+		r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "TransformFailed", err.Error())
+		md.Status.Endpoint = nil
+		md.Status.Replicas = nil
 		md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
 		md.Status.Message = fmt.Sprintf("Failed to generate vLLM resources: %s", err.Error())
 		return ctrl.Result{}, r.Status().Update(ctx, &md)
@@ -176,15 +260,61 @@ func (r *VLLMProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				return ctrl.Result{Requeue: true}, nil
 			}
 			logger.Error(err, "Failed to create/update resource", "name", resource.GetName(), "kind", resource.GetKind())
+			// Strict field validation rejected the write: the cluster does not accept a field
+			// this provider renders. Give it its own reason so an operator can tell it apart
+			// from a generic create failure, and keep requeueing — the remedy is
+			// an out-of-band upstream upgrade, and nothing else would re-trigger this
+			// reconcile. The provider-config watch fires only on Spec/Ready changes, and no
+			// upstream object exists to watch, so without a requeue the deployment would sit
+			// Failed until the ~10h resync even after the cluster is fixed.
+			//
+			// Ready is forced False here because the failure it catches is precisely a
+			// deployment that reports healthy while being unable to serve. Note this deliberately does NOT
+			// touch ProviderCompatible: that is set True earlier in this same reconcile, so
+			// flipping it here would rewrite LastTransitionTime on every requeue and the
+			// condition would never settle.
+			if isUpstreamSchemaRejection(err) {
+				detail := statusSafeRejectionDetail(err)
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "IncompatibleUpstream", detail)
+				r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, "IncompatibleUpstream", detail)
+				// Clear the Running-era endpoint and replica counts. This branch returns
+				// before syncStatus, so on an update rejection they would otherwise keep
+				// their previous values and the object would report Failed alongside a live
+				// endpoint and "1/1 ready" — the same contradiction described above.
+				md.Status.Endpoint = nil
+				md.Status.Replicas = nil
+				md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
+				md.Status.Message = fmt.Sprintf("Incompatible with the installed upstream: the cluster rejected a field in the rendered resource. This provider renders built-in Kubernetes types, so it usually means spec.provider.overrides sets a field that does not exist, or the cluster's Kubernetes version predates a field this provider uses. %s", detail)
+				if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+					return ctrl.Result{}, statusErr
+				}
+				return ctrl.Result{RequeueAfter: RequeueInterval}, nil
+			}
 			reason := "CreateFailed"
 			if isResourceConflict(err) {
+				// Ready is set below unconditionally with this same reason.
 				reason = "ResourceConflict"
-				r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, "ResourceConflict", err.Error())
 			}
-			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, err.Error())
+			// Same treatment as the TransformFailed and IncompatibleUpstream branches: a
+			// Failed deployment must not keep advertising a live endpoint and "1/1 ready".
+			// Leaving this branch alone would make the most common failure the one that
+			// still reports healthy — the same shape.
+			r.setCondition(&md, airunwayv1alpha1.ConditionTypeResourceCreated, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
+			r.setCondition(&md, airunwayv1alpha1.ConditionTypeReady, metav1.ConditionFalse, reason, statusSafeRejectionDetail(err))
+			md.Status.Endpoint = nil
+			md.Status.Replicas = nil
 			md.Status.Phase = airunwayv1alpha1.DeploymentPhaseFailed
-			md.Status.Message = fmt.Sprintf("Failed to create/update resource %s: %s", resource.GetName(), err.Error())
-			return ctrl.Result{}, r.Status().Update(ctx, &md)
+			md.Status.Message = fmt.Sprintf("Failed to create/update resource %s: %s", resource.GetName(), statusSafeRejectionDetail(err))
+			// Requeue. Unlike a schema rejection this is usually transient — a timeout, a
+			// leader change, a momentary 500 — and it is the case that most needs a retry.
+			// Without one the second pass writes identical status, which the API server
+			// treats as a no-op, so nothing re-enqueues and the deployment sits Failed with
+			// its endpoint cleared until the ~10h resync even though the workload may still
+			// be serving.
+			if statusErr := r.Status().Update(ctx, &md); statusErr != nil {
+				return ctrl.Result{}, statusErr
+			}
+			return ctrl.Result{RequeueAfter: RequeueInterval}, nil
 		}
 	}
 
@@ -320,7 +450,7 @@ func (r *VLLMProviderReconciler) createOrUpdateResource(ctx context.Context, res
 	// Server-side apply: handles both create and update without needing resourceVersion.
 	// ForceOwnership ensures our field manager wins over any conflicting field managers.
 	logger.Info("Applying resource", "kind", resource.GetKind(), "name", resource.GetName())
-	return r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership)
+	return r.Patch(ctx, resource, client.Apply, client.FieldOwner(FieldManager), client.ForceOwnership, strictFieldValidation)
 }
 
 // syncStatus fetches the primary Deployment and syncs its status to the ModelDeployment

--- a/providers/vllm/controller_test.go
+++ b/providers/vllm/controller_test.go
@@ -503,7 +503,10 @@ func TestSyncStatusRunningUpdatesMessage(t *testing.T) {
 	deploy.SetGroupVersionKind(deploymentGVK)
 	deploy.SetName("test")
 	deploy.SetNamespace("default")
+	deploy.Object["spec"] = map[string]interface{}{"replicas": int64(1)}
 	deploy.Object["status"] = map[string]interface{}{
+		"readyReplicas":     int64(1),
+		"availableReplicas": int64(1),
 		"conditions": []interface{}{
 			map[string]interface{}{"type": "Available", "status": "True"},
 		},
@@ -532,5 +535,47 @@ func TestSyncStatusRunningUpdatesMessage(t *testing.T) {
 	}
 	if md.Status.Message == "" {
 		t.Errorf("expected a non-empty status message in Running phase")
+	}
+}
+
+func TestSyncStatusStaleAvailableConditionIsNotReady(t *testing.T) {
+	scheme := newScheme()
+
+	deploy := &unstructured.Unstructured{}
+	deploy.SetGroupVersionKind(deploymentGVK)
+	deploy.SetName("test")
+	deploy.SetNamespace("default")
+	deploy.Object["spec"] = map[string]interface{}{"replicas": int64(1)}
+	deploy.Object["status"] = map[string]interface{}{
+		"conditions": []interface{}{
+			map[string]interface{}{"type": "Available", "status": "True"},
+			map[string]interface{}{"type": "Progressing", "status": "True"},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Message = "Deployments created, pods are ready"
+
+	desired := &unstructured.Unstructured{}
+	desired.SetGroupVersionKind(deploymentGVK)
+	desired.SetName("test")
+	desired.SetNamespace("default")
+
+	if err := r.syncStatus(context.Background(), md, desired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if md.Status.Phase != airunwayv1alpha1.DeploymentPhaseDeploying {
+		t.Fatalf("expected Deploying phase, got %s", md.Status.Phase)
+	}
+	if strings.Contains(md.Status.Message, "pods are ready") {
+		t.Errorf("status retained a stale healthy message: %q", md.Status.Message)
+	}
+	ready := meta.FindStatusCondition(md.Status.Conditions, airunwayv1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "DeploymentInProgress" {
+		t.Errorf("Ready = %+v, want False with reason DeploymentInProgress", ready)
 	}
 }

--- a/providers/vllm/status.go
+++ b/providers/vllm/status.go
@@ -71,9 +71,9 @@ func (t *StatusTranslator) TranslateStatus(upstream *unstructured.Unstructured) 
 	}
 
 	condMap := t.parseConditions(conditions)
-
-	result.Phase, result.Message = t.mapConditionsToPhase(condMap)
 	result.Replicas = t.extractReplicas(upstream)
+
+	result.Phase, result.Message = t.mapConditionsToPhase(condMap, result.Replicas)
 	result.Endpoint = t.extractEndpoint(upstream)
 
 	return result, nil
@@ -110,16 +110,19 @@ func (t *StatusTranslator) parseConditions(conditions []interface{}) map[string]
 // mapConditionsToPhase maps Kubernetes Deployment conditions to a ModelDeployment phase.
 //
 // Mapping logic:
-//   - Available=True → Running
+//   - Available=True with all desired replicas currently ready and available → Running
 //   - Available=False AND Progressing=True → Deploying
 //   - Progressing=False (DeadlineExceeded) OR Available=False with reason → Failed
 //   - else → Pending
-func (t *StatusTranslator) mapConditionsToPhase(condMap map[string]conditionInfo) (airunwayv1alpha1.DeploymentPhase, string) {
+func (t *StatusTranslator) mapConditionsToPhase(condMap map[string]conditionInfo, replicas *airunwayv1alpha1.ReplicaStatus) (airunwayv1alpha1.DeploymentPhase, string) {
 	avail, hasAvail := condMap[conditionAvailable]
 	prog, hasProg := condMap[conditionProgressing]
 
-	// Available = True means all desired replicas are up
-	if hasAvail && avail.Status == "True" {
+	// Available=True guarantees only minimum availability, and Deployment status
+	// can lag the underlying Pods. Require full current counts before advertising
+	// that all replicas are ready.
+	if hasAvail && avail.Status == "True" && replicas != nil && replicas.Desired > 0 &&
+		replicas.Ready >= replicas.Desired && replicas.Available >= replicas.Desired {
 		return airunwayv1alpha1.DeploymentPhaseRunning, ""
 	}
 

--- a/providers/vllm/status_test.go
+++ b/providers/vllm/status_test.go
@@ -75,6 +75,45 @@ func TestTranslateStatusAvailableTrue(t *testing.T) {
 	}
 }
 
+func TestTranslateStatusAvailableTrueRequiresCurrentReplicas(t *testing.T) {
+	tests := []struct {
+		name        string
+		desired     int64
+		ready       int64
+		available   int64
+		setReplicas bool
+	}{
+		{name: "ready count is stale", desired: 1, ready: 0, available: 1, setReplicas: true},
+		{name: "available count is stale", desired: 1, ready: 1, available: 0, setReplicas: true},
+		{name: "both counts are stale", desired: 1, ready: 0, available: 0, setReplicas: true},
+		{name: "counts are below desired", desired: 2, ready: 1, available: 1, setReplicas: true},
+		{name: "scaled to zero is not serving", desired: 0, ready: 0, available: 0, setReplicas: true},
+		{name: "replica fields are missing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := NewStatusTranslator()
+			d := newTestDeployment("test", "default")
+			if tt.setReplicas {
+				setDeploymentReplicas(d, tt.desired, tt.ready, tt.available)
+			}
+			setDeploymentConditions(d, []map[string]interface{}{
+				{"type": "Available", "status": "True"},
+				{"type": "Progressing", "status": "True"},
+			})
+
+			result, err := st.TranslateStatus(d)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Phase != airunwayv1alpha1.DeploymentPhaseDeploying {
+				t.Errorf("expected Deploying phase, got %s", result.Phase)
+			}
+		})
+	}
+}
+
 func TestTranslateStatusProgressingDeadlineExceeded(t *testing.T) {
 	st := NewStatusTranslator()
 	d := newTestDeployment("test", "default")

--- a/providers/vllm/transformer.go
+++ b/providers/vllm/transformer.go
@@ -864,6 +864,23 @@ func applyOverrides(obj *unstructured.Unstructured, md *airunwayv1alpha1.ModelDe
 		}
 	}
 
+	// Reject any root key other than "spec". These objects declare only
+	// apiVersion/kind/metadata/spec/status at the root, so anything else is a field no API
+	// server will store. Before strict field validation it was pruned silently, which meant
+	// a typo'd override was invisible — the same silent-no-op issue #308 is about. Sorted so
+	// the message is stable: an unstable status.message re-enqueues the object every
+	// reconcile (the ModelDeployment watch has no GenerationChangedPredicate).
+	var unsupported []string
+	for key := range overrides {
+		if key != "spec" {
+			unsupported = append(unsupported, key)
+		}
+	}
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		return fmt.Errorf("unsupported provider.overrides key(s) %q: only \"spec\" is supported", unsupported)
+	}
+
 	obj.Object = deepMerge(obj.Object, overrides)
 	return nil
 }

--- a/providers/vllm/upstream_strict_validation_test.go
+++ b/providers/vllm/upstream_strict_validation_test.go
@@ -99,9 +99,14 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "observed: custom resource create against an older CRD (400)",
+			// Unreachable for this provider: it writes only apps/v1 Deployment and v1 Service,
+			// both through server-side apply, so a custom-resource strict-decoding error can
+			// never arrive. Not matching it is deliberate — the phrase would otherwise be a
+			// way for an ordinary validation error echoing a user value to be misread as a
+			// version mismatch and retried forever.
+			name: "not ours: custom-resource strict decoding (this provider writes no CRs)",
 			err:  apierrors.NewBadRequest(`strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`),
-			want: true,
+			want: false,
 		},
 		{
 			// The sibling wrapper. structuredmerge emits this one when the LIVE object
@@ -121,12 +126,10 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			want: false,
 		},
 		{
-			// The reason the needle is "strict decoding error" and not the bare
-			// "unknown field": an Invalid status echoes the offending value back, so a
-			// user-supplied string can contain the bare phrase. Classifying this as an
-			// upstream mismatch would tell an operator to upgrade a cluster that is fine,
-			// and retry every 30s forever.
-			name: "not ours: Invalid echoing a user value that contains the bare phrase",
+			// An Invalid status echoes the offending value back, so a user-supplied string can
+			// carry any phrasing at all. This provider matches no bare phrase, so none of the
+			// three cases below can be misread as an upstream mismatch and retried every 30s.
+			name: "not ours: Invalid echoing a user value containing 'unknown field'",
 			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
 				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
 					"--served-model-name=unknown field probe", "must be a valid flag"),
@@ -134,12 +137,22 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			want: false,
 		},
 		{
-			// The needle requires BOTH halves. An Invalid status echoes the offending value
-			// back, so a user-supplied string containing only the prefix must not match.
-			name: "not ours: 'strict decoding error' echoed without an unknown-field cause",
+			name: "not ours: Invalid echoing a user value containing 'strict decoding error'",
 			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
 				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
 					"--served-model-name=strict decoding error probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
+			// The adversarial case: both phrases inside one user-supplied value. A provider
+			// that matches the custom-resource shape has to weigh this against the false
+			// negative of a stricter match; this one writes no custom resources, so the
+			// question does not arise and the answer is simply no.
+			name: "not ours: Invalid echoing a value containing both phrases at once",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=strict decoding error unknown field", "must be a valid flag"),
 			}),
 			want: false,
 		},

--- a/providers/vllm/upstream_strict_validation_test.go
+++ b/providers/vllm/upstream_strict_validation_test.go
@@ -133,6 +133,21 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 			}),
 			want: false,
 		},
+		{
+			// The needle requires BOTH halves. An Invalid status echoes the offending value
+			// back, so a user-supplied string containing only the prefix must not match.
+			name: "not ours: 'strict decoding error' echoed without an unknown-field cause",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=strict decoding error probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{
+			name: "not ours: typed-object wrapper without the schema diagnostic",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): some other failure"),
+			want: false,
+		},
 		{name: "nil", err: nil, want: false},
 	}
 	for _, tc := range cases {

--- a/providers/vllm/upstream_strict_validation_test.go
+++ b/providers/vllm/upstream_strict_validation_test.go
@@ -1,0 +1,587 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package vllm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	airunwayv1alpha1 "github.com/ai-runway/airunway/controller/api/v1alpha1"
+)
+
+// Regression test for upstream schema compatibility.
+//
+// Every write to the upstream resource must carry fieldValidation=Strict, so the API
+// server rejects fields the installed upstream does not declare instead of silently
+// pruning them. Without it the shim can render a field the cluster drops without any
+// error, leaving a workload that reports healthy but cannot serve.
+//
+// This asserts the option reaches the client. It deliberately does NOT assert the API
+// server's behaviour — the fake client has no structural schema and cannot prune, which
+// is exactly why no pre-existing test caught this bug.
+
+func TestUpstreamApplyUsesStrictFieldValidation(t *testing.T) {
+	var got string
+	var called bool
+	c := fake.NewClientBuilder().WithScheme(newScheme()).WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			called = true
+			o := &client.PatchOptions{}
+			for _, opt := range opts {
+				opt.ApplyToPatch(o)
+			}
+			got = o.FieldValidation
+			return nil
+		},
+	}).Build()
+
+	r := NewVLLMProviderReconciler(c, newScheme())
+
+	md := &airunwayv1alpha1.ModelDeployment{}
+	md.Name = "test"
+	md.Namespace = "default"
+	md.UID = types.UID("test-uid")
+
+	desired := &unstructured.Unstructured{}
+	desired.SetAPIVersion("apps/v1")
+	desired.SetKind("Deployment")
+	desired.SetName("test")
+	desired.SetNamespace("default")
+	desired.Object["spec"] = map[string]interface{}{"replicas": int64(1)}
+
+	if err := r.createOrUpdateResource(context.Background(), desired, md); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("Patch was never called")
+	}
+	if got != metav1.FieldValidationStrict {
+		t.Errorf("apply fieldValidation = %q, want %q", got, metav1.FieldValidationStrict)
+	}
+}
+
+// TestIsUpstreamSchemaRejection pins the matcher to error strings observed against a live
+// cluster. The API server's response class varies by write path — custom-resource create is
+// 400, merge patch is 422, and server-side apply on a built-in type is **500** (the error
+// comes from the field manager, not from field validation) — which is why this matches on
+// message rather than status code.
+//
+// The negative cases are the point: gating on IsInvalid would capture ordinary CEL and type
+// violations and report them as an upstream version mismatch, sending an operator off to
+// upgrade a cluster that is already fine.
+func TestIsUpstreamSchemaRejection(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "observed: custom resource create against an older CRD (400)",
+			err:  apierrors.NewBadRequest(`strict decoding error: unknown field "spec.services.VllmWorker.frontendSidecar"`),
+			want: true,
+		},
+		{
+			// The sibling wrapper. structuredmerge emits this one when the LIVE object
+			// carries a field the current schema no longer declares.
+			name: "server-side apply, live-object wrapper (500)",
+			err:  fmt.Errorf("failed to create typed live object (default/x; apps/v1, Kind=Deployment): .spec.legacy: field not declared in schema"),
+			want: true,
+		},
+		{
+			name: "observed: server-side apply on a built-in type (500)",
+			err:  fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.bogus: field not declared in schema"),
+			want: true,
+		},
+		{
+			name: "not ours: CEL or type validation failure the user must fix",
+			err:  apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", nil),
+			want: false,
+		},
+		{
+			// The reason the needle is "strict decoding error" and not the bare
+			// "unknown field": an Invalid status echoes the offending value back, so a
+			// user-supplied string can contain the bare phrase. Classifying this as an
+			// upstream mismatch would tell an operator to upgrade a cluster that is fine,
+			// and retry every 30s forever.
+			name: "not ours: Invalid echoing a user value that contains the bare phrase",
+			err: apierrors.NewInvalid(schema.GroupKind{Kind: "X"}, "x", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "engine", "extraArgs"),
+					"--served-model-name=unknown field probe", "must be a valid flag"),
+			}),
+			want: false,
+		},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUpstreamSchemaRejection(tc.err); got != tc.want {
+				t.Errorf("isUpstreamSchemaRejection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReconcileRequeuesOnStrictRejection covers the recovery path for the failure mode
+// strict validation introduces. A schema rejection is terminal from the controller's point
+// of view — the remedy is an out-of-band upstream upgrade — and nothing in the watch set
+// re-triggers this reconcile afterwards, so without an explicit requeue the deployment
+// would sit Failed until the ~10h resync even after the cluster is fixed.
+func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	// Seed the Running-era status. Without this the clearing below is a no-op the
+	// assertions cannot observe, and deleting it from the controller would not fail
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	// The shape this provider can actually receive. It renders built-in types through
+	// server-side apply, where the rejection comes from the field manager as a plain error
+	// naming ONE arbitrarily-chosen unknown field — never the custom-resource
+	// "strict decoding error" wording.
+	rejection := fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
+		"Kind=Deployment): .spec.someNewerField: field not declared in schema")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				// Gated on Kind so this cannot pass for the wrong reason if a future
+				// refactor adds an earlier Patch to the reconcile path.
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return rejection
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a strict-validation rejection")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	reasons := map[string]string{}
+	statuses := map[string]metav1.ConditionStatus{}
+	for _, cond := range updated.Status.Conditions {
+		reasons[cond.Type] = cond.Reason
+		statuses[cond.Type] = cond.Status
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "IncompatibleUpstream" {
+		t.Errorf("ResourceCreated reason = %q, want %q", got, "IncompatibleUpstream")
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False — #308 is about reporting healthy while broken", got)
+	}
+	// docs/providers.md promises BOTH conditions carry this reason.
+	if got := reasons[airunwayv1alpha1.ConditionTypeReady]; got != "IncompatibleUpstream" {
+		t.Errorf("Ready reason = %q, want IncompatibleUpstream", got)
+	}
+	// ProviderCompatible is deliberately NOT touched here: it is set True earlier in the same
+	// reconcile, so flipping it would rewrite LastTransitionTime on every 30s requeue and the
+	// condition would never settle — a permanent status-write loop.
+	if got := statuses[airunwayv1alpha1.ConditionTypeProviderCompatible]; got != metav1.ConditionTrue {
+		t.Errorf("ProviderCompatible = %q, want True — flipping it here causes permanent churn", got)
+	}
+
+	// The volatile field path must be normalised out of anything stored. SSA names only one
+	// of possibly several unknown fields and picks a different one per call, so storing it
+	// raw would rewrite status every reconcile and re-enqueue the object each time.
+	if strings.Contains(updated.Status.Message, "someNewerField") {
+		t.Errorf("status.message retains the volatile field path: %q", updated.Status.Message)
+	}
+	if !strings.Contains(updated.Status.Message, "controller logs") {
+		t.Errorf("status.message is not the normalised form: %q", updated.Status.Message)
+	}
+
+	// Condition messages are status too. meta.SetStatusCondition propagates a changed
+	// Message unconditionally, so a volatile field path here mutates the object on every
+	// requeue and re-enqueues it — the same loop, with status.message looking stable.
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type != airunwayv1alpha1.ConditionTypeReady &&
+			cond.Type != airunwayv1alpha1.ConditionTypeResourceCreated {
+			continue
+		}
+		if strings.Contains(cond.Message, "someNewerField") {
+			t.Errorf("condition %s retains the volatile field path: %q", cond.Type, cond.Message)
+		}
+		if !strings.Contains(cond.Message, "controller logs") {
+			t.Errorf("condition %s is not the normalised form: %q", cond.Type, cond.Message)
+		}
+	}
+
+	// Stale endpoint/replicas must be cleared. Reporting Failed alongside a live endpoint
+	// and "1/1 ready" is the same contradiction.
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil — a Failed deployment must not still advertise an endpoint", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+}
+
+// TestReconcileTransformFailureClearsStaleStatus covers the OTHER failure branch: a spec the
+// transformer refuses to render (here, an unsupported provider.overrides root key).
+//
+// It must get the same treatment as an upstream rejection — Ready forced False and the
+// Running-era endpoint/replica counts dropped. Without that, a previously-Running deployment
+// edited into something unrenderable reports Failed while still advertising a live endpoint
+// and "1/1 ready", which is the contradiction this guards against.
+func TestReconcileTransformFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name:      md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{Raw: []byte(`{"totallyBogusRootKey":{"a":1}}`)},
+	}
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason, readyReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "TransformFailed" {
+		t.Errorf("ResourceCreated reason = %q, want TransformFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if readyReason != "TransformFailed" {
+		t.Errorf("Ready reason = %q, want TransformFailed", readyReason)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestStatusSafeRejectionDetailIsStable guards against a hot reconcile loop.
+//
+// Server-side apply reports only the first unknown field it hits, and picks a different one
+// per call when several are unknown — measured against a live API server: three unknown
+// fields produced three different messages across twelve calls. Storing that raw would
+// rewrite status.message every reconcile, and each status write re-enqueues the object
+// because the ModelDeployment watch has no GenerationChangedPredicate.
+func TestStatusSafeRejectionDetailIsStable(t *testing.T) {
+	// The same rejection, as the API server might word it on successive calls.
+	variants := []error{
+		fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.alphaUnknown: field not declared in schema"),
+		fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.midUnknown: field not declared in schema"),
+		fmt.Errorf("failed to create typed patch object (default/x; apps/v1, Kind=Deployment): .spec.zebraUnknown: field not declared in schema"),
+	}
+	first := statusSafeRejectionDetail(variants[0])
+	for _, v := range variants[1:] {
+		if got := statusSafeRejectionDetail(v); got != first {
+			t.Errorf("detail differs between equivalent rejections:\n  %q\n  %q\n"+
+				"an unstable status.message re-enqueues the object on every write", first, got)
+		}
+	}
+
+	// The live-object wrapper must normalise too, or the volatile detail leaks through.
+	liveVariants := []error{
+		fmt.Errorf("failed to create typed live object (default/x; apps/v1, Kind=Deployment): .spec.alpha: field not declared in schema"),
+		fmt.Errorf("failed to create typed live object (default/x; apps/v1, Kind=Deployment): .spec.zeta: field not declared in schema"),
+	}
+	if a, b := statusSafeRejectionDetail(liveVariants[0]), statusSafeRejectionDetail(liveVariants[1]); a != b {
+		t.Errorf("live-object wrapper detail is not normalised:\n  %q\n  %q", a, b)
+	}
+
+	// Custom-resource strict decoding lists every unknown field in sorted order, so those
+	// messages are already stable and must pass through with their detail intact.
+	crErr := fmt.Errorf(`strict decoding error: unknown field "spec.a", unknown field "spec.b"`)
+	if got := statusSafeRejectionDetail(crErr); got != crErr.Error() {
+		t.Errorf("strict-decoding detail should pass through unchanged, got %q", got)
+	}
+}
+
+// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
+// write failure that is neither a transform error nor a schema rejection.
+//
+// It is the most common of the three, and it must not be the one that still reports healthy.
+// Without the clearing, a previously-Running deployment hitting a transient upstream error
+// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
+// this guards against.
+func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return apierrors.NewInternalError(fmt.Errorf("simulated upstream outage"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	// A generic write failure is usually transient, so it must retry. Without a requeue the
+	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
+	// deployment sits Failed with no endpoint until the default resync.
+	if res.RequeueAfter <= 0 {
+		t.Error("expected a requeue after a transient write failure")
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
+			createdReason = cond.Reason
+		}
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestUnsupportedOverrideErrorIsDeterministic guards against a status-write loop.
+//
+// Go randomises map iteration, so returning on the first unsupported key yields a different
+// message per call for the same spec. That message lands in status.message, and because the
+// ModelDeployment watch has no GenerationChangedPredicate, a changing message means every
+// reconcile writes status, which re-enqueues the object.
+func TestUnsupportedOverrideErrorIsDeterministic(t *testing.T) {
+	newMD := func() *airunwayv1alpha1.ModelDeployment {
+		md := newMDForController("test", "default")
+		md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+			Name:      md.Status.Provider.Name,
+			Overrides: &runtime.RawExtension{Raw: []byte(`{"zeta":{},"alpha":{},"mu":{}}`)},
+		}
+		return md
+	}
+	var first string
+	for i := 0; i < 100; i++ {
+		_, err := NewTransformer().Transform(context.Background(), newMD())
+		if err == nil {
+			t.Fatal("expected an error for unsupported override keys")
+		}
+		if i == 0 {
+			first = err.Error()
+			continue
+		}
+		if err.Error() != first {
+			t.Fatalf("override rejection message is nondeterministic:\n  %q\n  %q", first, err.Error())
+		}
+	}
+	for _, want := range []string{"alpha", "mu", "zeta"} {
+		if !strings.Contains(first, want) {
+			t.Errorf("error %q does not name offending key %q", first, want)
+		}
+	}
+}
+
+// TestOverrideRootKeyComparisonIsCaseSensitive pins a deliberate choice: the accepted root
+// key is matched case-sensitively, so "Spec" is rejected rather than merged. encoding/json
+// would not decode it into anything meaningful, and merging it would push a key no upstream
+// schema declares into the rendered object.
+func TestOverrideRootKeyComparisonIsCaseSensitive(t *testing.T) {
+	md := newMDForController("test", "default")
+	md.Spec.Provider = &airunwayv1alpha1.ProviderSpec{
+		Name:      md.Status.Provider.Name,
+		Overrides: &runtime.RawExtension{Raw: []byte(`{"Spec":{"x":1}}`)},
+	}
+	if _, err := NewTransformer().Transform(context.Background(), md); err == nil {
+		t.Error("a capitalised root key was accepted; it must be rejected, not merged")
+	}
+}
+
+// TestGenericFailureNormalisesVolatileSSADetail closes the one hole in this change's own
+// invariant.
+//
+// A server-side apply TYPE mismatch carries the same "failed to create typed patch object"
+// wrapper but NOT the unknown-field needle, so isUpstreamSchemaRejection returns false and it
+// lands in the generic branch rather than the rejection branch. structured-merge-diff
+// accumulates type errors without sorting them, so their concatenation order follows Go map
+// iteration — just as volatile as the unknown-field case, and with a 30s requeue on top.
+func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	typeMismatch := fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
+		"Kind=Deployment): .spec.replicas: expected numeric, got string")
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return typeMismatch
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// It must NOT reach the rejection branch...
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated && cond.Reason != "CreateFailed" {
+			t.Errorf("ResourceCreated reason = %q, want CreateFailed — a type mismatch is not a schema rejection", cond.Reason)
+		}
+	}
+	// ...and the volatile per-call detail must still be normalised out of stored status.
+	if strings.Contains(updated.Status.Message, "expected numeric") {
+		t.Errorf("status.message retains the volatile SSA detail: %q", updated.Status.Message)
+	}
+	// The normalised wording must stay cause-neutral. This branch is reached precisely when
+	// the error is NOT an unknown-field rejection, so claiming "not declared in its schema"
+	// would send an operator hunting for a field that exists and is merely mistyped.
+	if strings.Contains(updated.Status.Message, "not declared") {
+		t.Errorf("generic-failure message asserts a cause this branch cannot know: %q", updated.Status.Message)
+	}
+	if !strings.Contains(updated.Status.Message, "controller logs") {
+		t.Errorf("generic-failure message does not point at the logs: %q", updated.Status.Message)
+	}
+	for _, cond := range updated.Status.Conditions {
+		if strings.Contains(cond.Message, "expected numeric") {
+			t.Errorf("condition %s retains the volatile SSA detail: %q", cond.Type, cond.Message)
+		}
+	}
+}
+
+// TestReconcileOwnershipConflictSetsReadyReason covers the ownership-collision branch's Ready
+// condition specifically.
+//
+// vLLM already had ownership coverage in controller_test.go, but it asserts only
+// ResourceCreated. The Ready condition carries the same reason, and an operator alerting on
+// Ready.reason=ResourceConflict must be able to tell a collision needing manual intervention
+// from a transient CreateFailed that will retry on its own.
+func TestReconcileOwnershipConflictSetsReadyReason(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+
+	foreign := &unstructured.Unstructured{}
+	foreign.SetAPIVersion("apps/v1")
+	foreign.SetKind("Deployment")
+	foreign.SetName("test")
+	foreign.SetNamespace("default")
+	foreign.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "someone-else",
+		UID:        types.UID("a-different-uid"),
+	}})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("reconcile returned an error: %v", err)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var readyReason string
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyReason = cond.Reason
+		}
+	}
+	if readyReason != "ResourceConflict" {
+		t.Errorf("Ready reason = %q, want ResourceConflict", readyReason)
+	}
+}

--- a/providers/vllm/upstream_strict_validation_test.go
+++ b/providers/vllm/upstream_strict_validation_test.go
@@ -13,7 +13,9 @@ package vllm
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"syscall"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -172,6 +174,34 @@ func TestIsUpstreamSchemaRejection(t *testing.T) {
 	}
 }
 
+func TestIsRetryableUpstreamWriteErrorTransportEOF(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "wrapped resource write EOF",
+			err:  wrapResourceWriteError(io.EOF, true),
+		},
+		{
+			name: "wrapped resource write unexpected EOF",
+			err:  wrapResourceWriteError(io.ErrUnexpectedEOF, true),
+		},
+		{
+			name: "wrapped resource write broken pipe",
+			err:  wrapResourceWriteError(syscall.EPIPE, true),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !isRetryableUpstreamWriteError(tc.err) {
+				t.Errorf("isRetryableUpstreamWriteError(%v) = false, want true", tc.err)
+			}
+		})
+	}
+}
+
 // TestReconcileRequeuesOnStrictRejection covers the recovery path for the failure mode
 // strict validation introduces. A schema rejection is terminal from the controller's point
 // of view — the remedy is an out-of-band upstream upgrade — and nothing in the watch set
@@ -215,8 +245,8 @@ func TestReconcileRequeuesOnStrictRejection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the rejection should be reported in status: %v", err)
 	}
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a strict-validation rejection")
+	if res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("RequeueAfter = %s, want external recovery interval %s", res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -384,22 +414,28 @@ func TestStatusSafeRejectionDetailIsStable(t *testing.T) {
 	}
 }
 
-// TestReconcileGenericFailureClearsStaleStatus covers the THIRD failure branch — an ordinary
-// write failure that is neither a transform error nor a schema rejection.
-//
-// It is the most common of the three, and it must not be the one that still reports healthy.
-// Without the clearing, a previously-Running deployment hitting a transient upstream error
-// reports Failed while advertising a live endpoint and "1/1 ready" — the contradiction issue
-// this guards against.
-func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
+// TestReconcileTransientWriteFailurePreservesLastKnownStatus covers retryable API failures.
+// A failed update to an observed existing resource does not prove the workload stopped
+// serving, so the provider records the failed write while retaining last-known status.
+func TestReconcileTransientWriteFailurePreservesLastKnownStatus(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
 	controllerutil.AddFinalizer(md, FinalizerName)
 	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
 	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
-	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:    airunwayv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "last observed workload is ready",
+	})
 
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
@@ -416,11 +452,8 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
 	}
-	// A generic write failure is usually transient, so it must retry. Without a requeue the
-	// second pass writes identical status (a server-side no-op), nothing re-enqueues, and the
-	// deployment sits Failed with no endpoint until the default resync.
-	if res.RequeueAfter <= 0 {
-		t.Error("expected a requeue after a transient write failure")
+	if res.RequeueAfter != RequeueInterval {
+		t.Errorf("RequeueAfter = %s, want %s", res.RequeueAfter, RequeueInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -428,20 +461,518 @@ func TestReconcileGenericFailureClearsStaleStatus(t *testing.T) {
 		t.Fatalf("get: %v", err)
 	}
 	var createdReason string
+	var createdStatus metav1.ConditionStatus
 	var readyStatus metav1.ConditionStatus
+	var readyReason string
 	for _, cond := range updated.Status.Conditions {
 		if cond.Type == airunwayv1alpha1.ConditionTypeResourceCreated {
 			createdReason = cond.Reason
+			createdStatus = cond.Status
 		}
 		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
 			readyStatus = cond.Status
+			readyReason = cond.Reason
 		}
 	}
 	if createdReason != "CreateFailed" {
 		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
 	}
-	if readyStatus != metav1.ConditionFalse {
-		t.Errorf("Ready = %q, want False", readyStatus)
+	if createdStatus != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", createdStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseRunning {
+		t.Errorf("Status.Phase = %q, want Running", updated.Status.Phase)
+	}
+	if readyStatus != metav1.ConditionTrue || readyReason != "DeploymentReady" {
+		t.Errorf("Ready = %q reason %q, want True reason DeploymentReady", readyStatus, readyReason)
+	}
+	if updated.Status.Endpoint == nil || updated.Status.Endpoint.Service != "stale-svc" || updated.Status.Endpoint.Port != 8000 {
+		t.Errorf("Status.Endpoint = %+v, want stale-svc:8000", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas == nil || updated.Status.Replicas.Desired != 1 || updated.Status.Replicas.Ready != 1 || updated.Status.Replicas.Available != 1 {
+		t.Errorf("Status.Replicas = %+v, want 1 desired/ready/available", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed proves that existence,
+// ownership, and a non-terminating object are not enough to retain stale serving health. The
+// pre-write Deployment snapshot is explicitly Deploying, so a retryable apply failure must
+// use the prompt retry cadence while clearing the stale Ready/endpoint/replica status.
+func TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedUnreadyDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	deploymentPatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					deploymentPatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Deployment apply failure"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the apply failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched {
+		t.Fatal("Deployment Patch was never called")
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientLaterServiceFailureAfterSuccessfulDeploymentApplyFailsClosed proves
+// that the pre-write serving snapshot becomes stale as soon as an earlier resource write
+// succeeds. Even when every required resource was initially ready, a later ambiguous Service
+// failure cannot retain Ready because the Deployment apply may already have started a rollout.
+func TestReconcileTransientLaterServiceFailureAfterSuccessfulDeploymentApplyFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	var patchOrder []string
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				kind := obj.GetObjectKind().GroupVersionKind().Kind
+				switch kind {
+				case "Deployment":
+					patchOrder = append(patchOrder, kind)
+					return nil
+				case "Service":
+					patchOrder = append(patchOrder, kind)
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Service apply failure"))
+				default:
+					return cl.Patch(ctx, obj, patch, opts...)
+				}
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the later apply failure should be reported in status: %v", err)
+	}
+	if len(patchOrder) != 2 || patchOrder[0] != "Deployment" || patchOrder[1] != "Service" {
+		t.Fatalf("patch order = %v, want [Deployment Service]", patchOrder)
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientCreateFailureFailsClosed covers an ambiguous write failure after the
+// controller successfully observed that the primary Deployment was absent. There is no
+// workload whose health can be preserved, so stale Running status must be cleared even though
+// the 5xx gets the prompt transient retry cadence.
+func TestReconcileTransientCreateFailureFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deploymentPatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					deploymentPatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient create failure"))
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the create failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched {
+		t.Fatal("Deployment Patch was never called")
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientMissingServiceFailureFailsClosed covers a partially present resource
+// set: the primary Deployment exists, but its required Service does not. A successful
+// Deployment update cannot justify retaining Ready when creation of the missing child fails.
+func TestReconcileTransientMissingServiceFailureFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	deploymentPatched := false
+	servicePatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				switch obj.GetObjectKind().GroupVersionKind().Kind {
+				case "Deployment":
+					deploymentPatched = true
+					return nil
+				case "Service":
+					servicePatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Service create failure"))
+				default:
+					return cl.Patch(ctx, obj, patch, opts...)
+				}
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the create failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched || !servicePatched {
+		t.Fatalf("patch calls: Deployment=%v Service=%v, want both", deploymentPatched, servicePatched)
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientExistingServiceAfterMissingDeploymentFailsClosed reverses the partial
+// resource set above: the required primary Deployment was absent, while its Service already
+// existed. Even though the Deployment apply succeeds and the later transient failure is an
+// update to that Service, the reconcile cannot preserve stale serving health after observing
+// the primary workload missing earlier in the same resource pass.
+func TestReconcileTransientExistingServiceAfterMissingDeploymentFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	service := ownedServiceForMD(md)
+	deploymentPatched := false
+	servicePatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				switch obj.GetObjectKind().GroupVersionKind().Kind {
+				case "Deployment":
+					deploymentPatched = true
+					return nil
+				case "Service":
+					servicePatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Service update failure"))
+				default:
+					return cl.Patch(ctx, obj, patch, opts...)
+				}
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the update failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched || !servicePatched {
+		t.Fatalf("patch calls: Deployment=%v Service=%v, want both", deploymentPatched, servicePatched)
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientEarlierFailureWithForeignRequiredResourceFailsClosed proves the
+// pre-write resource snapshot validates ownership across the complete set. The Deployment
+// update fails before reconciliation reaches the foreign Service; mere presence of that later
+// object must not make stale Ready=True safe to preserve.
+func TestReconcileTransientEarlierFailureWithForeignRequiredResourceFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	service.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       "someone-else",
+		UID:        types.UID("foreign-uid"),
+	}})
+	deploymentPatched := false
+	servicePatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				switch obj.GetObjectKind().GroupVersionKind().Kind {
+				case "Deployment":
+					deploymentPatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Deployment update failure"))
+				case "Service":
+					servicePatched = true
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the update failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched {
+		t.Fatal("Deployment Patch was never called")
+	}
+	if servicePatched {
+		t.Fatal("Service Patch was called despite the earlier Deployment failure")
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+// TestReconcileTransientEarlierFailureWithTerminatingRequiredResourceFailsClosed proves an
+// object already being deleted is not counted as a usable member of the required resource
+// set. A retryable Deployment update error occurs first, but stale serving status must still
+// be cleared because the later Service has a deletion timestamp.
+func TestReconcileTransientEarlierFailureWithTerminatingRequiredResourceFailsClosed(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	md.UID = types.UID("test-uid")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	seedStaleServingStatus(md)
+
+	deployment := ownedDeploymentForMD(md)
+	seedRunningDeploymentStatus(t, deployment)
+	service := ownedServiceForMD(md)
+	service.SetFinalizers([]string{"test.airunway.ai/hold"})
+	deletingAt := metav1.Now()
+	service.SetDeletionTimestamp(&deletingAt)
+	deploymentPatched := false
+	servicePatched := false
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, deployment, service).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				switch obj.GetObjectKind().GroupVersionKind().Kind {
+				case "Deployment":
+					deploymentPatched = true
+					return apierrors.NewInternalError(fmt.Errorf("simulated transient Deployment update failure"))
+				case "Service":
+					servicePatched = true
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the update failure should be reported in status: %v", err)
+	}
+	if !deploymentPatched {
+		t.Fatal("Deployment Patch was never called")
+	}
+	if servicePatched {
+		t.Fatal("Service Patch was called despite the earlier Deployment failure")
+	}
+	assertPromptRetryFailedClosed(t, c, res, types.NamespacedName{Name: "test", Namespace: "default"})
+}
+
+func ownedDeploymentForMD(md *airunwayv1alpha1.ModelDeployment) *unstructured.Unstructured {
+	deployment := &unstructured.Unstructured{}
+	deployment.SetGroupVersionKind(deploymentGVK)
+	deployment.SetName(md.Name)
+	deployment.SetNamespace(md.Namespace)
+	deployment.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       md.Name,
+		UID:        md.UID,
+	}})
+	return deployment
+}
+
+func seedRunningDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured) {
+	t.Helper()
+	seedDeploymentStatus(t, deployment, "True", int64(1), int64(1))
+}
+
+func seedUnreadyDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured) {
+	t.Helper()
+	seedDeploymentStatus(t, deployment, "False", int64(0), int64(0))
+	if err := unstructured.SetNestedSlice(deployment.Object, []interface{}{
+		map[string]interface{}{"type": conditionAvailable, "status": "False"},
+		map[string]interface{}{"type": conditionProgressing, "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("set unready Deployment conditions: %v", err)
+	}
+}
+
+func seedDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured, available string, readyReplicas, availableReplicas int64) {
+	t.Helper()
+	if err := unstructured.SetNestedField(deployment.Object, int64(1), "spec", "replicas"); err != nil {
+		t.Fatalf("set Deployment desired replicas: %v", err)
+	}
+	if err := unstructured.SetNestedField(deployment.Object, readyReplicas, "status", "readyReplicas"); err != nil {
+		t.Fatalf("set Deployment ready replicas: %v", err)
+	}
+	if err := unstructured.SetNestedField(deployment.Object, availableReplicas, "status", "availableReplicas"); err != nil {
+		t.Fatalf("set Deployment available replicas: %v", err)
+	}
+	if err := unstructured.SetNestedSlice(deployment.Object, []interface{}{
+		map[string]interface{}{"type": conditionAvailable, "status": available},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("set Deployment conditions: %v", err)
+	}
+}
+
+func ownedServiceForMD(md *airunwayv1alpha1.ModelDeployment) *unstructured.Unstructured {
+	service := &unstructured.Unstructured{}
+	service.SetGroupVersionKind(serviceGVK)
+	service.SetName(md.Name)
+	service.SetNamespace(md.Namespace)
+	service.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: airunwayv1alpha1.GroupVersion.String(),
+		Kind:       "ModelDeployment",
+		Name:       md.Name,
+		UID:        md.UID,
+	}})
+	return service
+}
+
+func seedStaleServingStatus(md *airunwayv1alpha1.ModelDeployment) {
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+}
+
+func assertPromptRetryFailedClosed(t *testing.T, c client.Client, res ctrl.Result, key types.NamespacedName) {
+	t.Helper()
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s", res, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), key, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	statuses := map[string]metav1.ConditionStatus{}
+	reasons := map[string]string{}
+	for _, cond := range updated.Status.Conditions {
+		statuses[cond.Type] = cond.Status
+		reasons[cond.Type] = cond.Reason
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeReady]; got != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", got)
+	}
+	if got := statuses[airunwayv1alpha1.ConditionTypeResourceCreated]; got != metav1.ConditionFalse {
+		t.Errorf("ResourceCreated = %q, want False", got)
+	}
+	if got := reasons[airunwayv1alpha1.ConditionTypeResourceCreated]; got != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", got)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("phase = %q, want %q", updated.Status.Phase, airunwayv1alpha1.DeploymentPhaseFailed)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
+}
+
+// TestReconcileNotFoundWriteFailureClearsStaleStatus covers a definite API-server 404.
+// Unlike an ambiguous transport or server failure, NotFound proves the write did not leave
+// the expected object at that name, so retaining Running/Ready and its endpoint would report
+// a workload the controller knows is absent. It still retries promptly because recreation can
+// succeed without a ModelDeployment change.
+func TestReconcileNotFoundWriteFailureClearsStaleStatus(t *testing.T) {
+	scheme := newScheme()
+	md := newMDForController("test", "default")
+	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1, Available: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, obj.GetName())
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).Build()
+	r := NewVLLMProviderReconciler(c, scheme)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile returned an error; the failure should be reported in status: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != RequeueInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s", res, RequeueInterval)
+	}
+
+	var updated airunwayv1alpha1.ModelDeployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var createdReason, readyReason string
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		switch cond.Type {
+		case airunwayv1alpha1.ConditionTypeResourceCreated:
+			createdReason = cond.Reason
+		case airunwayv1alpha1.ConditionTypeReady:
+			readyStatus = cond.Status
+			readyReason = cond.Reason
+		}
+	}
+	if createdReason != "CreateFailed" {
+		t.Errorf("ResourceCreated reason = %q, want CreateFailed", createdReason)
+	}
+	if readyStatus != metav1.ConditionFalse || readyReason != "CreateFailed" {
+		t.Errorf("Ready = %q reason %q, want False reason CreateFailed", readyStatus, readyReason)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
 	}
 	if updated.Status.Endpoint != nil {
 		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
@@ -509,14 +1040,25 @@ func TestOverrideRootKeyComparisonIsCaseSensitive(t *testing.T) {
 // wrapper but NOT the unknown-field needle, so isUpstreamSchemaRejection returns false and it
 // lands in the generic branch rather than the rejection branch. structured-merge-diff
 // accumulates type errors without sorting them, so their concatenation order follows Go map
-// iteration — just as volatile as the unknown-field case, and with a 30s requeue on top.
+// iteration — just as volatile as the unknown-field case. The failure needs an external
+// change, so it must fail closed and retry only at the slower recovery cadence.
 func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
 	controllerutil.AddFinalizer(md, FinalizerName)
+	md.Status.Phase = airunwayv1alpha1.DeploymentPhaseRunning
+	md.Status.Endpoint = &airunwayv1alpha1.EndpointStatus{Service: "stale-svc", Port: 8000}
+	md.Status.Replicas = &airunwayv1alpha1.ReplicaStatus{Desired: 1, Ready: 1}
+	md.Status.Conditions = append(md.Status.Conditions, metav1.Condition{
+		Type:   airunwayv1alpha1.ConditionTypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: "DeploymentReady",
+	})
 
-	typeMismatch := fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
-		"Kind=Deployment): .spec.replicas: expected numeric, got string")
+	// Kubernetes wraps deterministic managed-fields conversion failures as HTTP 500.
+	// The status code must not make an invalid override look transient.
+	typeMismatch := apierrors.NewInternalError(fmt.Errorf("failed to create typed patch object (default/test; apps/v1, " +
+		"Kind=Deployment): .spec.replicas: expected numeric, got string"))
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md).WithStatusSubresource(md).
 		WithInterceptorFuncs(interceptor.Funcs{
@@ -530,10 +1072,14 @@ func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
 
 	r := NewVLLMProviderReconciler(c, scheme)
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile returned an error: %v", err)
+	}
+	if res.Requeue || res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("requeue = %+v, want RequeueAfter=%s for deterministic SSA validation failure", res, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment
@@ -564,6 +1110,24 @@ func TestGenericFailureNormalisesVolatileSSADetail(t *testing.T) {
 			t.Errorf("condition %s retains the volatile SSA detail: %q", cond.Type, cond.Message)
 		}
 	}
+	var readyStatus metav1.ConditionStatus
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == airunwayv1alpha1.ConditionTypeReady {
+			readyStatus = cond.Status
+		}
+	}
+	if readyStatus != metav1.ConditionFalse {
+		t.Errorf("Ready = %q, want False", readyStatus)
+	}
+	if updated.Status.Phase != airunwayv1alpha1.DeploymentPhaseFailed {
+		t.Errorf("Status.Phase = %q, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Endpoint != nil {
+		t.Errorf("Status.Endpoint = %+v, want nil", updated.Status.Endpoint)
+	}
+	if updated.Status.Replicas != nil {
+		t.Errorf("Status.Replicas = %+v, want nil", updated.Status.Replicas)
+	}
 }
 
 // TestReconcileOwnershipConflictSetsReadyReason covers the ownership-collision branch's Ready
@@ -593,10 +1157,14 @@ func TestReconcileOwnershipConflictSetsReadyReason(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(md, foreign).WithStatusSubresource(md).Build()
 	r := NewVLLMProviderReconciler(c, scheme)
 
-	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("reconcile returned an error: %v", err)
+	}
+	if res.RequeueAfter != ExternalRecoveryInterval {
+		t.Errorf("RequeueAfter = %s, want external recovery interval %s", res.RequeueAfter, ExternalRecoveryInterval)
 	}
 
 	var updated airunwayv1alpha1.ModelDeployment

--- a/providers/vllm/upstream_strict_validation_test.go
+++ b/providers/vllm/upstream_strict_validation_test.go
@@ -496,8 +496,9 @@ func TestReconcileTransientWriteFailurePreservesLastKnownStatus(t *testing.T) {
 
 // TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed proves that existence,
 // ownership, and a non-terminating object are not enough to retain stale serving health. The
-// pre-write Deployment snapshot is explicitly Deploying, so a retryable apply failure must
-// use the prompt retry cadence while clearing the stale Ready/endpoint/replica status.
+// pre-write Deployment snapshot has a stale Available=True condition but zero current replica
+// counts, so a retryable apply failure must use the prompt retry cadence while clearing the
+// stale Ready/endpoint/replica status.
 func TestReconcileTransientApplyFailureWithUnreadyDeploymentFailsClosed(t *testing.T) {
 	scheme := newScheme()
 	md := newMDForController("test", "default")
@@ -823,9 +824,9 @@ func seedRunningDeploymentStatus(t *testing.T, deployment *unstructured.Unstruct
 
 func seedUnreadyDeploymentStatus(t *testing.T, deployment *unstructured.Unstructured) {
 	t.Helper()
-	seedDeploymentStatus(t, deployment, "False", int64(0), int64(0))
+	seedDeploymentStatus(t, deployment, "True", int64(0), int64(0))
 	if err := unstructured.SetNestedSlice(deployment.Object, []interface{}{
-		map[string]interface{}{"type": conditionAvailable, "status": "False"},
+		map[string]interface{}{"type": conditionAvailable, "status": "True"},
 		map[string]interface{}{"type": conditionProgressing, "status": "True"},
 	}, "status", "conditions"); err != nil {
 		t.Fatalf("set unready Deployment conditions: %v", err)


### PR DESCRIPTION
## Description

Provider shims render manifests for an upstream operator whose schema they don't own. When the installed upstream is older than the shim expects, a CRD with a structural schema **prunes** undeclared fields — the write succeeds, the field vanishes, and no error is raised. That produced a worker with no HTTP frontend, a gateway returning 503, and `status.phase` still reading `Running`.

Every write to an upstream resource now sets `fieldValidation=Strict`, so the API server rejects unknown fields rather than dropping them. `kubectl` has sent strict validation by default for years; Go clients do not, which is why this was invisible — a human applying the same YAML by hand would have been told immediately, by field name.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
begin work on this project: https://github.com/ai-runway/airunway/issues/308
```

</details>

**AI Tool:** Claude Code

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

**On "breaking":** this is fail-closed. A cluster that was silently degraded now blocks the deployment. That's the fix working as intended, but it will read as a regression to anyone currently running a mismatched pair. There is no runtime opt-out — to revert the behaviour, pin the previous provider image.

## Related Issues

Fixes #308

## Changes Made

- **`fieldValidation=Strict` on all 8 upstream write sites** across `dynamo`, `kaito`, `kuberay`, `llmd`, `vllm`.
- **A rejection surfaces properly:** `ResourceCreated=False` and `Ready=False` with reason `IncompatibleUpstream`, stale endpoint and replica counts cleared, and a requeue so an upstream upgrade recovers the deployment without anyone touching the `ModelDeployment`.
- **Detection matches the error message, not the status class**, because the class varies by write path: a custom resource create returns 400, a merge patch 422, and server-side apply on a built-in type 500 from the field manager. Gating on `IsInvalid` alone would also capture CEL and type violations that no upstream upgrade would fix.
- **`llmd`/`vllm` normalise the volatile half of the apply error** before storing it. Server-side apply names one arbitrarily chosen unknown field per call, so a changing `status.message` would re-enqueue the object on every write.

Three defects surfaced by enabling strict validation are fixed alongside it:

- **`provider.overrides` leaked keys the transformer had already consumed** into the rendered object's root, where the API server had been pruning them. Enabling strict validation without this would have broken the **documented** override example on perfectly up-to-date clusters. Those keys are now stripped, and unsupported root keys are rejected rather than silently ignored.
- **The transform-failure and generic-failure branches** left a `Failed` deployment advertising a live endpoint and "1/1 ready", and did not requeue after a transient error.
- **KubeRay had no conflict guard**, so a lost Get/Update race against the operator could clear the endpoint of a still-serving workload.

## Testing

- [x] Unit tests pass — five provider Go modules under `-race -count=2`, plus the controller module's six packages including envtest. (`bun run test` is the JS/TS suite and is untouched by this change.)
- [x] Manual testing performed
- [x] Tested with a Kubernetes cluster

**On a real cluster** (kind + the real Dynamo operator, at both 1.0.2 and 1.1.1):

| | matched CRD (1.1.1) | mismatched CRD (1.0.2) |
|---|---|---|
| phase | `Deploying` | `Failed` |
| `ResourceCreated` | `True` | `False / IncompatibleUpstream` |
| `Ready` | `False / DeploymentInProgress` | `False / IncompatibleUpstream` |
| endpoint / replicas | populated | cleared |
| DGD created | yes | **none** |

**Mutation-tested:** every fix in the change was deleted in turn and a test confirmed to fail. The one surviving mutant is KubeRay's transform-failure branch, which is provably unreachable from a spec (`buildRayClusterConfig` has no error returns) and documented as such in its test file.

## Checklist

- [x] My code follows the project's style guidelines
- [x] Linting clean — `gofmt` and `go vet` across all five modules (`bun run lint` covers the JS/TS workspaces, untouched here)
- [x] I have added tests that prove my fix works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings

## Additional Notes

**KubeRay carries the most residual risk.** It writes a third-party CRD, has no version pin anywhere in the repo (`versions.env` has no KubeRay entry), and has no real-API-server test lane. I read everything its transformer emits and it is all long-standing RayService surface, so I judge the practical risk low — but that is a call worth making knowingly rather than inheriting.

**Recommended follow-up:** `e2e-dynamo-mocker.yml` already stands up real Dynamo CRDs on every PR. An override fixture setting an undeclared `spec` field would prove prune-vs-reject against a real API server in CI, rather than by unit tests that structurally cannot prune. Deliberately left out of this PR.

**Known gaps, disclosed in `docs/providers.md`:** three writers are not covered — provider self-registration to `InferenceProviderConfig`, the PVC/Job writes in `controller/pkg/storage`, and the gateway reconciler (`InferencePool`, `HTTPRoute`, `DestinationRule`, `ReferenceGrant`). The gateway reconciler is the closest remaining instance of this bug class in the codebase.

**Not hoisted:** `strictFieldValidation`, `isUpstreamSchemaRejection` and `statusSafeRejectionDetail` are duplicated across the five provider modules. `controller/pkg/` is the established seam for shared provider code and would be the right home, but that is a cross-module change deserving its own review.
